### PR TITLE
Target debian when packaging and building martin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,8 @@ commands:
       - run:
           name: Install Dart
           command: |
-            wget https://storage.googleapis.com/dart-archive/channels/stable/release/2.15.1/linux_packages/dart_2.15.1-1_amd64.deb
-            sudo dpkg -i dart_2.15.1-1_amd64.deb
+            curl -o dart.deb https://storage.googleapis.com/dart-archive/channels/stable/release/2.15.1/linux_packages/dart_2.15.1-1_amd64.deb
+            sudo dpkg -i dart.deb
   install-fvm-linux:
     steps:
       - install-dart-linux
@@ -380,7 +380,7 @@ jobs:
           path: ~/project
       - run:
           name: "Download legacy styles deb"
-          command: wget https://github.com/digitalfabrik/ehrenamtskarte-maplibre-style/releases/download/before-migration/eak-map-styles_0.4785-1_all.deb
+          command: curl -o eak-map-styles_0.4785-1_all.deb https://github.com/digitalfabrik/ehrenamtskarte-maplibre-style/releases/download/before-migration/eak-map-styles_0.4785-1_all.deb
       - run:
           name: "Move .deb to artifacts folder"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,8 +308,8 @@ jobs:
       - run:
           name: "Install OpenSSL"
           command: |
-            sudo apt update
-            sudo apt install -y openssl libssl-dev
+            apt update
+            apt install -y openssl libssl-dev
       - run:
           name: "Build"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,6 +379,11 @@ jobs:
       - checkout:
           path: ~/project
       - run:
+          name: "Setup dependencies"
+          command: |
+            apt-get update
+            apt-get install -y curl
+      - run:
           name: "Download legacy styles deb"
           command: curl -o eak-map-styles_0.4785-1_all.deb https://github.com/digitalfabrik/ehrenamtskarte-maplibre-style/releases/download/before-migration/eak-map-styles_0.4785-1_all.deb
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ jobs:
 
   martin-build:
     docker:
-      - image: cimg/rust:1.63.0
+      - image: rust:bullseye
     working_directory: ~/martin
     steps:
       - run:
@@ -333,7 +333,7 @@ jobs:
 
   backend-pack:
     docker:
-      - image: cimg/base:2022.09
+      - image: debian:11 # We deploy on debian -> pack on debian
     working_directory: ~/project/backend
     steps:
       - checkout:
@@ -353,7 +353,7 @@ jobs:
 
   administration-pack:
     docker:
-      - image: cimg/base:2022.09
+      - image: debian:11 # We deploy on debian -> pack on debian
     working_directory: ~/project/administration
     steps:
       - checkout:
@@ -373,7 +373,7 @@ jobs:
 
   styles-pack:
     docker:
-      - image: cimg/base:2022.09
+      - image: debian:11 # We deploy on debian -> pack on debian
     working_directory: ~/project/map-tiles/styles
     steps:
       - checkout:
@@ -393,7 +393,7 @@ jobs:
 
   martin-pack:
     docker:
-      - image: cimg/base:2022.09
+      - image: debian:11 # We deploy on debian -> pack on debian
     working_directory: ~/project/map-tiles/martin
     steps:
       - checkout:
@@ -419,7 +419,7 @@ jobs:
 
   meta-pack:
     docker:
-      - image: cimg/base:2022.09
+      - image: debian:11 # We deploy on debian -> pack on debian
     working_directory: ~/project/administration
     steps:
       - checkout:


### PR DESCRIPTION
Fixes: 

```

dpkg-deb: error: archive '/var/lib/local-apt-repository/../../..//srv/local-apt-repository/eak-backend_0.8607-1_all.deb' uses unknown compression for member 'control.tar.zst', giving up
Traceback (most recent call last):
  File "/usr/share/apt-listchanges/DebianFiles.py", line 124, in readdeb
    output = subprocess.check_output(command)
  File "/usr/lib/python3.9/subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['dpkg-deb', '-f', '/var/lib/local-apt-repository/../../..//srv/local-apt-repository/eak-backend_0.8607-1_all.deb', 'Package', 'Source', 'Version', 'Architecture', 'Status']' returned non-zero exit status 2.

```