### PR TITLE
839: Setup DB migrations

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -44,15 +44,19 @@ dependencies {
     // Use the Kotlin JUnit integration.
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
 
+    // Database
     implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-dao:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-java-time:$exposedVersion")
+    implementation("net.postgis:postgis-jdbc:2.5.0")
     implementation("org.postgresql:postgresql:42.5.1")
+
+    // Database Migrations
+    implementation("org.flywaydb:flyway-core:9.15.1")
+
     implementation("com.kohlschutter.junixsocket:junixsocket-core:2.6.1")
     implementation("com.kohlschutter.junixsocket:junixsocket-common:2.6.1")
-
-    implementation("net.postgis:postgis-jdbc:2.5.0")
 
     implementation("io.ktor:ktor-client-core:2.1.2")
     implementation("io.ktor:ktor-client-cio:2.1.2")

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/common/database/Database.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/common/database/Database.kt
@@ -3,6 +3,7 @@ package app.ehrenamtskarte.backend.common.database
 import app.ehrenamtskarte.backend.auth.database.repos.AdministratorsRepository
 import app.ehrenamtskarte.backend.auth.webservice.schema.types.Role
 import app.ehrenamtskarte.backend.config.BackendConfiguration
+import org.flywaydb.core.Flyway
 import org.jetbrains.exposed.sql.Database.Companion.connect
 import org.jetbrains.exposed.sql.StdOutSqlLogger
 import org.jetbrains.exposed.sql.addLogger
@@ -66,6 +67,17 @@ class Database {
                 setupDatabaseForApplication()
                 setupDatabaseForAuth()
             }
+
+            migrate(config)
+        }
+
+        fun migrate(config: BackendConfiguration) {
+            val flyway = Flyway.configure()
+                .baselineOnMigrate(true) // remove after first production release
+                .dataSource(config.postgres.url, config.postgres.user, config.postgres.password)
+                .locations("classpath:db/migrations")
+                .load()
+            flyway.migrate()
         }
     }
 }

--- a/backend/src/main/resources/db/migrations/V1__remove_old_email_index.sql
+++ b/backend/src/main/resources/db/migrations/V1__remove_old_email_index.sql
@@ -1,0 +1,1 @@
+alter table administrators drop constraint administrators_email_unique;


### PR DESCRIPTION
Flyway seems to be the most popular tool in regard to db migrations. There is a community and an enterprise version and I think the community edition provides enough for our regards. 
Setup seems to be quite simple.