### PR TITLE
675: Support static qr codes in backend and administration

### DIFF
--- a/administration/src/cards/CardBlueprint.ts
+++ b/administration/src/cards/CardBlueprint.ts
@@ -1,4 +1,4 @@
-import { CardExtensions, CardInfo, DynamicActivationCode, QrCode } from '../generated/card_pb'
+import { CardExtensions, CardInfo, DynamicActivationCode, QrCode, StaticVerifyCode } from '../generated/card_pb'
 import { dateToDaysSinceEpoch } from './validityPeriod'
 import { ExtensionHolder } from './extensions'
 
@@ -61,6 +61,26 @@ export class CardBlueprint {
     return new QrCode({ qrCode: { value: this.generateActivationCode(), case: 'dynamicActivationCode' } }).toBinary()
       .length
   }
+    
+  generateCardInfo = (): CardInfo => {
+    let extension_message = {}
+
+    for (const state of this.extensionHolders) {
+      if (!state) {
+        throw new Error('Tried to add invalid extension')
+      }
+      state.extension.setProtobufData(state, extension_message)
+    }
+
+    const expirationDate = this.expirationDate
+
+    return new CardInfo({
+      fullName: this.fullName,
+      expirationDay:
+        expirationDate !== null && !this.hasInfiniteLifetime() ? dateToDaysSinceEpoch(expirationDate) : undefined,
+      extensions: new CardExtensions(extension_message),
+    })
+  }
 
   generateActivationCode = (): DynamicActivationCode => {
     if (!window.isSecureContext) {
@@ -76,26 +96,24 @@ export class CardBlueprint {
     const totpSecret = new Uint8Array(TOTP_SECRET_LENGTH)
     crypto.getRandomValues(totpSecret)
 
-    let extension_message = {}
-
-    for (const state of this.extensionHolders) {
-      if (!state) {
-        throw new Error('Tried to add invalid extension')
-      }
-      state.extension.setProtobufData(state, extension_message)
-    }
-
-    const expirationDate = this.expirationDate
-
     return new DynamicActivationCode({
-      info: new CardInfo({
-        fullName: this.fullName,
-        expirationDay:
-          expirationDate !== null && !this.hasInfiniteLifetime() ? dateToDaysSinceEpoch(expirationDate) : undefined,
-        extensions: new CardExtensions(extension_message),
-      }),
+      info: this.generateCardInfo(),
       pepper: pepper,
       totpSecret: totpSecret,
+    })
+  }
+
+  generateStaticVerifyCode = (): StaticVerifyCode => {
+    if (!window.isSecureContext) {
+      // localhost is considered secure.
+      throw Error('Environment is not considered secure nor are we using Internet Explorer.')
+    }
+    const pepper = new Uint8Array(PEPPER_LENGTH) // 128 bit randomness
+    crypto.getRandomValues(pepper)
+
+    return new StaticVerifyCode({
+      info: this.generateCardInfo(),
+      pepper: pepper,
     })
   }
 }

--- a/administration/src/cards/CardBlueprint.ts
+++ b/administration/src/cards/CardBlueprint.ts
@@ -61,7 +61,7 @@ export class CardBlueprint {
     return new QrCode({ qrCode: { value: this.generateActivationCode(), case: 'dynamicActivationCode' } }).toBinary()
       .length
   }
-    
+
   generateCardInfo = (): CardInfo => {
     let extension_message = {}
 

--- a/administration/src/components/cards/CreateCardsController.tsx
+++ b/administration/src/components/cards/CreateCardsController.tsx
@@ -11,6 +11,7 @@ import { Exception } from '../../exception'
 import { activateCards } from '../../cards/activation'
 import { generatePdf, loadTTFFont } from '../../cards/PdfFactory'
 import { ProjectConfigContext } from '../../project-configs/ProjectConfigContext'
+import { CodeType } from '../../generated/graphql'
 
 enum CardActivationState {
   input,
@@ -50,9 +51,9 @@ const CreateCardsController = () => {
       const font = await loadTTFFont('NotoSans', 'normal', '/pdf-fonts/NotoSans-Regular.ttf')
       const pdfDataUri = generatePdf(font, region, activationCodes, staticCodes)
 
-      await activateCards(client, activationCodes, region)
+      await activateCards(client, activationCodes, region, CodeType.Dynamic)
 
-      if (staticCodes) await activateCards(client, staticCodes, region)
+      if (staticCodes) await activateCards(client, staticCodes, region, CodeType.Static)
 
       downloadDataUri(pdfDataUri, 'ehrenamtskarten.pdf')
       setState(CardActivationState.finished)

--- a/administration/src/project-configs/bayern/config.ts
+++ b/administration/src/project-configs/bayern/config.ts
@@ -6,6 +6,7 @@ const config: ProjectConfig = {
   name: 'Ehrenamtskarte Bayern',
   projectId: 'bayern.ehrenamtskarte.app',
   applicationFeatureEnabled: true,
+  staticQrCodesEnabled: false,
   createEmptyCard: createEmptyBavariaCard,
   dataPrivacyHeadline: dataPrivacyBaseHeadline,
   dataPrivacyContent: DataPrivacyBaseText,

--- a/administration/src/project-configs/getProjectConfig.ts
+++ b/administration/src/project-configs/getProjectConfig.ts
@@ -9,6 +9,7 @@ export interface ProjectConfig {
   name: string
   projectId: string
   applicationFeatureEnabled: boolean
+  staticQrCodesEnabled: boolean
   createEmptyCard: (region: Region) => CardBlueprint
   dataPrivacyHeadline: string
   dataPrivacyContent: () => ReactElement

--- a/administration/src/project-configs/nuernberg/config.ts
+++ b/administration/src/project-configs/nuernberg/config.ts
@@ -6,6 +6,7 @@ const config: ProjectConfig = {
   name: 'Digitaler Nürnberg-Pass',
   projectId: 'nuernberg.sozialpass.app',
   applicationFeatureEnabled: false,
+  staticQrCodesEnabled: true,
   createEmptyCard: createEmptyNuernbergCard,
   dataPrivacyHeadline: dataPrivacyBaseHeadline,
   dataPrivacyContent: DataPrivacyBaseText,

--- a/administration/src/project-configs/showcase/config.ts
+++ b/administration/src/project-configs/showcase/config.ts
@@ -6,6 +6,7 @@ const config: ProjectConfig = {
   name: 'Showcase Berechtigungskarte',
   projectId: 'showcase.entitlementcard.app',
   applicationFeatureEnabled: true,
+  staticQrCodesEnabled: false,
   createEmptyCard: createEmptyBavariaCard,
   dataPrivacyHeadline: dataPrivacyBaseHeadline,
   dataPrivacyContent: DataPrivacyBaseText,

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/database/Schema.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/database/Schema.kt
@@ -13,7 +13,7 @@ const val CARD_INFO_HASH_LENGTH = 32 // Using SHA256-HMAC
 const val TOTP_SECRET_LENGTH = 20
 
 object Cards : IntIdTable() {
-    val totpSecret = binary("totpSecret", TOTP_SECRET_LENGTH)
+    val totpSecret = binary("totpSecret", TOTP_SECRET_LENGTH).nullable()
     // Days since 1970-01-01. For more information refer to the card.proto,
     // Using long because unsigned ints are not available, but we want to be able to represent them.
     val expirationDay = long("expirationDay").nullable()

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/database/repos/CardRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/database/repos/CardRepository.kt
@@ -5,6 +5,7 @@ import app.ehrenamtskarte.backend.projects.database.Projects
 import app.ehrenamtskarte.backend.regions.database.Regions
 import app.ehrenamtskarte.backend.verification.database.CardEntity
 import app.ehrenamtskarte.backend.verification.database.Cards
+import app.ehrenamtskarte.backend.verification.database.CodeType
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.select
@@ -20,7 +21,7 @@ object CardRepository {
         return if (query == null) null else CardEntity.wrapRow(query)
     }
 
-    fun insert(cardInfoHash: ByteArray, totpSecret: ByteArray?, expirationDay: Long?, regionId: Int, issuerId: Int) =
+    fun insert(cardInfoHash: ByteArray, totpSecret: ByteArray?, expirationDay: Long?, regionId: Int, issuerId: Int, codeType: CodeType) =
         CardEntity.new {
             this.cardInfoHash = cardInfoHash
             this.totpSecret = totpSecret
@@ -29,5 +30,6 @@ object CardRepository {
             this.regionId = EntityID(regionId, Regions)
             this.issuerId = EntityID(issuerId, Administrators)
             this.revoked = false
+            this.codeType = codeType
         }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/database/repos/CardRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/database/repos/CardRepository.kt
@@ -20,7 +20,7 @@ object CardRepository {
         return if (query == null) null else CardEntity.wrapRow(query)
     }
 
-    fun insert(cardInfoHash: ByteArray, totpSecret: ByteArray, expirationDay: Long?, regionId: Int, issuerId: Int) =
+    fun insert(cardInfoHash: ByteArray, totpSecret: ByteArray?, expirationDay: Long?, regionId: Int, issuerId: Int) =
         CardEntity.new {
             this.cardInfoHash = cardInfoHash
             this.totpSecret = totpSecret

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/service/CardVerifier.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/service/CardVerifier.kt
@@ -17,7 +17,7 @@ const val TOTP_LENGTH = 6
 object CardVerifier {
     fun verifyCardHash(project: String, cardHash: ByteArray, totp: Int?, timezone: ZoneId): Boolean {
         val card = transaction { CardRepository.findByHashModel(project, cardHash) } ?: return false
-        return if (totp != null) verifyCard(card, totp, timezone) else verifyStaticCard(card, timezone)
+        return if (totp != null) verifyDynamicCard(card, totp, timezone) else verifyStaticCard(card, timezone)
     }
 
     private fun verifyStaticCard(card: CardEntity, timezone: ZoneId): Boolean {
@@ -25,7 +25,7 @@ object CardVerifier {
             !card.revoked
     }
 
-    private fun verifyCard(card: CardEntity, totp: Int, timezone: ZoneId): Boolean {
+    private fun verifyDynamicCard(card: CardEntity, totp: Int, timezone: ZoneId): Boolean {
         return !isExpired(card.expirationDay, timezone) &&
             !card.revoked &&
             isTotpValid(totp, card.totpSecret)

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/service/CardVerifier.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/service/CardVerifier.kt
@@ -15,19 +15,28 @@ val TIME_STEP: Duration = Duration.ofSeconds(30)
 const val TOTP_LENGTH = 6
 
 object CardVerifier {
-    fun verifyCardHash(project: String, cardHash: ByteArray, totp: Int, timezone: ZoneId): Boolean {
+    fun verifyCardHash(project: String, cardHash: ByteArray, totp: Int?, timezone: ZoneId): Boolean {
         val card = transaction { CardRepository.findByHashModel(project, cardHash) } ?: return false
-        return verifyCard(card, totp, timezone)
+        return if (totp != null) verifyCard(card, totp, timezone) else verifyStaticCard(card, timezone)
+    }
+
+    private fun verifyStaticCard(card: CardEntity, timezone: ZoneId): Boolean {
+        return !isExpired(card.expirationDay, timezone) &&
+            !card.revoked
     }
 
     private fun verifyCard(card: CardEntity, totp: Int, timezone: ZoneId): Boolean {
-        val expirationDay = card.expirationDay
-        return (expirationDay == null || isOnOrBeforeToday(daysSinceEpochToDate(expirationDay), timezone)) &&
+        return !isExpired(card.expirationDay, timezone) &&
             !card.revoked &&
             isTotpValid(totp, card.totpSecret)
     }
 
-    private fun isTotpValid(totp: Int, secret: ByteArray): Boolean {
+    private fun isExpired(expirationDay: Long?, timezone: ZoneId): Boolean {
+        return expirationDay != null && !isOnOrBeforeToday(daysSinceEpochToDate(expirationDay), timezone)
+    }
+
+    private fun isTotpValid(totp: Int, secret: ByteArray?): Boolean {
+        if (secret == null) return false
         if (generateTotp(secret) == totp) return true
 
         // current TOTP is invalid, but we are also happy with the previous/next one

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/webservice/schema/CardMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/webservice/schema/CardMutationService.kt
@@ -29,7 +29,8 @@ class CardMutationService {
                 totpSecret,
                 card.cardExpirationDay,
                 card.regionId,
-                user.id.value
+                user.id.value,
+                card.codeType
             )
         }
         return true

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/webservice/schema/CardMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/webservice/schema/CardMutationService.kt
@@ -23,9 +23,10 @@ class CardMutationService {
             if (!Authorizer.mayCreateCardInRegion(user, targetedRegionId)) {
                 throw UnauthorizedException()
             }
+            val totpSecret = if (card.totpSecretBase64 != null) Base64.getDecoder().decode(card.totpSecretBase64) else null
             CardRepository.insert(
                 Base64.getDecoder().decode(card.cardInfoHashBase64),
-                Base64.getDecoder().decode(card.totpSecretBase64),
+                totpSecret,
                 card.cardExpirationDay,
                 card.regionId,
                 user.id.value

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/webservice/schema/types/CardGenerationModel.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/webservice/schema/types/CardGenerationModel.kt
@@ -1,9 +1,12 @@
 package app.ehrenamtskarte.backend.verification.webservice.schema.types
 
+import app.ehrenamtskarte.backend.verification.database.CodeType
+
 data class CardGenerationModel constructor(
     val cardInfoHashBase64: String,
     val totpSecretBase64: String?,
     // Using Long because UInt is not supported, and a protobuf uin32 is not representable by a Kotlin Int
     val cardExpirationDay: Long?,
-    val regionId: Int
+    val regionId: Int,
+    val codeType: CodeType
 )

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/webservice/schema/types/CardGenerationModel.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/webservice/schema/types/CardGenerationModel.kt
@@ -2,7 +2,7 @@ package app.ehrenamtskarte.backend.verification.webservice.schema.types
 
 data class CardGenerationModel constructor(
     val cardInfoHashBase64: String,
-    val totpSecretBase64: String,
+    val totpSecretBase64: String?,
     // Using Long because UInt is not supported, and a protobuf uin32 is not representable by a Kotlin Int
     val cardExpirationDay: Long?,
     val regionId: Int

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/webservice/schema/types/CardVerificationModel.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/webservice/schema/types/CardVerificationModel.kt
@@ -2,5 +2,5 @@ package app.ehrenamtskarte.backend.verification.webservice.schema.types
 
 data class CardVerificationModel(
     val cardInfoHashBase64: String,
-    val totp: Int
+    val totp: Int?
 )

--- a/specs/backend-api.graphql
+++ b/specs/backend-api.graphql
@@ -260,12 +260,12 @@ input CardGenerationModelInput {
   cardExpirationDay: Long
   cardInfoHashBase64: String!
   regionId: Int!
-  totpSecretBase64: String!
+  totpSecretBase64: String
 }
 
 input CardVerificationModelInput {
   cardInfoHashBase64: String!
-  totp: Int!
+  totp: Int
 }
 
 input CoordinatesInput {

--- a/specs/backend-api.graphql
+++ b/specs/backend-api.graphql
@@ -169,6 +169,11 @@ enum BlueCardEntitlementType {
   WORK_AT_ORGANIZATIONS
 }
 
+enum CodeType {
+  dynamic
+  static
+}
+
 enum GoldenCardEntitlementType {
   HONORED_BY_MINISTER_PRESIDENT
   MILITARY_RESERVE
@@ -259,6 +264,7 @@ input BlueCardWorkAtOrganizationsEntitlementInput {
 input CardGenerationModelInput {
   cardExpirationDay: Long
   cardInfoHashBase64: String!
+  codeType: CodeType!
   regionId: Int!
   totpSecretBase64: String
 }


### PR DESCRIPTION
I did not create a separate mutation/query for the static cards, so far as the only difference is the presence of the totp secret. 

Would it make sense to verify the project in the backend, so that you cannot create a static qrcode for bayern? I personally think that static qrcodes should be treated as a feature, that can be turned on for every project. But am not sure how to verify this correctly in the backend.