### PR TITLE
add-postgis-extension

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/V0001_Baseline.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/V0001_Baseline.kt
@@ -8,6 +8,7 @@ internal class V0001_Baseline() : Migration() {
     override val migrate: Statement = {
         exec(
             """
+            CREATE EXTENSION postgis;
             CREATE FUNCTION physical_stores(z integer, x integer, y integer, query_params json) RETURNS bytea
                 LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
             AS ${'$'}${'$'}


### PR DESCRIPTION
I'm not sure if this the right place but if i drop all tables and try to run the baseline migration i get the following error mentioned here:
https://stackoverflow.com/questions/6850500/postgis-installation-type-geometry-does-not-exist
