### PR TITLE
Fix map bugs

### DIFF
--- a/frontend/lib/map/map_page.dart
+++ b/frontend/lib/map/map_page.dart
@@ -97,10 +97,11 @@ class _MapPageState extends State<MapPage> implements MapPageController {
   PhysicalStoreFeatureData _extractPhysicalStoreData(dynamic rawFeature) {
     final feature = rawFeature as Map<String, dynamic>;
     final properties = feature["properties"] as Map<String, dynamic>;
+    final geometry = feature["geometry"] as Map<String, dynamic>;
 
     return PhysicalStoreFeatureData(
       _getIntOrNull(properties["id"]),
-      _getLatLngOrNull(properties["coordinates"]),
+      _getLatLngOrNull(geometry["coordinates"]),
       _getIntOrNull(properties["categoryId"]),
     );
   }


### PR DESCRIPTION
This PR fixes two bugs:

1. If the user selects selects a store on the map, the map **should** move the camera to center the store and show a larger symbol on top. However, it didn't.
2. If the user has given location permission to the app on Android, the app crashes on startup (especially with the release build).

The first bug was fixed by querying the coordinates from the geometry of the map feature. 

I fixed the second bug by removing a previous hack (which seems to be unnecessary by now). This luckily resolved the crash.

Please test this thoroughly:
With and without location permissions enabled, check whether all animations look correct (and that the animation does not stop early which was the reason for the hack).