### PR TITLE
1014: Limit fullname length

### DIFF
--- a/administration/src/cards/CardBlueprint.ts
+++ b/administration/src/cards/CardBlueprint.ts
@@ -9,7 +9,7 @@ import RegionExtension from './extensions/RegionExtension'
 import { Extension, ExtensionInstance, JSONExtension } from './extensions/extensions'
 import { PEPPER_LENGTH } from './hashCardInfo'
 
-const MAX_NAME_LENGTH = 50
+const MAX_NAME_LENGTH = 30
 const ACTIVATION_SECRET_LENGTH = 20
 
 export interface JSONCardBlueprint<E = ExtensionInstance> {
@@ -54,7 +54,7 @@ export class CardBlueprint {
 
   isFullNameValid(): boolean {
     const encodedName = new TextEncoder().encode(this.fullName)
-    return this.fullName.length > 0 && encodedName.length < MAX_NAME_LENGTH
+    return this.fullName.length > 0 && encodedName.length <= MAX_NAME_LENGTH
   }
 
   isExpirationDateValid(): boolean {

--- a/frontend/lib/identification/id_card/card_content.dart
+++ b/frontend/lib/identification/id_card/card_content.dart
@@ -166,11 +166,11 @@ class CardContent extends StatelessWidget {
                             FittedBox(
                               fit: BoxFit.scaleDown,
                               alignment: Alignment.topLeft,
-                              child:Text(
-                              cardInfo.fullName,
-                              style: TextStyle(fontSize: 14 * scaleFactor, color: textColor),
-                              textAlign: TextAlign.start,
-                            ),
+                              child: Text(
+                                cardInfo.fullName,
+                                style: TextStyle(fontSize: 14 * scaleFactor, color: textColor),
+                                textAlign: TextAlign.start,
+                              ),
                             ),
                             if (formattedBirthday != null)
                               Text(

--- a/frontend/lib/identification/id_card/card_content.dart
+++ b/frontend/lib/identification/id_card/card_content.dart
@@ -163,10 +163,14 @@ class CardContent extends StatelessWidget {
                           crossAxisAlignment: CrossAxisAlignment.stretch,
                           mainAxisAlignment: MainAxisAlignment.end,
                           children: [
-                            Text(
+                            FittedBox(
+                              fit: BoxFit.scaleDown,
+                              alignment: Alignment.topLeft,
+                              child:Text(
                               cardInfo.fullName,
                               style: TextStyle(fontSize: 14 * scaleFactor, color: textColor),
                               textAlign: TextAlign.start,
+                            ),
                             ),
                             if (formattedBirthday != null)
                               Text(


### PR DESCRIPTION
resolves #1014 

-limit is 30 to also ensure that names with wide chars can be displayed on the digital card and printed card in a single row
-added fitbox widget to ensure rendering of the fullname content