### PR TITLE
Release-3.1.0-fixes

### DIFF
--- a/docs/production-setup.md
+++ b/docs/production-setup.md
@@ -54,7 +54,7 @@ For Nürnberg replace:
 2. Select the correct build version
 
 ```bash
-fvm flutter pub run build_runner build —define “df_build_config=name=bayern”
+fvm flutter pub run build_runner build --define df_build_config=name=bayern
 ```
 
 3. Create bundles

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -15,8 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-# Next build version is 109 due to some ios targeting issues.
-version: 3.1.0+107
+version: 3.1.0+109
 
 environment:
   sdk: 3.0.2


### PR DESCRIPTION
Updated bash command for build config in docs since a minus was missing and quotes are not needed. This resulted for me to a fallback to bayern. Had to add a new build to android for sozialpass so i also updated latest build version