### PR TITLE
770: Add camera permission check

### DIFF
--- a/frontend/ios/Podfile
+++ b/frontend/ios/Podfile
@@ -42,5 +42,11 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+        target.build_configurations.each do |config|
+            config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+            '$(inherited)',
+            'PERMISSION_CAMERA=1',
+          ]
+        end
   end
 end

--- a/frontend/ios/Podfile.lock
+++ b/frontend/ios/Podfile.lock
@@ -76,6 +76,8 @@ PODS:
     - Flutter
   - path_provider_ios (0.0.1):
     - Flutter
+  - permission_handler_apple (9.0.4):
+    - Flutter
   - PromisesObjC (2.1.1)
   - Protobuf (3.21.12)
   - ReachabilitySwift (5.0.0)
@@ -95,6 +97,7 @@ DEPENDENCIES:
   - mobile_scanner (from `.symlinks/plugins/mobile_scanner/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
+  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - shared_preferences_ios (from `.symlinks/plugins/shared_preferences_ios/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
@@ -135,6 +138,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_ios:
     :path: ".symlinks/plugins/path_provider_ios/ios"
+  permission_handler_apple:
+    :path: ".symlinks/plugins/permission_handler_apple/ios"
   shared_preferences_ios:
     :path: ".symlinks/plugins/shared_preferences_ios/ios"
   url_launcher_ios:
@@ -162,12 +167,13 @@ SPEC CHECKSUMS:
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
+  permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
   Protobuf: 120350fc38646e2dedc26f49ecba778184ea1de2
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
   url_launcher_ios: 839c58cdb4279282219f5e248c3321761ff3c4de
 
-PODFILE CHECKSUM: 0fa3383a235346277d3d57c6fad80526eda80904
+PODFILE CHECKSUM: 9e624ef9ea1950d5ac2524cf89093b7a29070f86
 
 COCOAPODS: 1.11.3

--- a/frontend/lib/configuration/settings_model.dart
+++ b/frontend/lib/configuration/settings_model.dart
@@ -76,6 +76,6 @@ class SettingsModel extends ChangeNotifier {
 
   @override
   String toString() {
-    return 'SettingsModel{_firstStart: $_firstStart, _hideVerificationInfo: $_hideVerificationInfo, _locationFeatureEnabled: $_locationFeatureEnabled}';
+    return 'SettingsModel{_firstStart: $_firstStart, _hideVerificationInfo: $_hideVerificationInfo, _locationFeatureEnabled: $_locationFeatureEnabled}, _cameraPermissionRequested: $_cameraPermissionRequested}';
   }
 }

--- a/frontend/lib/configuration/settings_model.dart
+++ b/frontend/lib/configuration/settings_model.dart
@@ -7,7 +7,6 @@ class SettingsModel extends ChangeNotifier {
   var _firstStart = false;
   var _hideVerificationInfo = false;
   var _locationFeatureEnabled = false;
-  var _cameraPermissionRequested = false;
 
   SharedPreferences? _preferences;
 
@@ -17,7 +16,6 @@ class SettingsModel extends ChangeNotifier {
       _firstStart = await loadFirstStart();
       _hideVerificationInfo = await loadHideVerificationInfo();
       _locationFeatureEnabled = await loadLocationFeatureEnabled();
-      _cameraPermissionRequested = await loadCameraPermissionRequested();
     } on Exception {
       _preferences?.clear();
     }
@@ -56,26 +54,14 @@ class SettingsModel extends ChangeNotifier {
     await _preferences?.setBool("location", enabled);
   }
 
-  Future<bool> loadCameraPermissionRequested() async {
-    return _preferences?.getBool("camera") ?? false;
-  }
-
-  Future<void> setCameraPermissionRequested({required bool requested}) async {
-    _cameraPermissionRequested = requested;
-    notifyListeners();
-    await _preferences?.setBool("camera", requested);
-  }
-
   bool get firstStart => _firstStart;
 
   bool get hideVerificationInfo => _hideVerificationInfo;
 
   bool get locationFeatureEnabled => _locationFeatureEnabled;
 
-  bool get cameraPermissionRequested => _cameraPermissionRequested;
-
   @override
   String toString() {
-    return 'SettingsModel{_firstStart: $_firstStart, _hideVerificationInfo: $_hideVerificationInfo, _locationFeatureEnabled: $_locationFeatureEnabled}, _cameraPermissionRequested: $_cameraPermissionRequested}';
+    return 'SettingsModel{_firstStart: $_firstStart, _hideVerificationInfo: $_hideVerificationInfo, _locationFeatureEnabled: $_locationFeatureEnabled}';
   }
 }

--- a/frontend/lib/configuration/settings_model.dart
+++ b/frontend/lib/configuration/settings_model.dart
@@ -7,6 +7,7 @@ class SettingsModel extends ChangeNotifier {
   var _firstStart = false;
   var _hideVerificationInfo = false;
   var _locationFeatureEnabled = false;
+  var _cameraPermissionRequested = false;
 
   SharedPreferences? _preferences;
 
@@ -16,6 +17,7 @@ class SettingsModel extends ChangeNotifier {
       _firstStart = await loadFirstStart();
       _hideVerificationInfo = await loadHideVerificationInfo();
       _locationFeatureEnabled = await loadLocationFeatureEnabled();
+      _cameraPermissionRequested = await loadCameraPermissionRequested();
     } on Exception {
       _preferences?.clear();
     }
@@ -54,11 +56,23 @@ class SettingsModel extends ChangeNotifier {
     await _preferences?.setBool("location", enabled);
   }
 
+  Future<bool> loadCameraPermissionRequested() async {
+    return _preferences?.getBool("camera") ?? false;
+  }
+
+  Future<void> setCameraPermissionRequested({required bool requested}) async {
+    _cameraPermissionRequested = requested;
+    notifyListeners();
+    await _preferences?.setBool("camera", requested);
+  }
+
   bool get firstStart => _firstStart;
 
   bool get hideVerificationInfo => _hideVerificationInfo;
 
   bool get locationFeatureEnabled => _locationFeatureEnabled;
+
+  bool get cameraPermissionRequested => _cameraPermissionRequested;
 
   @override
   String toString() {

--- a/frontend/lib/identification/identification_page.dart
+++ b/frontend/lib/identification/identification_page.dart
@@ -46,29 +46,32 @@ class IdentificationPage extends StatelessWidget {
     );
   }
 
-  Future<bool> checkCameraPermission(BuildContext context, SettingsModel settings) async {
+  Future<void> checkCameraPermission(BuildContext context, SettingsModel settings) async {
     Future<void> showDialog() async => QrCodeCameraPermissionDialog.showPermissionDialog(context);
+    // ios & android set different status when access was denied
     final bool permissionsDenied =
         await Permission.camera.status.isPermanentlyDenied || await Permission.camera.status.isDenied;
     if (permissionsDenied && settings.cameraPermissionRequested) {
       await showDialog();
-    } else {
-      await Permission.camera.request().isGranted;
-      await settings.setCameraPermissionRequested(requested: true);
+      return;
     }
-    return Permission.camera.isGranted;
+    await settings.setCameraPermissionRequested(requested: true);
   }
 
   Future<void> _showVerificationDialog(BuildContext context, SettingsModel settings) async {
-    if (await checkCameraPermission(context, settings)) {
+    if (await Permission.camera.request().isGranted) {
       await VerificationWorkflow.startWorkflow(context, settings);
+      return;
     }
+    checkCameraPermission(context, settings);
   }
 
   Future<void> _startActivation(BuildContext context, SettingsModel settings) async {
-    if (await checkCameraPermission(context, settings)) {
+    if (await Permission.camera.request().isGranted) {
       Navigator.push(context, AppRoute(builder: (context) => const ActivationCodeScannerPage()));
+      return;
     }
+    checkCameraPermission(context, settings);
   }
 
   Future<bool> _startApplication() {

--- a/frontend/lib/identification/identification_page.dart
+++ b/frontend/lib/identification/identification_page.dart
@@ -46,26 +46,23 @@ class IdentificationPage extends StatelessWidget {
     );
   }
 
-  Future<bool> _isCameraPermissionDenied() async {
-    return await Permission.camera.status.isPermanentlyDenied || await Permission.camera.status.isDenied;
+  Future<bool> checkCameraPermission(BuildContext context) async {
+    Future<void> showDialog() async => QrCodeCameraPermissionDialog.showPermissionDialog(context);
+    if (await Permission.camera.status.isPermanentlyDenied) {
+      await showDialog();
+    }
+    return Permission.camera.request().isGranted;
   }
 
   Future<void> _showVerificationDialog(BuildContext context, SettingsModel settings) async {
-    Future<void> showDialog() async => QrCodeCameraPermissionDialog.showPermissionDialog(context);
-    if (await _isCameraPermissionDenied()) {
-      await showDialog();
-      return;
-    }
+    checkCameraPermission(context);
     await VerificationWorkflow.startWorkflow(context, settings);
   }
 
   Future<void> _startActivation(BuildContext context) async {
-    Future<void> showDialog() async => QrCodeCameraPermissionDialog.showPermissionDialog(context);
-    if (await _isCameraPermissionDenied()) {
-      await showDialog();
-      return;
+    if (await checkCameraPermission(context)) {
+      Navigator.push(context, AppRoute(builder: (context) => const ActivationCodeScannerPage()));
     }
-    Navigator.push(context, AppRoute(builder: (context) => const ActivationCodeScannerPage()));
   }
 
   Future<bool> _startApplication() {

--- a/frontend/lib/identification/identification_page.dart
+++ b/frontend/lib/identification/identification_page.dart
@@ -32,30 +32,22 @@ class IdentificationPage extends StatelessWidget {
           return CardDetailView(
             activationCode: activationCode,
             startVerification: () => _showVerificationDialog(context, settings),
-            startActivation: () => _startActivation(context, settings),
+            startActivation: () => _startActivation(context),
             startApplication: _startApplication,
           );
         }
 
         return NoCardView(
           startVerification: () => _showVerificationDialog(context, settings),
-          startActivation: () => _startActivation(context, settings),
+          startActivation: () => _startActivation(context),
           startApplication: _startApplication,
         );
       },
     );
   }
 
-  Future<void> checkCameraPermission(BuildContext context, SettingsModel settings) async {
-    Future<void> showDialog() async => QrCodeCameraPermissionDialog.showPermissionDialog(context);
-    // ios & android set different status when access was denied
-    final bool permissionsDenied =
-        await Permission.camera.status.isPermanentlyDenied || await Permission.camera.status.isDenied;
-    if (permissionsDenied && settings.cameraPermissionRequested) {
-      await showDialog();
-      return;
-    }
-    await settings.setCameraPermissionRequested(requested: true);
+  Future<void> handleDeniedCameraPermission(BuildContext context) async {
+    await QrCodeCameraPermissionDialog.showPermissionDialog(context);
   }
 
   Future<void> _showVerificationDialog(BuildContext context, SettingsModel settings) async {
@@ -63,15 +55,15 @@ class IdentificationPage extends StatelessWidget {
       await VerificationWorkflow.startWorkflow(context, settings);
       return;
     }
-    checkCameraPermission(context, settings);
+    handleDeniedCameraPermission(context);
   }
 
-  Future<void> _startActivation(BuildContext context, SettingsModel settings) async {
+  Future<void> _startActivation(BuildContext context) async {
     if (await Permission.camera.request().isGranted) {
       Navigator.push(context, AppRoute(builder: (context) => const ActivationCodeScannerPage()));
       return;
     }
-    checkCameraPermission(context, settings);
+    handleDeniedCameraPermission(context);
   }
 
   Future<bool> _startApplication() {

--- a/frontend/lib/identification/identification_page.dart
+++ b/frontend/lib/identification/identification_page.dart
@@ -4,9 +4,11 @@ import 'package:ehrenamtskarte/identification/activation_code_model.dart';
 import 'package:ehrenamtskarte/identification/activation_workflow/activation_code_scanner_page.dart';
 import 'package:ehrenamtskarte/identification/card_detail_view/card_detail_view.dart';
 import 'package:ehrenamtskarte/identification/no_card_view.dart';
+import 'package:ehrenamtskarte/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart';
 import 'package:ehrenamtskarte/identification/verification_workflow/verification_workflow.dart';
 import 'package:ehrenamtskarte/routing.dart';
 import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
@@ -44,11 +46,25 @@ class IdentificationPage extends StatelessWidget {
     );
   }
 
+  Future<bool> _isCameraPermissionDenied() async {
+    return await Permission.camera.status.isPermanentlyDenied || await Permission.camera.status.isDenied;
+  }
+
   Future<void> _showVerificationDialog(BuildContext context, SettingsModel settings) async {
+    Future<void> showDialog() async => QrCodeCameraPermissionDialog.showPermissionDialog(context);
+    if (await _isCameraPermissionDenied()) {
+      await showDialog();
+      return;
+    }
     await VerificationWorkflow.startWorkflow(context, settings);
   }
 
-  void _startActivation(BuildContext context) {
+  Future<void> _startActivation(BuildContext context) async {
+    Future<void> showDialog() async => QrCodeCameraPermissionDialog.showPermissionDialog(context);
+    if (await _isCameraPermissionDenied()) {
+      await showDialog();
+      return;
+    }
     Navigator.push(context, AppRoute(builder: (context) => const ActivationCodeScannerPage()));
   }
 

--- a/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
+++ b/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
@@ -12,7 +12,7 @@ class QrCodeCameraPermissionDialog extends StatelessWidget {
         child: ListBody(
           children: const <Widget>[
             Text(
-              "Zum Lesen von QR-Codes wird Kamerauzugriff benötigt.\nÖffnen sie die Einstellungen und klicken sie auf Erlauben",
+              "Zum Lesen von QR-Codes wird Kamerauzugriff benötigt.\nÖffnen sie die Einstellungen und wählen sie Kamerazugriff erlauben.",
             ),
           ],
         ),

--- a/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
+++ b/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
@@ -19,15 +19,15 @@ class QrCodeCameraPermissionDialog extends StatelessWidget {
       ),
       actions: <Widget>[
         TextButton(
-          child: const Text('Einstellungen öffnen'),
-          onPressed: () {
-            openAppSettings();
-          },
-        ),
-        TextButton(
           child: const Text('Abbrechen'),
           onPressed: () {
             Navigator.of(context).pop();
+          },
+        ),
+        TextButton(
+          child: const Text('Einstellungen öffnen'),
+          onPressed: () {
+            openAppSettings();
           },
         ),
       ],
@@ -37,7 +37,6 @@ class QrCodeCameraPermissionDialog extends StatelessWidget {
   static Future<void> showPermissionDialog(BuildContext context) async {
     return showDialog<void>(
       context: context,
-      barrierDismissible: false, // user must tap button!
       builder: (context) => const QrCodeCameraPermissionDialog(),
     );
   }

--- a/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
+++ b/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
@@ -19,7 +19,7 @@ class QrCodeCameraPermissionDialog extends StatelessWidget {
       ),
       actions: <Widget>[
         TextButton(
-          child: const Text('Einstellungen'),
+          child: const Text('Einstellungen öffnen'),
           onPressed: () {
             openAppSettings();
           },

--- a/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
+++ b/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
@@ -12,7 +12,7 @@ class QrCodeCameraPermissionDialog extends StatelessWidget {
         child: ListBody(
           children: const <Widget>[
             Text(
-              "Zum Lesen von QR-Codes wird Kamerauzugriff benötigt.\nÖffnen sie die Einstellungen und wählen sie Kamerazugriff erlauben.",
+              "Um einen QR-Code einzuscannen, benötigt die App Zugriff auf die Kamera.\nIn den Einstellungen können Sie der App den Zugriff auf die Kamera erlauben.",
             ),
           ],
         ),

--- a/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
+++ b/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
@@ -7,11 +7,13 @@ class QrCodeCameraPermissionDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Text("Kamerazugriff erforderlich"),
+      title: const Text("Kamerazugriff erforderlich", style: TextStyle(fontSize: 18)),
       content: SingleChildScrollView(
         child: ListBody(
           children: const <Widget>[
-            Text("Zum Lesen von QR-Codes wird Kamerauzugriff benötigt.\nÖffnen sie die Einstellungen und klicken sie auf Erlauben"),
+            Text(
+              "Zum Lesen von QR-Codes wird Kamerauzugriff benötigt.\nÖffnen sie die Einstellungen und klicken sie auf Erlauben",
+            ),
           ],
         ),
       ),

--- a/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
+++ b/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
@@ -7,7 +7,7 @@ class QrCodeCameraPermissionDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: const Text("Kamerazugriff erforderlich", style: TextStyle(fontSize: 18)),
+      title: const Text("Zugriff auf Kamera erforderlich", style: TextStyle(fontSize: 18)),
       content: SingleChildScrollView(
         child: ListBody(
           children: const <Widget>[

--- a/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
+++ b/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
@@ -25,7 +25,7 @@ class QrCodeCameraPermissionDialog extends StatelessWidget {
           },
         ),
         TextButton(
-          child: const Text('Ok'),
+          child: const Text('Abbrechen'),
           onPressed: () {
             Navigator.of(context).pop();
           },

--- a/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
+++ b/frontend/lib/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+class QrCodeCameraPermissionDialog extends StatelessWidget {
+  const QrCodeCameraPermissionDialog();
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text("Kamerazugriff erforderlich"),
+      content: SingleChildScrollView(
+        child: ListBody(
+          children: const <Widget>[
+            Text("Zum Lesen von QR-Codes wird Kamerauzugriff benötigt.\nÖffnen sie die Einstellungen und klicken sie auf Erlauben"),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          child: const Text('Einstellungen'),
+          onPressed: () {
+            openAppSettings();
+          },
+        ),
+        TextButton(
+          child: const Text('Ok'),
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+        ),
+      ],
+    );
+  }
+
+  static Future<void> showPermissionDialog(BuildContext context) async {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false, // user must tap button!
+      builder: (context) => const QrCodeCameraPermissionDialog(),
+    );
+  }
+}

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -827,6 +827,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "10.2.0"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "10.2.0"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "9.0.7"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.9.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2"
   petitparser:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   graphql_flutter: ^5.1.0
   url_launcher: ^6.1.6
   flutter_svg: ^1.1.4
+  permission_handler: ^10.2.0
   package_info_plus: ^1.4.3+1 # for about dialog
   mobile_scanner: ^2.1.0
   flutter_secure_storage: ^6.0.0


### PR DESCRIPTION
I'm not sure if this separate package for permissions is really needed
I used a state to check if permission was requested before because android permission is `denied` initially and by choosing explicit deny on permission dialog.
Let me know if that way is fine

- if camera access is not granted -> request permission before opening QRCode Scanner
- if camera access was denied showDialog

resolves https://github.com/digitalfabrik/entitlementcard/issues/770