### PR TITLE
851: Refactor data loaders and disable caching

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/applicationGraphQLParams.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/applicationGraphQLParams.kt
@@ -1,11 +1,10 @@
 package app.ehrenamtskarte.backend.application.webservice
 
-import app.ehrenamtskarte.backend.application.webservice.dataloader.APPLICATION_LOADER_NAME
-import app.ehrenamtskarte.backend.application.webservice.dataloader.VERIFICATIONS_BY_APPLICATION_LOADER_NAME
 import app.ehrenamtskarte.backend.application.webservice.dataloader.applicationLoader
 import app.ehrenamtskarte.backend.application.webservice.dataloader.verificationsByApplicationLoader
 import app.ehrenamtskarte.backend.application.webservice.schema.create.primitives.UploadKey
 import app.ehrenamtskarte.backend.common.webservice.GraphQLParams
+import app.ehrenamtskarte.backend.common.webservice.createRegistryFromNamedDataLoaders
 import com.expediagroup.graphql.generator.SchemaGeneratorConfig
 import com.expediagroup.graphql.generator.TopLevelObject
 import com.expediagroup.graphql.generator.hooks.SchemaGeneratorHooks
@@ -16,15 +15,7 @@ import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
 import graphql.schema.GraphQLScalarType
 import graphql.schema.GraphQLType
-import org.dataloader.DataLoaderRegistry
 import kotlin.reflect.KType
-
-private fun createDataLoaderRegistry(): DataLoaderRegistry {
-    val dataLoaderRegistry = DataLoaderRegistry()
-    dataLoaderRegistry.register(APPLICATION_LOADER_NAME, applicationLoader)
-    dataLoaderRegistry.register(VERIFICATIONS_BY_APPLICATION_LOADER_NAME, verificationsByApplicationLoader)
-    return dataLoaderRegistry
-}
 
 val Upload: GraphQLScalarType = GraphQLScalarType.newScalar()
     .name("Upload")
@@ -70,7 +61,10 @@ val applicationGraphQlParams = GraphQLParams(
                 }
         },
     ),
-    dataLoaderRegistry = createDataLoaderRegistry(),
+    dataLoaderRegistry = createRegistryFromNamedDataLoaders(
+        applicationLoader,
+        verificationsByApplicationLoader,
+    ),
     queries = listOf(
         TopLevelObject(EakApplicationQueryService()),
     ),

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/dataloader/ApplicationDataLoader.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/dataloader/ApplicationDataLoader.kt
@@ -7,58 +7,45 @@ import app.ehrenamtskarte.backend.application.database.Applications
 import app.ehrenamtskarte.backend.application.database.repos.ApplicationRepository
 import app.ehrenamtskarte.backend.application.webservice.schema.view.ApplicationVerificationView
 import app.ehrenamtskarte.backend.application.webservice.schema.view.ApplicationView
-import kotlinx.coroutines.runBlocking
-import org.dataloader.DataLoader
-import org.dataloader.DataLoaderFactory
+import app.ehrenamtskarte.backend.common.webservice.newNamedDataLoader
 import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
-import java.util.concurrent.CompletableFuture
 
-const val APPLICATION_LOADER_NAME = "APPLICATION_LOADER"
-
-val applicationLoader: DataLoader<Int, ApplicationView?> = DataLoaderFactory.newDataLoader { ids ->
-    CompletableFuture.supplyAsync {
-        runBlocking {
-            transaction {
-                ApplicationRepository.findByIds(ids).map { it?.let { ApplicationView.fromDbEntity(it) } }
-            }
+val applicationLoader = newNamedDataLoader("APPLICATION_LOADER") { ids ->
+    transaction {
+        ApplicationRepository.findByIds(ids).map {
+            it?.let { ApplicationView.fromDbEntity(it) }
         }
     }
 }
 
-const val VERIFICATIONS_BY_APPLICATION_LOADER_NAME = "VERIFICATIONS_BY_APPLICATION_LOADER"
-val verificationsByApplicationLoader: DataLoader<Int, List<ApplicationVerificationView>?> =
-    DataLoaderFactory.newDataLoader { ids ->
-        CompletableFuture.supplyAsync {
-            runBlocking {
-                transaction {
-                    val list = (Applications leftJoin ApplicationVerifications)
-                        .slice(listOf(Applications.id).plus(ApplicationVerifications.columns))
-                        .select { Applications.id inList ids }
-                        .orderBy(Applications.id to SortOrder.ASC, ApplicationVerifications.id to SortOrder.ASC)
-                        .toList()
-                    val groupedByApplication = list.groupBy { row -> row[Applications.id].value }
-                    val entities = ids.map { id ->
-                        groupedByApplication[id]?.let { list ->
-                            val verificationEntities = list.mapNotNull {
-                                if (it[ApplicationVerifications.id.nullable()] == null) {
-                                    null
-                                } else {
-                                    ApplicationVerificationEntity.wrapRow(it)
-                                }
-                            }
-                            verificationEntities
-                        }
+val verificationsByApplicationLoader = newNamedDataLoader<Int, _>("VERIFICATIONS_BY_APPLICATION_LOADER") { ids ->
+    transaction {
+        val list = (Applications leftJoin ApplicationVerifications)
+            .slice(listOf(Applications.id).plus(ApplicationVerifications.columns))
+            .select { Applications.id inList ids }
+            .orderBy(Applications.id to SortOrder.ASC, ApplicationVerifications.id to SortOrder.ASC)
+            .toList()
+        val groupedByApplication = list.groupBy { row -> row[Applications.id].value }
+        val entities = ids.map { id ->
+            groupedByApplication[id]?.let { list ->
+                val verificationEntities = list.mapNotNull {
+                    if (it[ApplicationVerifications.id.nullable()] == null) {
+                        null
+                    } else {
+                        ApplicationVerificationEntity.wrapRow(it)
                     }
-                    entities.map {
-                        it?.let { verificationEntities ->
-                            verificationEntities.map { entity ->
-                                ApplicationVerificationView.fromDbEntity(entity)
-                            }
-                        }
-                    }
+                }
+                verificationEntities
+            }
+        }
+        entities.map {
+            it?.let { verificationEntities ->
+                verificationEntities.map { entity ->
+                    ApplicationVerificationView.fromDbEntity(entity)
                 }
             }
         }
     }
+}

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/schema/view/ApplicationView.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/schema/view/ApplicationView.kt
@@ -1,7 +1,8 @@
 package app.ehrenamtskarte.backend.application.webservice.schema.view
 
 import app.ehrenamtskarte.backend.application.database.ApplicationEntity
-import app.ehrenamtskarte.backend.application.webservice.dataloader.VERIFICATIONS_BY_APPLICATION_LOADER_NAME
+import app.ehrenamtskarte.backend.application.webservice.dataloader.verificationsByApplicationLoader
+import app.ehrenamtskarte.backend.common.webservice.fromEnvironment
 import graphql.schema.DataFetchingEnvironment
 import java.util.concurrent.CompletableFuture
 
@@ -12,9 +13,6 @@ data class ApplicationView(val id: Int, val regionId: Int, val createdDate: Stri
             ApplicationView(entity.id.value, entity.regionId.value, entity.createdDate.toString(), entity.jsonValue)
     }
 
-    fun verifications(dfe: DataFetchingEnvironment): CompletableFuture<List<ApplicationVerificationView>> {
-        return dfe.getDataLoader<Int, List<ApplicationVerificationView>?>(
-            VERIFICATIONS_BY_APPLICATION_LOADER_NAME,
-        ).load(this.id)!!
-    }
+    fun verifications(environment: DataFetchingEnvironment): CompletableFuture<List<ApplicationVerificationView>> =
+        verificationsByApplicationLoader.fromEnvironment(environment).load(id).thenApply { it!! }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/Setup.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/Setup.kt
@@ -4,7 +4,7 @@ import org.jetbrains.exposed.sql.SchemaUtils
 
 fun setupDatabase() {
     SchemaUtils.create(
-        Administrators
+        Administrators,
     )
     createEmailIndexIfNotExists()
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/repos/AdministratorsRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/repos/AdministratorsRepository.kt
@@ -32,7 +32,7 @@ object AdministratorsRepository {
         val resultRow = (Administrators innerJoin Projects)
             .slice(Administrators.columns)
             .select(
-                (Projects.project eq project) and (LowerCase(Administrators.email) eq email.lowercase())
+                (Projects.project eq project) and (LowerCase(Administrators.email) eq email.lowercase()),
             )
             .firstOrNull()
         return resultRow?.let {
@@ -51,7 +51,7 @@ object AdministratorsRepository {
         email: String,
         password: String?,
         role: Role,
-        regionId: Int? = null
+        regionId: Int? = null,
     ): AdministratorEntity {
         val projectEntity = ProjectEntity.find { Projects.project eq project }.firstOrNull()
             ?: throw IllegalArgumentException("Project does not exist.")

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/authGraphQLParams.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/authGraphQLParams.kt
@@ -1,6 +1,5 @@
 package app.ehrenamtskarte.backend.auth.webservice
 
-import app.ehrenamtskarte.backend.auth.webservice.dataloader.ADMINISTRATOR_LOADER_NAME
 import app.ehrenamtskarte.backend.auth.webservice.dataloader.administratorLoader
 import app.ehrenamtskarte.backend.auth.webservice.schema.ChangePasswordMutationService
 import app.ehrenamtskarte.backend.auth.webservice.schema.ManageUsersMutationService
@@ -8,26 +7,20 @@ import app.ehrenamtskarte.backend.auth.webservice.schema.ResetPasswordMutationSe
 import app.ehrenamtskarte.backend.auth.webservice.schema.SignInMutationService
 import app.ehrenamtskarte.backend.auth.webservice.schema.ViewAdministratorsQueryService
 import app.ehrenamtskarte.backend.common.webservice.GraphQLParams
+import app.ehrenamtskarte.backend.common.webservice.createRegistryFromNamedDataLoaders
 import com.expediagroup.graphql.generator.SchemaGeneratorConfig
 import com.expediagroup.graphql.generator.TopLevelObject
-import org.dataloader.DataLoaderRegistry
-
-private fun createDataLoaderRegistry(): DataLoaderRegistry {
-    val dataLoader = DataLoaderRegistry()
-    dataLoader.register(ADMINISTRATOR_LOADER_NAME, administratorLoader)
-    return dataLoader
-}
 
 val authGraphQlParams = GraphQLParams(
     config = SchemaGeneratorConfig(supportedPackages = listOf("app.ehrenamtskarte.backend.auth.webservice.schema")),
-    dataLoaderRegistry = createDataLoaderRegistry(),
+    dataLoaderRegistry = createRegistryFromNamedDataLoaders(administratorLoader),
     mutations = listOf(
         TopLevelObject(SignInMutationService()),
         TopLevelObject(ChangePasswordMutationService()),
         TopLevelObject(ResetPasswordMutationService()),
-        TopLevelObject(ManageUsersMutationService())
+        TopLevelObject(ManageUsersMutationService()),
     ),
     queries = listOf(
-        TopLevelObject(ViewAdministratorsQueryService())
-    )
+        TopLevelObject(ViewAdministratorsQueryService()),
+    ),
 )

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/dataloader/AdministratorDataLoader.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/dataloader/AdministratorDataLoader.kt
@@ -3,26 +3,15 @@ package app.ehrenamtskarte.backend.auth.webservice.dataloader
 import app.ehrenamtskarte.backend.auth.database.repos.AdministratorsRepository
 import app.ehrenamtskarte.backend.auth.webservice.schema.types.Administrator
 import app.ehrenamtskarte.backend.auth.webservice.schema.types.Role
-import com.expediagroup.graphql.generator.exceptions.GraphQLKotlinException
-import kotlinx.coroutines.runBlocking
-import org.dataloader.DataLoader
-import org.dataloader.DataLoaderFactory
+import app.ehrenamtskarte.backend.common.webservice.newNamedDataLoader
 import org.jetbrains.exposed.sql.transactions.transaction
-import java.util.concurrent.CompletableFuture
 
-const val ADMINISTRATOR_LOADER_NAME = "ADMINISTRATOR_LOADER"
-
-val administratorLoader: DataLoader<Int, Administrator?> = DataLoaderFactory.newDataLoader { ids ->
-    CompletableFuture.supplyAsync {
-        runBlocking {
-            transaction {
-                AdministratorsRepository.findByIds(ids).map {
-                    if (it == null) null
-                    else {
-                        val role = Role.fromDbValue(it.role) ?: throw GraphQLKotlinException("Invalid role.")
-                        Administrator(it.id.value, it.email, it.regionId?.value, role)
-                    }
-                }
+val administratorLoader = newNamedDataLoader("ADMINISTRATOR_LOADER") { ids ->
+    transaction {
+        AdministratorsRepository.findByIds(ids).map {
+            it?.let {
+                val role = Role.fromDbValue(it.role)
+                Administrator(it.id.value, it.email, it.regionId?.value, role)
             }
         }
     }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/common/database/sortByKeys.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/common/database/sortByKeys.kt
@@ -1,6 +1,14 @@
 package app.ehrenamtskarte.backend.common.database
 
-fun <TValue, TKey> Iterable<TValue>.sortByKeys(keyFetcher: (TValue) -> TKey, keys: Iterable<TKey>): List<TValue?> {
-    val objectsMap = this.associateBy { keyFetcher(it) }
-    return keys.map { key -> objectsMap[key] }.asIterable().toList()
+/***
+ * Extending an iterable of values (this).
+ * Given a list of keys, we return `result`, a list of optional values.
+ * The i-th element in `result` corresponds to the i-th element in `keys`.
+ * If there was no value present with the i-th key, `result[i]` is null.
+ * If there was exactly one value present with the i-th key, this value will be in `result[i]`.
+ * Otherwise, if there are multiple values with the i-th key, then the method will throw.
+ */
+fun <TValue, TKey> Iterable<TValue>.sortByKeys(keySelector: (TValue) -> TKey, keys: Iterable<TKey>): List<TValue?> {
+    val objectsMap = groupBy(keySelector)
+    return keys.map { objectsMap[it]?.single() }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/common/database/sortByKeys.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/common/database/sortByKeys.kt
@@ -9,6 +9,6 @@ package app.ehrenamtskarte.backend.common.database
  * Otherwise, if there are multiple values with the i-th key, then the method will throw.
  */
 fun <TValue, TKey> Iterable<TValue>.sortByKeys(keySelector: (TValue) -> TKey, keys: Iterable<TKey>): List<TValue?> {
-    val objectsMap = groupBy(keySelector)
-    return keys.map { objectsMap[it]?.single() }
+    val valuesByKey = groupBy(keySelector)
+    return keys.map { valuesByKey[it]?.single() }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/common/webservice/GraphQLParams.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/common/webservice/GraphQLParams.kt
@@ -10,15 +10,19 @@ data class GraphQLParams(
     val dataLoaderRegistry: DataLoaderRegistry,
     val queries: List<TopLevelObject>,
     val mutations: List<TopLevelObject> = emptyList(),
-    val subscriptions: List<TopLevelObject> = emptyList()
+    val subscriptions: List<TopLevelObject> = emptyList(),
 ) {
     infix fun stitch(other: GraphQLParams): GraphQLParams {
+        val duplicateDataLoaderNames = dataLoaderRegistry.keys.intersect(other.dataLoaderRegistry.keys)
+        if (duplicateDataLoaderNames.isNotEmpty()) {
+            throw IllegalArgumentException("Duplicate names for data loaders found: $duplicateDataLoaderNames")
+        }
         return GraphQLParams(
             config + other.config,
             dataLoaderRegistry.combine(other.dataLoaderRegistry),
             queries + other.queries,
             mutations + other.mutations,
-            subscriptions + other.subscriptions
+            subscriptions + other.subscriptions,
         )
     }
 }
@@ -30,6 +34,6 @@ infix operator fun SchemaGeneratorConfig.plus(other: SchemaGeneratorConfig): Sch
     val hooks = if (hooks == NoopSchemaGeneratorHooks) other.hooks else hooks
     return SchemaGeneratorConfig(
         this.supportedPackages + other.supportedPackages,
-        hooks = hooks
+        hooks = hooks,
     )
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/common/webservice/NamedDataLoader.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/common/webservice/NamedDataLoader.kt
@@ -1,0 +1,44 @@
+package app.ehrenamtskarte.backend.common.webservice
+
+import graphql.schema.DataFetchingEnvironment
+import kotlinx.coroutines.runBlocking
+import org.dataloader.DataLoader
+import org.dataloader.DataLoaderFactory
+import org.dataloader.DataLoaderOptions
+import org.dataloader.DataLoaderRegistry
+import java.util.concurrent.CompletableFuture
+
+interface NamedDataLoader<K, V> {
+    val name: String
+    val loader: DataLoader<K, V>
+}
+
+fun <K, V> NamedDataLoader<K, V>.fromEnvironment(environment: DataFetchingEnvironment): DataLoader<K, V> {
+    return environment.getDataLoader(name)
+        ?: throw IllegalArgumentException("Registry does not have a DataLoader named $name")
+}
+
+fun <K, V> newNamedDataLoader(name: String, loadBatch: suspend (ids: List<K>) -> List<V>): NamedDataLoader<K, V> {
+    return object : NamedDataLoader<K, V> {
+        override val name = name
+        override val loader = DataLoaderFactory.newDataLoader(
+            { ids ->
+                CompletableFuture.supplyAsync {
+                    runBlocking { loadBatch(ids) }
+                }
+            },
+            DataLoaderOptions.newOptions().setCachingEnabled(false),
+        )
+    }
+}
+
+fun createRegistryFromNamedDataLoaders(vararg loaders: NamedDataLoader<*, *>): DataLoaderRegistry {
+    val registry = DataLoaderRegistry()
+    loaders.forEach {
+        if (it.name in registry.keys) {
+            throw IllegalArgumentException("Duplicate name of data loader specified.")
+        }
+        registry.register(it.name, it.loader)
+    }
+    return registry
+}

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/projects/database/Setup.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/projects/database/Setup.kt
@@ -6,7 +6,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 
 fun setupDatabase(config: BackendConfiguration) {
     SchemaUtils.create(
-        Projects
+        Projects,
     )
 
     transaction {

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/regions/webservice/dataloader/RegionDataLoader.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/regions/webservice/dataloader/RegionDataLoader.kt
@@ -1,24 +1,16 @@
 package app.ehrenamtskarte.backend.regions.webservice.dataloader
 
+import app.ehrenamtskarte.backend.common.webservice.newNamedDataLoader
 import app.ehrenamtskarte.backend.regions.database.repos.RegionsRepository
 import app.ehrenamtskarte.backend.regions.webservice.schema.types.Region
-import kotlinx.coroutines.runBlocking
-import org.dataloader.DataLoader
-import org.dataloader.DataLoaderFactory
 import org.jetbrains.exposed.sql.transactions.transaction
-import java.util.concurrent.CompletableFuture
 
 const val REGION_LOADER_NAME = "REGION_LOADER"
 
-val regionLoader: DataLoader<Int, Region?> = DataLoaderFactory.newDataLoader { ids ->
-    CompletableFuture.supplyAsync {
-        runBlocking {
-            transaction {
-                RegionsRepository.findByIds(ids).map {
-                    if (it == null) null
-                    else Region(it.id.value, it.prefix, it.name, it.regionIdentifier, it.dataPrivacyPolicy)
-                }
-            }
+val regionLoader = newNamedDataLoader("REGION_LOADER") { ids ->
+    transaction {
+        RegionsRepository.findByIds(ids).map {
+            it?.let { Region(it.id.value, it.prefix, it.name, it.regionIdentifier, it.dataPrivacyPolicy) }
         }
     }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/regions/webservice/regionsGraphQLParams.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/regions/webservice/regionsGraphQLParams.kt
@@ -1,27 +1,20 @@
 package app.ehrenamtskarte.backend.regions.webservice
 
 import app.ehrenamtskarte.backend.common.webservice.GraphQLParams
-import app.ehrenamtskarte.backend.regions.webservice.dataloader.REGION_LOADER_NAME
+import app.ehrenamtskarte.backend.common.webservice.createRegistryFromNamedDataLoaders
 import app.ehrenamtskarte.backend.regions.webservice.dataloader.regionLoader
 import app.ehrenamtskarte.backend.regions.webservice.schema.RegionsMutationService
 import app.ehrenamtskarte.backend.regions.webservice.schema.RegionsQueryService
 import com.expediagroup.graphql.generator.SchemaGeneratorConfig
 import com.expediagroup.graphql.generator.TopLevelObject
-import org.dataloader.DataLoaderRegistry
-
-private fun createDataLoaderRegistry(): DataLoaderRegistry {
-    val dataLoaderRegistry = DataLoaderRegistry()
-    dataLoaderRegistry.register(REGION_LOADER_NAME, regionLoader)
-    return dataLoaderRegistry
-}
 
 val regionsGraphQlParams = GraphQLParams(
     config = SchemaGeneratorConfig(supportedPackages = listOf("app.ehrenamtskarte.backend.regions.webservice.schema")),
-    dataLoaderRegistry = createDataLoaderRegistry(),
+    dataLoaderRegistry = createRegistryFromNamedDataLoaders(regionLoader),
     queries = listOf(
-        TopLevelObject(RegionsQueryService())
+        TopLevelObject(RegionsQueryService()),
     ),
     mutations = listOf(
-        TopLevelObject(RegionsMutationService())
-    )
+        TopLevelObject(RegionsMutationService()),
+    ),
 )

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/database/repos/AcceptingStoresRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/database/repos/AcceptingStoresRepository.kt
@@ -23,13 +23,6 @@ import org.postgis.Point
 
 object AcceptingStoresRepository {
 
-    fun findByIdsInProject(project: String, ids: List<Int>): List<AcceptingStoreEntity> {
-        val query = (Projects innerJoin AcceptingStores)
-            .slice(AcceptingStores.columns)
-            .select { Projects.project eq project and (AcceptingStores.id inList ids) }
-        return AcceptingStoreEntity.wrapRows(query).toList()
-    }
-
     // TODO would be great to support combinations like "Tür an Tür Augsburg"
     // TODO Fulltext search is possible with tsvector in postgres: https://www.compose.com/articles/mastering-postgresql-tools-full-text-search-and-phrase-search/
     // TODO Probably not relevant right now
@@ -39,7 +32,7 @@ object AcceptingStoresRepository {
         categoryIds: List<Int>?,
         coordinates: Coordinates?,
         limit: Int,
-        offset: Long
+        offset: Long,
     ): SizedIterable<AcceptingStoreEntity> {
         val categoryMatcher =
             if (categoryIds == null) {
@@ -58,15 +51,15 @@ object AcceptingStoresRepository {
                         AcceptingStores.description ilike "%$searchText%",
                         Addresses.location ilike "%$searchText%",
                         Addresses.postalCode ilike "%$searchText%",
-                        Addresses.street ilike "%$searchText%"
-                    )
+                        Addresses.street ilike "%$searchText%",
+                    ),
                 )
             }
 
         val sortExpression = if (coordinates != null) {
             DistanceFunction(
                 PhysicalStores.coordinates,
-                MakePointFunction(doubleParam(coordinates.lng), doubleParam(coordinates.lat))
+                MakePointFunction(doubleParam(coordinates.lng), doubleParam(coordinates.lat)),
             )
         } else {
             AcceptingStores.name

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/AcceptingStoreDataLoader.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/AcceptingStoreDataLoader.kt
@@ -1,23 +1,15 @@
 package app.ehrenamtskarte.backend.stores.webservice.dataloader
 
+import app.ehrenamtskarte.backend.common.webservice.newNamedDataLoader
 import app.ehrenamtskarte.backend.stores.database.repos.AcceptingStoresRepository
 import app.ehrenamtskarte.backend.stores.webservice.schema.types.AcceptingStore
-import kotlinx.coroutines.runBlocking
-import org.dataloader.DataLoader
-import org.dataloader.DataLoaderFactory
 import org.jetbrains.exposed.sql.transactions.transaction
-import java.util.concurrent.CompletableFuture
 
-const val ACCEPTING_STORE_LOADER_NAME = "ACCEPTING_STORE_LOADER"
-
-val acceptingStoreLoader: DataLoader<Int, AcceptingStore?> = DataLoaderFactory.newDataLoader { ids ->
-    CompletableFuture.supplyAsync {
-        runBlocking {
-            transaction {
-                AcceptingStoresRepository.findByIds(ids).map {
-                    if (it == null) null
-                    else AcceptingStore(it.id.value, it.name, it.description, it.contactId.value, it.categoryId.value)
-                }
+val acceptingStoreLoader = newNamedDataLoader("ACCEPTING_STORE_LOADER") { ids ->
+    transaction {
+        AcceptingStoresRepository.findByIds(ids).map {
+            it?.let {
+                AcceptingStore(it.id.value, it.name, it.description, it.contactId.value, it.categoryId.value)
             }
         }
     }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/AddressDataLoader.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/AddressDataLoader.kt
@@ -1,24 +1,14 @@
 package app.ehrenamtskarte.backend.stores.webservice.dataloader
 
+import app.ehrenamtskarte.backend.common.webservice.newNamedDataLoader
 import app.ehrenamtskarte.backend.stores.database.repos.AddressRepository
 import app.ehrenamtskarte.backend.stores.webservice.schema.types.Address
-import kotlinx.coroutines.runBlocking
-import org.dataloader.DataLoader
-import org.dataloader.DataLoaderFactory
 import org.jetbrains.exposed.sql.transactions.transaction
-import java.util.concurrent.CompletableFuture
 
-const val ADDRESS_LOADER_NAME = "ADDRESS_LOADER"
-
-val addressLoader: DataLoader<Int, Address?> = DataLoaderFactory.newDataLoader { ids ->
-    CompletableFuture.supplyAsync {
-        runBlocking {
-            transaction {
-                AddressRepository.findByIds(ids).map {
-                    if (it == null) null
-                    else Address(it.id.value, it.street, it.postalCode, it.location, it.countryCode)
-                }
-            }
+val addressLoader = newNamedDataLoader("ADDRESS_LOADER") { ids ->
+    transaction {
+        AddressRepository.findByIds(ids).map {
+            it?.let { Address(it.id.value, it.street, it.postalCode, it.location, it.countryCode) }
         }
     }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/CategoryDataLoader.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/CategoryDataLoader.kt
@@ -1,24 +1,14 @@
 package app.ehrenamtskarte.backend.stores.webservice.dataloader
 
+import app.ehrenamtskarte.backend.common.webservice.newNamedDataLoader
 import app.ehrenamtskarte.backend.stores.database.repos.CategoriesRepository
 import app.ehrenamtskarte.backend.stores.webservice.schema.types.Category
-import kotlinx.coroutines.runBlocking
-import org.dataloader.DataLoader
-import org.dataloader.DataLoaderFactory
 import org.jetbrains.exposed.sql.transactions.transaction
-import java.util.concurrent.CompletableFuture
 
-const val CATEGORY_LOADER_NAME = "CATEGORY_LOADER"
-
-val categoryLoader: DataLoader<Int, Category?> = DataLoaderFactory.newDataLoader { ids ->
-    CompletableFuture.supplyAsync {
-        runBlocking {
-            transaction {
-                CategoriesRepository.findByIds(ids).map {
-                    if (it == null) null
-                    else Category(it.id.value, it.name)
-                }
-            }
+val categoryLoader = newNamedDataLoader("CATEGORY_LOADER") { ids ->
+    transaction {
+        CategoriesRepository.findByIds(ids).map {
+            it?.let { Category(it.id.value, it.name) }
         }
     }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/ContactDataLoader.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/ContactDataLoader.kt
@@ -1,23 +1,14 @@
 package app.ehrenamtskarte.backend.stores.webservice.dataloader
 
+import app.ehrenamtskarte.backend.common.webservice.newNamedDataLoader
 import app.ehrenamtskarte.backend.stores.database.repos.ContactsRepository
 import app.ehrenamtskarte.backend.stores.webservice.schema.types.Contact
-import kotlinx.coroutines.runBlocking
-import org.dataloader.DataLoader
 import org.jetbrains.exposed.sql.transactions.transaction
-import java.util.concurrent.CompletableFuture
 
-const val CONTACT_LOADER_NAME = "CONTACT_LOADER"
-
-val contactLoader = DataLoader<Int, Contact?> { ids ->
-    CompletableFuture.supplyAsync {
-        runBlocking {
-            transaction {
-                ContactsRepository.findByIds(ids).map {
-                    if (it == null) null
-                    else Contact(it.id.value, it.email, it.telephone, it.website)
-                }
-            }
+val contactLoader = newNamedDataLoader("CONTACT_LOADER") { ids ->
+    transaction {
+        ContactsRepository.findByIds(ids).map {
+            it?.let { Contact(it.id.value, it.email, it.telephone, it.website) }
         }
     }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/PhysicalStoreByStoreIdLoader.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/PhysicalStoreByStoreIdLoader.kt
@@ -1,33 +1,27 @@
 package app.ehrenamtskarte.backend.stores.webservice.dataloader
 
+import app.ehrenamtskarte.backend.common.database.sortByKeys
+import app.ehrenamtskarte.backend.common.webservice.newNamedDataLoader
 import app.ehrenamtskarte.backend.stores.database.PhysicalStoreEntity
 import app.ehrenamtskarte.backend.stores.database.PhysicalStores
 import app.ehrenamtskarte.backend.stores.webservice.schema.types.Coordinates
 import app.ehrenamtskarte.backend.stores.webservice.schema.types.PhysicalStore
-import kotlinx.coroutines.runBlocking
-import org.dataloader.DataLoader
-import org.dataloader.DataLoaderFactory
+import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
-import java.util.concurrent.CompletableFuture
 
-const val PHYSICAL_STORE_BY_STORE_ID_LOADER_NAME = "PHYSICAL_STORE_BY_STORE_ID_LOADER"
-
-val physicalStoreByStoreIdLoader: DataLoader<Int, PhysicalStore?> = DataLoaderFactory.newDataLoader { ids ->
-    CompletableFuture.supplyAsync {
-        runBlocking {
-            transaction {
-                ids.map { storeId ->
-                    PhysicalStoreEntity.find { PhysicalStores.storeId eq storeId }
-                        .map {
-                            PhysicalStore(
-                                it.id.value,
-                                it.storeId.value,
-                                it.addressId.value,
-                                Coordinates(it.coordinates.x, it.coordinates.y)
-                            )
-                        }
-                        .firstOrNull()
-                }.toList()
+val physicalStoreByStoreIdLoader = newNamedDataLoader<Int, _>("PHYSICAL_STORE_BY_STORE_ID_LOADER") { ids ->
+    transaction {
+        val entities = PhysicalStoreEntity.wrapRows(
+            PhysicalStores.select { PhysicalStores.storeId inList ids },
+        )
+        entities.sortByKeys({ it.storeId }, ids).map {
+            it?.let {
+                PhysicalStore(
+                    it.id.value,
+                    it.storeId.value,
+                    it.addressId.value,
+                    Coordinates(it.coordinates.x, it.coordinates.y),
+                )
             }
         }
     }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/PhysicalStoreByStoreIdLoader.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/PhysicalStoreByStoreIdLoader.kt
@@ -6,23 +6,21 @@ import app.ehrenamtskarte.backend.stores.database.PhysicalStoreEntity
 import app.ehrenamtskarte.backend.stores.database.PhysicalStores
 import app.ehrenamtskarte.backend.stores.webservice.schema.types.Coordinates
 import app.ehrenamtskarte.backend.stores.webservice.schema.types.PhysicalStore
-import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
 
 val physicalStoreByStoreIdLoader = newNamedDataLoader<Int, _>("PHYSICAL_STORE_BY_STORE_ID_LOADER") { ids ->
     transaction {
-        val entities = PhysicalStoreEntity.wrapRows(
-            PhysicalStores.select { PhysicalStores.storeId inList ids },
-        )
-        entities.sortByKeys({ it.storeId }, ids).map {
-            it?.let {
-                PhysicalStore(
-                    it.id.value,
-                    it.storeId.value,
-                    it.addressId.value,
-                    Coordinates(it.coordinates.x, it.coordinates.y),
-                )
+        PhysicalStoreEntity.find { PhysicalStores.storeId inList ids }
+            .sortByKeys({ it.storeId }, ids)
+            .map {
+                it?.let {
+                    PhysicalStore(
+                        it.id.value,
+                        it.storeId.value,
+                        it.addressId.value,
+                        Coordinates(it.coordinates.x, it.coordinates.y),
+                    )
+                }
             }
-        }
     }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/PhysicalStoreDataLoader.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/PhysicalStoreDataLoader.kt
@@ -1,29 +1,21 @@
 package app.ehrenamtskarte.backend.stores.webservice.dataloader
 
+import app.ehrenamtskarte.backend.common.webservice.newNamedDataLoader
 import app.ehrenamtskarte.backend.stores.database.repos.PhysicalStoresRepository
 import app.ehrenamtskarte.backend.stores.webservice.schema.types.Coordinates
 import app.ehrenamtskarte.backend.stores.webservice.schema.types.PhysicalStore
-import kotlinx.coroutines.runBlocking
-import org.dataloader.DataLoader
-import org.dataloader.DataLoaderFactory
 import org.jetbrains.exposed.sql.transactions.transaction
-import java.util.concurrent.CompletableFuture
 
-const val PHYSICAL_STORE_LOADER_NAME = "PHYSICAL_STORE_LOADER"
-
-val physicalStoreLoader: DataLoader<Int, PhysicalStore?> = DataLoaderFactory.newDataLoader { ids ->
-    CompletableFuture.supplyAsync {
-        runBlocking {
-            transaction {
-                PhysicalStoresRepository.findByIds(ids).map {
-                    if (it == null) null
-                    else PhysicalStore(
-                        it.id.value,
-                        it.storeId.value,
-                        it.addressId.value,
-                        Coordinates(it.coordinates.x, it.coordinates.y)
-                    )
-                }
+val physicalStoreLoader = newNamedDataLoader("PHYSICAL_STORE_LOADER") { ids ->
+    transaction {
+        PhysicalStoresRepository.findByIds(ids).map {
+            it?.let {
+                PhysicalStore(
+                    it.id.value,
+                    it.storeId.value,
+                    it.addressId.value,
+                    Coordinates(it.coordinates.x, it.coordinates.y),
+                )
             }
         }
     }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/schema/types/AcceptingStore.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/schema/types/AcceptingStore.kt
@@ -1,25 +1,27 @@
 package app.ehrenamtskarte.backend.stores.webservice.schema.types
 
-import app.ehrenamtskarte.backend.stores.webservice.dataloader.CATEGORY_LOADER_NAME
-import app.ehrenamtskarte.backend.stores.webservice.dataloader.CONTACT_LOADER_NAME
-import app.ehrenamtskarte.backend.stores.webservice.dataloader.PHYSICAL_STORE_BY_STORE_ID_LOADER_NAME
+import app.ehrenamtskarte.backend.common.webservice.fromEnvironment
+import app.ehrenamtskarte.backend.stores.webservice.dataloader.categoryLoader
+import app.ehrenamtskarte.backend.stores.webservice.dataloader.contactLoader
+import app.ehrenamtskarte.backend.stores.webservice.dataloader.physicalStoreByStoreIdLoader
 import graphql.schema.DataFetchingEnvironment
 import java.util.concurrent.CompletableFuture
 
+@Suppress("unused")
 data class AcceptingStore(
     val id: Int,
     val name: String?,
     val description: String?,
     val contactId: Int,
-    val categoryId: Int
+    val categoryId: Int,
 ) {
 
-    fun contact(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<Contact> =
-        dataFetchingEnvironment.getDataLoader<Int, Contact>(CONTACT_LOADER_NAME).load(contactId)
+    fun contact(environment: DataFetchingEnvironment): CompletableFuture<Contact> =
+        contactLoader.fromEnvironment(environment).load(contactId).thenApply { it!! }
 
-    fun category(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<Category> =
-        dataFetchingEnvironment.getDataLoader<Int, Category>(CATEGORY_LOADER_NAME).load(categoryId)
+    fun category(environment: DataFetchingEnvironment): CompletableFuture<Category> =
+        categoryLoader.fromEnvironment(environment).load(categoryId).thenApply { it!! }
 
-    fun physicalStore(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<PhysicalStore?> =
-        dataFetchingEnvironment.getDataLoader<Int, PhysicalStore?>(PHYSICAL_STORE_BY_STORE_ID_LOADER_NAME).load(id)
+    fun physicalStore(environment: DataFetchingEnvironment): CompletableFuture<PhysicalStore?> =
+        physicalStoreByStoreIdLoader.fromEnvironment(environment).load(id)
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/schema/types/PhysicalStore.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/schema/types/PhysicalStore.kt
@@ -1,7 +1,8 @@
 package app.ehrenamtskarte.backend.stores.webservice.schema.types
 
-import app.ehrenamtskarte.backend.stores.webservice.dataloader.ACCEPTING_STORE_LOADER_NAME
-import app.ehrenamtskarte.backend.stores.webservice.dataloader.ADDRESS_LOADER_NAME
+import app.ehrenamtskarte.backend.common.webservice.fromEnvironment
+import app.ehrenamtskarte.backend.stores.webservice.dataloader.acceptingStoreLoader
+import app.ehrenamtskarte.backend.stores.webservice.dataloader.addressLoader
 import graphql.schema.DataFetchingEnvironment
 import java.util.concurrent.CompletableFuture
 
@@ -9,13 +10,13 @@ data class PhysicalStore(
     val id: Int,
     val storeId: Int,
     val addressId: Int,
-    val coordinates: Coordinates
+    val coordinates: Coordinates,
 ) {
 
-    fun store(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<AcceptingStore> =
-        dataFetchingEnvironment.getDataLoader<Int, AcceptingStore?>(ACCEPTING_STORE_LOADER_NAME).load(storeId)
+    fun store(environment: DataFetchingEnvironment): CompletableFuture<AcceptingStore> =
+        acceptingStoreLoader.fromEnvironment(environment).load(storeId)
             .thenApply { it!! }
 
-    fun address(dataFetchingEnvironment: DataFetchingEnvironment): CompletableFuture<Address> =
-        dataFetchingEnvironment.getDataLoader<Int, Address?>(ADDRESS_LOADER_NAME).load(addressId).thenApply { it!! }
+    fun address(environment: DataFetchingEnvironment): CompletableFuture<Address> =
+        addressLoader.fromEnvironment(environment).load(addressId).thenApply { it!! }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/schema/types/PhysicalStore.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/schema/types/PhysicalStore.kt
@@ -14,8 +14,7 @@ data class PhysicalStore(
 ) {
 
     fun store(environment: DataFetchingEnvironment): CompletableFuture<AcceptingStore> =
-        acceptingStoreLoader.fromEnvironment(environment).load(storeId)
-            .thenApply { it!! }
+        acceptingStoreLoader.fromEnvironment(environment).load(storeId).thenApply { it!! }
 
     fun address(environment: DataFetchingEnvironment): CompletableFuture<Address> =
         addressLoader.fromEnvironment(environment).load(addressId).thenApply { it!! }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/storesGraphQLParams.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/storesGraphQLParams.kt
@@ -1,12 +1,7 @@
 package app.ehrenamtskarte.backend.stores.webservice
 
 import app.ehrenamtskarte.backend.common.webservice.GraphQLParams
-import app.ehrenamtskarte.backend.stores.webservice.dataloader.ACCEPTING_STORE_LOADER_NAME
-import app.ehrenamtskarte.backend.stores.webservice.dataloader.ADDRESS_LOADER_NAME
-import app.ehrenamtskarte.backend.stores.webservice.dataloader.CATEGORY_LOADER_NAME
-import app.ehrenamtskarte.backend.stores.webservice.dataloader.CONTACT_LOADER_NAME
-import app.ehrenamtskarte.backend.stores.webservice.dataloader.PHYSICAL_STORE_BY_STORE_ID_LOADER_NAME
-import app.ehrenamtskarte.backend.stores.webservice.dataloader.PHYSICAL_STORE_LOADER_NAME
+import app.ehrenamtskarte.backend.common.webservice.createRegistryFromNamedDataLoaders
 import app.ehrenamtskarte.backend.stores.webservice.dataloader.acceptingStoreLoader
 import app.ehrenamtskarte.backend.stores.webservice.dataloader.addressLoader
 import app.ehrenamtskarte.backend.stores.webservice.dataloader.categoryLoader
@@ -17,24 +12,19 @@ import app.ehrenamtskarte.backend.stores.webservice.schema.AcceptingStoreQuerySe
 import app.ehrenamtskarte.backend.stores.webservice.schema.CategoriesQueryService
 import com.expediagroup.graphql.generator.SchemaGeneratorConfig
 import com.expediagroup.graphql.generator.TopLevelObject
-import org.dataloader.DataLoaderRegistry
-
-private fun createDataLoaderRegistry(): DataLoaderRegistry {
-    val dataLoaderRegistry = DataLoaderRegistry()
-    dataLoaderRegistry.register(CONTACT_LOADER_NAME, contactLoader)
-    dataLoaderRegistry.register(CATEGORY_LOADER_NAME, categoryLoader)
-    dataLoaderRegistry.register(ACCEPTING_STORE_LOADER_NAME, acceptingStoreLoader)
-    dataLoaderRegistry.register(PHYSICAL_STORE_LOADER_NAME, physicalStoreLoader)
-    dataLoaderRegistry.register(PHYSICAL_STORE_BY_STORE_ID_LOADER_NAME, physicalStoreByStoreIdLoader)
-    dataLoaderRegistry.register(ADDRESS_LOADER_NAME, addressLoader)
-    return dataLoaderRegistry
-}
 
 val storesGraphQlParams = GraphQLParams(
     config = SchemaGeneratorConfig(supportedPackages = listOf("app.ehrenamtskarte.backend.stores.webservice.schema")),
-    dataLoaderRegistry = createDataLoaderRegistry(),
+    dataLoaderRegistry = createRegistryFromNamedDataLoaders(
+        contactLoader,
+        acceptingStoreLoader,
+        categoryLoader,
+        physicalStoreLoader,
+        physicalStoreByStoreIdLoader,
+        addressLoader,
+    ),
     queries = listOf(
         TopLevelObject(AcceptingStoreQueryService()),
-        TopLevelObject(CategoriesQueryService())
-    )
+        TopLevelObject(CategoriesQueryService()),
+    ),
 )

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/webservice/verificationGraphQLParams.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/webservice/verificationGraphQLParams.kt
@@ -1,25 +1,19 @@
 package app.ehrenamtskarte.backend.verification.webservice
 
 import app.ehrenamtskarte.backend.common.webservice.GraphQLParams
+import app.ehrenamtskarte.backend.common.webservice.createRegistryFromNamedDataLoaders
 import app.ehrenamtskarte.backend.verification.webservice.schema.CardMutationService
 import app.ehrenamtskarte.backend.verification.webservice.schema.CardQueryService
 import com.expediagroup.graphql.generator.SchemaGeneratorConfig
 import com.expediagroup.graphql.generator.TopLevelObject
-import org.dataloader.DataLoaderRegistry
-
-private fun createDataLoaderRegistry(): DataLoaderRegistry {
-    val dataLoaderRegistry = DataLoaderRegistry()
-    // Maybe integrate a dataloader for cards here.
-    return dataLoaderRegistry
-}
 
 val verificationGraphQlParams = GraphQLParams(
     config = SchemaGeneratorConfig(supportedPackages = listOf("app.ehrenamtskarte.backend.verification.webservice.schema")),
-    dataLoaderRegistry = createDataLoaderRegistry(),
+    dataLoaderRegistry = createRegistryFromNamedDataLoaders(),
     queries = listOf(
-        TopLevelObject(CardQueryService())
+        TopLevelObject(CardQueryService()),
     ),
     mutations = listOf(
-        TopLevelObject(CardMutationService())
-    )
+        TopLevelObject(CardMutationService()),
+    ),
 )


### PR DESCRIPTION
Closes #851. Refactoring of the data loaders:
* Disable caching on all data loaders
* Make registering and naming of data loaders less boilerplaty and less error-prone
* Avoid name conflicts of data loaders
* Make them more type safe

Also, I rewrote the data loader for physicalStoreByStoreIdLoader which makes the `searchAcceptingStores` GraphQL query  a lot faster: Instead of ~20 single SQL queries (one for each store) we now make a single SQL query.