### PR TITLE
Upgrade to React 18

### DIFF
--- a/administration/public/index.html
+++ b/administration/public/index.html
@@ -29,6 +29,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <div id="toaster"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/administration/public/index.html
+++ b/administration/public/index.html
@@ -29,7 +29,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <div id="toaster"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/administration/src/App.tsx
+++ b/administration/src/App.tsx
@@ -15,6 +15,7 @@ import KeepAliveToken from "./KeepAliveToken";
 import ApplicationsController from "./components/applications/ApplicationsController";
 import {Button, H3} from '@blueprintjs/core';
 import {ProjectConfigProvider} from './project-configs/ProjectConfigContext';
+import {AppToasterProvider} from "./components/AppToaster";
 
 if (!process.env.REACT_APP_API_BASE_URL) {
     throw new Error('REACT_APP_API_BASE_URL is not set!')
@@ -44,38 +45,40 @@ const Main = styled.div`
 `
 
 const App = () => <ProjectConfigProvider>
-    <AuthProvider>
-        <AuthContext.Consumer>{([authData, onSignIn, onSignOut]) => (
-            <ApolloProvider client={createClient(authData?.token)}>{
-                authData !== null && authData.expiry > new Date()
-                    ? <KeepAliveToken authData={authData} onSignIn={onSignIn} onSignOut={onSignOut}>
-                        <RegionProvider>
-                            <HashRouter>
-                                <Navigation onSignOut={onSignOut}/>
-                                <Main>
-                                    <Routes>
-                                        <Route path={"/"} element={<div
-                                            style={{display: 'flex', alignItems: 'center', flexDirection: 'column'}}>
-                                            <H3>Wählen Sie eine Aktion aus:</H3>
-                                            <NavLink to={"/applications"}><Button style={{marginBottom: '10px'}}
-                                                                                  icon="form"
-                                                                                  text="Eingehende Anträge"/></NavLink>
-                                            <NavLink to={"/eak-generation"}><Button icon="people"
-                                                                                    text="Karten erstellen"/></NavLink>
-                                        </div>}/>
-                                        <Route path={"/applications"}
-                                               element={<ApplicationsController token={authData.token}/>}/>
-                                        <Route path={"/eak-generation"} element={<GenerationController/>}/>
-                                    </Routes>
-                                </Main>
-                            </HashRouter>
-                        </RegionProvider>
-                    </KeepAliveToken>
-                    : <Login onSignIn={onSignIn}/>
-            }</ApolloProvider>
-        )}
-        </AuthContext.Consumer>
-    </AuthProvider>
+    <AppToasterProvider>
+        <AuthProvider>
+            <AuthContext.Consumer>{([authData, onSignIn, onSignOut]) => (
+                <ApolloProvider client={createClient(authData?.token)}>{
+                    authData !== null && authData.expiry > new Date()
+                        ? <KeepAliveToken authData={authData} onSignIn={onSignIn} onSignOut={onSignOut}>
+                            <RegionProvider>
+                                <HashRouter>
+                                    <Navigation onSignOut={onSignOut}/>
+                                    <Main>
+                                        <Routes>
+                                            <Route path={"/"} element={<div
+                                                style={{display: 'flex', alignItems: 'center', flexDirection: 'column'}}>
+                                                <H3>Wählen Sie eine Aktion aus:</H3>
+                                                <NavLink to={"/applications"}><Button style={{marginBottom: '10px'}}
+                                                                                      icon="form"
+                                                                                      text="Eingehende Anträge"/></NavLink>
+                                                <NavLink to={"/eak-generation"}><Button icon="people"
+                                                                                        text="Karten erstellen"/></NavLink>
+                                            </div>}/>
+                                            <Route path={"/applications"}
+                                                   element={<ApplicationsController token={authData.token}/>}/>
+                                            <Route path={"/eak-generation"} element={<GenerationController/>}/>
+                                        </Routes>
+                                    </Main>
+                                </HashRouter>
+                            </RegionProvider>
+                        </KeepAliveToken>
+                        : <Login onSignIn={onSignIn}/>
+                }</ApolloProvider>
+            )}
+            </AuthContext.Consumer>
+        </AuthProvider>
+    </AppToasterProvider>
 </ProjectConfigProvider>
 
 export default App;

--- a/administration/src/KeepAliveToken.tsx
+++ b/administration/src/KeepAliveToken.tsx
@@ -2,7 +2,7 @@ import {useMutation} from "@apollo/client";
 import {Button, Classes, Dialog} from "@blueprintjs/core";
 import React, {ReactNode, useContext, useEffect, useState} from "react";
 import {AuthContextData} from "./AuthProvider";
-import {AppToaster} from "./components/AppToaster";
+import {getAppToaster} from "./components/AppToaster";
 import {SignInDocument, SignInMutation, SignInMutationVariables, SignInPayload} from "./generated/graphql";
 import {ProjectConfigContext} from "./project-configs/ProjectConfigContext";
 
@@ -22,7 +22,7 @@ const KeepAliveToken = (props: Props) => {
 
     const [signIn, mutationState] = useMutation<SignInMutation, SignInMutationVariables>(SignInDocument, {
         onCompleted: (payload) => props.onSignIn(payload.signInPayload, props.authData.password),
-        onError: () => AppToaster.show({intent: "danger", message: "Etwas ist schief gelaufen."})
+        onError: () => getAppToaster().show({intent: "danger", message: "Etwas ist schief gelaufen."})
     })
     const extendLogin = () => signIn({
         variables: {

--- a/administration/src/KeepAliveToken.tsx
+++ b/administration/src/KeepAliveToken.tsx
@@ -2,7 +2,7 @@ import {useMutation} from "@apollo/client";
 import {Button, Classes, Dialog} from "@blueprintjs/core";
 import React, {ReactNode, useContext, useEffect, useState} from "react";
 import {AuthContextData} from "./AuthProvider";
-import {getAppToaster} from "./components/AppToaster";
+import {useAppToaster} from "./components/AppToaster";
 import {SignInDocument, SignInMutation, SignInMutationVariables, SignInPayload} from "./generated/graphql";
 import {ProjectConfigContext} from "./project-configs/ProjectConfigContext";
 
@@ -19,10 +19,11 @@ const KeepAliveToken = (props: Props) => {
     useEffect(() => {
         setTimeout(() => setTimeLeft(Math.round((props.authData.expiry.valueOf() - Date.now()) / 1000)), 1000)
     })
+    const appToaster = useAppToaster()
 
     const [signIn, mutationState] = useMutation<SignInMutation, SignInMutationVariables>(SignInDocument, {
         onCompleted: (payload) => props.onSignIn(payload.signInPayload, props.authData.password),
-        onError: () => getAppToaster().show({intent: "danger", message: "Etwas ist schief gelaufen."})
+        onError: () => appToaster?.show({intent: "danger", message: "Etwas ist schief gelaufen."})
     })
     const extendLogin = () => signIn({
         variables: {

--- a/administration/src/components/AppToaster.ts
+++ b/administration/src/components/AppToaster.ts
@@ -1,6 +1,0 @@
-import { Position, Toaster } from "@blueprintjs/core";
-
-/** Singleton toaster instance. Create separate instances for different options. */
-export const AppToaster = Toaster.create({
-    position: Position.TOP
-});

--- a/administration/src/components/AppToaster.tsx
+++ b/administration/src/components/AppToaster.tsx
@@ -1,0 +1,13 @@
+import {Position, Toaster} from "@blueprintjs/core";
+import {createRoot} from "react-dom/client";
+
+/** Singleton toaster instance. Create separate instances for different options. */
+let toasterRef: Toaster | null
+createRoot(document.getElementById("toaster")!).render(
+    <Toaster ref={ref => {
+        toasterRef = ref
+    }} position={Position.TOP}/>
+)
+export const getAppToaster = () => {
+    return toasterRef!
+}

--- a/administration/src/components/AppToaster.tsx
+++ b/administration/src/components/AppToaster.tsx
@@ -1,13 +1,15 @@
 import {Position, Toaster} from "@blueprintjs/core";
-import {createRoot} from "react-dom/client";
+import {createContext, ReactElement, useCallback, useContext, useState} from "react";
 
-/** Singleton toaster instance. Create separate instances for different options. */
-let toasterRef: Toaster | null
-createRoot(document.getElementById("toaster")!).render(
-    <Toaster ref={ref => {
-        toasterRef = ref
-    }} position={Position.TOP}/>
-)
-export const getAppToaster = () => {
-    return toasterRef!
+const ToasterContext = createContext<Toaster | null>(null)
+
+export const useAppToaster = (): Toaster | null => useContext(ToasterContext)
+
+export const AppToasterProvider = (props: { children: ReactElement }) => {
+    const [toaster, setToaster] = useState<Toaster | null>(null)
+    const toasterRef = useCallback(setToaster, [setToaster])
+    return <ToasterContext.Provider value={toaster}>
+        <Toaster ref={toasterRef} position={Position.TOP}/>
+        {props.children}
+    </ToasterContext.Provider>
 }

--- a/administration/src/components/AppToaster.tsx
+++ b/administration/src/components/AppToaster.tsx
@@ -1,5 +1,5 @@
 import {Position, Toaster} from "@blueprintjs/core";
-import {createContext, ReactElement, useCallback, useContext, useState} from "react";
+import {createContext, ReactElement, useContext, useState} from "react";
 
 const ToasterContext = createContext<Toaster | null>(null)
 
@@ -7,9 +7,8 @@ export const useAppToaster = (): Toaster | null => useContext(ToasterContext)
 
 export const AppToasterProvider = (props: { children: ReactElement }) => {
     const [toaster, setToaster] = useState<Toaster | null>(null)
-    const toasterRef = useCallback(setToaster, [setToaster])
     return <ToasterContext.Provider value={toaster}>
-        <Toaster ref={toasterRef} position={Position.TOP}/>
+        <Toaster ref={setToaster} position={Position.TOP}/>
         {props.children}
     </ToasterContext.Provider>
 }

--- a/administration/src/components/applications/ApplicationsOverview.tsx
+++ b/administration/src/components/applications/ApplicationsOverview.tsx
@@ -4,7 +4,7 @@ import {format} from "date-fns";
 import React, {FunctionComponent, useState} from "react";
 import styled from "styled-components";
 import JsonFieldView, {JsonField} from "./JsonFieldView";
-import {getAppToaster} from "../AppToaster";
+import {useAppToaster} from "../AppToaster";
 import FlipMove from "react-flip-move";
 import {
     DeleteApplicationDocument,
@@ -56,17 +56,18 @@ const ApplicationView: FunctionComponent<{ application: Application, token: stri
         const baseUrl = `${process.env.REACT_APP_API_BASE_URL}/application/${id}`
         const [collapsed, setCollapsed] = useState(false)
         const [height, setHeight] = useState(0)
+        const appToaster = useAppToaster()
         const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
         const [deleteApplication, {loading}] = useMutation<DeleteApplicationMutation, DeleteApplicationMutationVariables>(DeleteApplicationDocument, {
             onError: (error) => {
                 console.error(error)
-                getAppToaster().show({intent: "danger", message: "Etwas ist schief gelaufen."})
+                appToaster?.show({intent: "danger", message: "Etwas ist schief gelaufen."})
             },
             onCompleted: ({deleted}: { deleted: boolean }) => {
                 if (deleted) gotDeleted()
                 else {
                     console.error("Delete operation returned false.")
-                    getAppToaster().show({intent: "danger", message: "Etwas ist schief gelaufen."})
+                    appToaster?.show({intent: "danger", message: "Etwas ist schief gelaufen."})
                 }
             }
         });

--- a/administration/src/components/applications/ApplicationsOverview.tsx
+++ b/administration/src/components/applications/ApplicationsOverview.tsx
@@ -4,7 +4,7 @@ import {format} from "date-fns";
 import React, {FunctionComponent, useState} from "react";
 import styled from "styled-components";
 import JsonFieldView, {JsonField} from "./JsonFieldView";
-import {AppToaster} from "../AppToaster";
+import {getAppToaster} from "../AppToaster";
 import FlipMove from "react-flip-move";
 import {
     DeleteApplicationDocument,
@@ -60,13 +60,13 @@ const ApplicationView: FunctionComponent<{ application: Application, token: stri
         const [deleteApplication, {loading}] = useMutation<DeleteApplicationMutation, DeleteApplicationMutationVariables>(DeleteApplicationDocument, {
             onError: (error) => {
                 console.error(error)
-                AppToaster.show({intent: "danger", message: "Etwas ist schief gelaufen."})
+                getAppToaster().show({intent: "danger", message: "Etwas ist schief gelaufen."})
             },
             onCompleted: ({deleted}: { deleted: boolean }) => {
                 if (deleted) gotDeleted()
                 else {
                     console.error("Delete operation returned false.")
-                    AppToaster.show({intent: "danger", message: "Etwas ist schief gelaufen."})
+                    getAppToaster().show({intent: "danger", message: "Etwas ist schief gelaufen."})
                 }
             }
         });

--- a/administration/src/components/applications/JsonFieldView.tsx
+++ b/administration/src/components/applications/JsonFieldView.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {Button, Icon} from "@blueprintjs/core";
-import {AppToaster} from "../AppToaster";
+import {getAppToaster} from "../AppToaster";
 import downloadDataUri from "../../util/downloadDataUri";
 import { FunctionComponent } from "react";
 
@@ -38,7 +38,7 @@ const JsonFieldView: FunctionComponent<{ jsonField: JsonField, baseUrl: string, 
         const attachement = props.jsonField.value
         const downloadUrl = `${props.baseUrl}/file/${attachement.fileIndex}`
         const onClick = () => {
-            AppToaster.show({message: `Lädt ${attachement.fileName}...`, intent: 'primary'})
+            getAppToaster().show({message: `Lädt ${attachement.fileName}...`, intent: 'primary'})
             fetch(downloadUrl, {headers: {authorization: `Bearer ${props.token}`}})
                 .then(result => {
                     if (result.status === 200)
@@ -49,7 +49,7 @@ const JsonFieldView: FunctionComponent<{ jsonField: JsonField, baseUrl: string, 
                     const file = new File([result], attachement.fileName)
                     downloadDataUri(file, attachement.fileName)
                 })
-                .catch(() => AppToaster.show({message: 'Etwas ist schiefgelaufen.', intent: 'danger'}))
+                .catch(() => getAppToaster().show({message: 'Etwas ist schiefgelaufen.', intent: 'danger'}))
         }
         return <p>
             {props.jsonField.translations.de}:&nbsp;<Button icon='download' onClick={onClick}>

--- a/administration/src/components/applications/JsonFieldView.tsx
+++ b/administration/src/components/applications/JsonFieldView.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import {Button, Icon} from "@blueprintjs/core";
-import {getAppToaster} from "../AppToaster";
 import downloadDataUri from "../../util/downloadDataUri";
-import { FunctionComponent } from "react";
+import {FunctionComponent} from "react";
+import {useAppToaster} from "../AppToaster";
 
 
 export interface JsonField {
@@ -13,6 +13,8 @@ export interface JsonField {
 }
 
 const JsonFieldView: FunctionComponent<{ jsonField: JsonField, baseUrl: string, token: string, key?: number }> = props => {
+    const appToaster = useAppToaster()
+
     if (props.jsonField.type === 'Array') {
         return <>
             <p><b>{props.jsonField.translations.de}</b></p>
@@ -38,7 +40,7 @@ const JsonFieldView: FunctionComponent<{ jsonField: JsonField, baseUrl: string, 
         const attachement = props.jsonField.value
         const downloadUrl = `${props.baseUrl}/file/${attachement.fileIndex}`
         const onClick = () => {
-            getAppToaster().show({message: `Lädt ${attachement.fileName}...`, intent: 'primary'})
+            appToaster?.show({message: `Lädt ${attachement.fileName}...`, intent: 'primary'})
             fetch(downloadUrl, {headers: {authorization: `Bearer ${props.token}`}})
                 .then(result => {
                     if (result.status === 200)
@@ -49,7 +51,7 @@ const JsonFieldView: FunctionComponent<{ jsonField: JsonField, baseUrl: string, 
                     const file = new File([result], attachement.fileName)
                     downloadDataUri(file, attachement.fileName)
                 })
-                .catch(() => getAppToaster().show({message: 'Etwas ist schiefgelaufen.', intent: 'danger'}))
+                .catch(() => appToaster?.show({message: 'Etwas ist schiefgelaufen.', intent: 'danger'}))
         }
         return <p>
             {props.jsonField.translations.de}:&nbsp;<Button icon='download' onClick={onClick}>

--- a/administration/src/components/auth/Login.tsx
+++ b/administration/src/components/auth/Login.tsx
@@ -2,7 +2,7 @@ import {useMutation} from "@apollo/client";
 import React, {useContext} from "react";
 import styled from "styled-components";
 import LoginForm from "./LoginForm";
-import {AppToaster} from "../AppToaster";
+import {getAppToaster} from "../AppToaster";
 import {Card, H2} from "@blueprintjs/core";
 import {SignInDocument, SignInMutation, SignInMutationVariables, SignInPayload} from "../../generated/graphql";
 import {ProjectConfigContext} from "../../project-configs/ProjectConfigContext";
@@ -29,7 +29,7 @@ const Login = (props: Props) => {
     const [state, setState] = React.useState<State>({email: "", password: ""})
     const [signIn, mutationState] = useMutation<SignInMutation, SignInMutationVariables>(SignInDocument, {
         onCompleted: (payload: SignInMutation) => props.onSignIn(payload.signInPayload, state.password),
-        onError: () => AppToaster.show({intent: "danger", message: "Login fehlgeschlagen."})
+        onError: () => getAppToaster().show({intent: "danger", message: "Login fehlgeschlagen."})
     })
     const onSubmit = () => signIn({
         variables: {

--- a/administration/src/components/auth/Login.tsx
+++ b/administration/src/components/auth/Login.tsx
@@ -2,7 +2,7 @@ import {useMutation} from "@apollo/client";
 import React, {useContext} from "react";
 import styled from "styled-components";
 import LoginForm from "./LoginForm";
-import {getAppToaster} from "../AppToaster";
+import {useAppToaster} from "../AppToaster";
 import {Card, H2} from "@blueprintjs/core";
 import {SignInDocument, SignInMutation, SignInMutationVariables, SignInPayload} from "../../generated/graphql";
 import {ProjectConfigContext} from "../../project-configs/ProjectConfigContext";
@@ -26,10 +26,11 @@ interface State {
 
 const Login = (props: Props) => {
     const config = useContext(ProjectConfigContext)
+    const appToaster = useAppToaster()
     const [state, setState] = React.useState<State>({email: "", password: ""})
     const [signIn, mutationState] = useMutation<SignInMutation, SignInMutationVariables>(SignInDocument, {
         onCompleted: (payload: SignInMutation) => props.onSignIn(payload.signInPayload, state.password),
-        onError: () => getAppToaster().show({intent: "danger", message: "Login fehlgeschlagen."})
+        onError: () => appToaster?.show({intent: "danger", message: "Login fehlgeschlagen."})
     })
     const onSubmit = () => signIn({
         variables: {

--- a/administration/src/components/generation/GenerationController.tsx
+++ b/administration/src/components/generation/GenerationController.tsx
@@ -3,7 +3,7 @@ import {Spinner} from "@blueprintjs/core";
 import {CardCreationModel} from "./CardCreationModel";
 import GenerationForm from "./GenerationForm";
 import {useApolloClient} from "@apollo/client";
-import {getAppToaster} from "../AppToaster";
+import {useAppToaster} from "../AppToaster";
 import GenerationFinished from "./GenerationFinished";
 import downloadDataUri from "../../util/downloadDataUri";
 import generateCards from "./generateCards";
@@ -22,6 +22,7 @@ const GenerationController = () => {
     const client = useApolloClient();
     const [region] = useContext(RegionContext)
     const [mode, setMode] = useState(Mode.input);
+    const appToaster = useAppToaster()
 
     if (region === null) {
         return <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
@@ -41,20 +42,20 @@ const GenerationController = () => {
             if (e instanceof Exception) {
                 switch (e.data.type) {
                     case "pdf-generation":
-                        getAppToaster().show({
+                        appToaster?.show({
                             message: "Etwas ist schiefgegangen beim erstellen der PDF.",
                             intent: "danger"
                         })
                         break;
                     case "unicode":
-                        getAppToaster().show({
+                        appToaster?.show({
                             message: `Ein Zeichen konnte nicht in der PDF eingebunden werden: ${e.data.unsupportedChar}`,
                             intent: "danger"
                         })
                         break;
                 }
             } else {
-                getAppToaster().show({message: "Etwas ist schiefgegangen.", intent: "danger"})
+                appToaster?.show({message: "Etwas ist schiefgegangen.", intent: "danger"})
             }
             setMode(Mode.input)
         }

--- a/administration/src/components/generation/GenerationController.tsx
+++ b/administration/src/components/generation/GenerationController.tsx
@@ -3,7 +3,7 @@ import {Spinner} from "@blueprintjs/core";
 import {CardCreationModel} from "./CardCreationModel";
 import GenerationForm from "./GenerationForm";
 import {useApolloClient} from "@apollo/client";
-import {AppToaster} from "../AppToaster";
+import {getAppToaster} from "../AppToaster";
 import GenerationFinished from "./GenerationFinished";
 import downloadDataUri from "../../util/downloadDataUri";
 import generateCards from "./generateCards";
@@ -41,14 +41,20 @@ const GenerationController = () => {
             if (e instanceof Exception) {
                 switch (e.data.type) {
                     case "pdf-generation":
-                        AppToaster.show({message: "Etwas ist schiefgegangen beim erstellen der PDF.", intent: "danger"})
+                        getAppToaster().show({
+                            message: "Etwas ist schiefgegangen beim erstellen der PDF.",
+                            intent: "danger"
+                        })
                         break;
                     case "unicode":
-                        AppToaster.show({message: `Ein Zeichen konnte nicht in der PDF eingebunden werden: ${e.data.unsupportedChar}`, intent: "danger"})
+                        getAppToaster().show({
+                            message: `Ein Zeichen konnte nicht in der PDF eingebunden werden: ${e.data.unsupportedChar}`,
+                            intent: "danger"
+                        })
                         break;
                 }
             } else {
-                AppToaster.show({message: "Etwas ist schiefgegangen.", intent: "danger"})
+                getAppToaster().show({message: "Etwas ist schiefgegangen.", intent: "danger"})
             }
             setMode(Mode.input)
         }

--- a/administration/src/index.tsx
+++ b/administration/src/index.tsx
@@ -1,14 +1,13 @@
 import './polyfills'
 import React from 'react';
-import ReactDOM from 'react-dom';
+import {createRoot} from 'react-dom/client'
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
-ReactDOM.render(
-    React.createElement(App), // Don't use <App />, otherwise Babel will destroy IE11 functionality
-    document.getElementById('root')
-);
+
+const root = createRoot(document.getElementById("root")!)
+root.render(<App/>);
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -39,7 +39,8 @@ This short guide focuses on setting up the project using IntelliJ instead of And
 8. Create an admin account using `./gradlew run --args="create-admin <email> <password>"`
 9. Take a look at the martin endpoints: [http://localhost:5002/tiles/accepting_stores/index.json](http://localhost:5002/tiles/accepting_stores/index.json) and [http://localhost:5002/tiles/accepting_stores/rpc/index.json](http://localhost:5002/tiles/accepting_stores/rpc/index.json). The data shown on the map is fetched from a hardcoded url and is not using the data from the local martin!
 10. Take a look at the style by viewing the test map: [http://localhost:5002](http://localhost:5002)
-11. Take a look at the backend: [http://localhost:7000](http://localhost:7000) (The public version is available at api.ehrenamtskarte.app)
+11. Take a look at the backend: [http://localhost:7000](http://localhost:7000) (The public version is available at
+    api.entitlementcard.app)
 
 ## Dumping and restoring the database through docker
 


### PR DESCRIPTION
To complete the upgrade to react 18, we need to use createRoot from react-dom/client.
Moreover, I had to adjust the creation of the AppToaster, which uses the deprecated old API.