### PR TITLE
Fix CI: Migrate constructor syntax due to protoc_plugin 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ commands:
       - run:
           name: Install Dart
           command: |
-            curl -o dart.deb https://storage.googleapis.com/dart-archive/channels/stable/release/2.18.5/linux_packages/dart_2.18.5-1_amd64.deb
+            curl -o dart.deb https://storage.googleapis.com/dart-archive/channels/stable/release/3.0.5/linux_packages/dart_3.0.5-1_amd64.deb
             sudo dpkg -i dart.deb
   install-dart-mac:
     steps:
@@ -531,16 +531,16 @@ jobs:
     docker:
       - image: cimg/base:2022.09
     parameters:
-        server:
-            enum:
-              - entitlementcard.tuerantuer.org
-              - entitlementcard-test.tuerantuer.org
-            type: enum
-        ssh-host-fingerprint:
-            enum:
-                - '|1|dkYQrdGB1QML0o+POL3QzAkBbek=|b4Tm0Ymh82UKyZPJfVKy4t+MFV8= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIONuARu18Fktz+j4QosI+nRqgMnFOMgE7OZLuTOwgZ0k'
-                - '|1|iikuvSrIo3wkj+EqUgLRMsAq6yk=|r9bSjkawWFa94b45qE/se5Oio5k= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIED3MwobbCs+ENMLXdyqlJb3bJ26TuIYt977TA3NrN66'
-            type: enum
+      server:
+        enum:
+          - entitlementcard.tuerantuer.org
+          - entitlementcard-test.tuerantuer.org
+        type: enum
+      ssh-host-fingerprint:
+        enum:
+          - '|1|dkYQrdGB1QML0o+POL3QzAkBbek=|b4Tm0Ymh82UKyZPJfVKy4t+MFV8= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIONuARu18Fktz+j4QosI+nRqgMnFOMgE7OZLuTOwgZ0k'
+          - '|1|iikuvSrIo3wkj+EqUgLRMsAq6yk=|r9bSjkawWFa94b45qE/se5Oio5k= ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIED3MwobbCs+ENMLXdyqlJb3bJ26TuIYt977TA3NrN66'
+        type: enum
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/frontend/lib/about/dev_settings_view.dart
+++ b/frontend/lib/about/dev_settings_view.dart
@@ -23,40 +23,26 @@ import 'package:provider/provider.dart';
 
 // this data includes a Base32 encoded random key created with openssl
 // for testing, so this is intended
-final sampleActivationCodeBavaria = DynamicUserCode(
-  info: CardInfo(
-    fullName: "Erika Mustermann",
-    expirationDay: 19746,
-    extensions: CardExtensions(
-      extensionBavariaCardType: BavariaCardTypeExtension(
-        cardType: BavariaCardType.STANDARD,
-      ),
-      extensionRegion: RegionExtension(regionId: 42),
-    ),
-  ),
-  pepper: const Base64Decoder().convert("aGVsbG8gdGhpcyBpcyBhIHRlc3Q="),
-  totpSecret: base32.decode("MZLBSF6VHD56ROVG55J6OKJCZIPVDPCX"),
-);
+final sampleActivationCodeBavaria = DynamicUserCode()
+  ..info = (CardInfo()
+    ..fullName = "Erika Mustermann"
+    ..expirationDay = 19746
+    ..extensions = (CardExtensions()
+      ..extensionBavariaCardType = (BavariaCardTypeExtension()..cardType = BavariaCardType.STANDARD)
+      ..extensionRegion = (RegionExtension()..regionId = 42)))
+  ..pepper = const Base64Decoder().convert("aGVsbG8gdGhpcyBpcyBhIHRlc3Q=")
+  ..totpSecret = base32.decode("MZLBSF6VHD56ROVG55J6OKJCZIPVDPCX");
 
-final sampleActivationCodeNuernberg = DynamicUserCode(
-  info: CardInfo(
-    fullName: "Erika Mustermann",
-    expirationDay: 19746,
-    extensions: CardExtensions(
-      extensionBirthday: BirthdayExtension(
-        birthday: 19746,
-      ),
-      extensionNuernbergPassNumber: NuernbergPassNumberExtension(
-        passNumber: 12323123,
-      ),
-      extensionRegion: RegionExtension(
-        regionId: 93,
-      ),
-    ),
-  ),
-  pepper: const Base64Decoder().convert("aGVsbG8gdGhpcyBpcyBhIHRlc3Q="),
-  totpSecret: base32.decode("MZLBSF6VHD56ROVG55J6OKJCZIPVDPCX"),
-);
+final sampleActivationCodeNuernberg = DynamicUserCode()
+  ..info = (CardInfo()
+    ..fullName = "Erika Mustermann"
+    ..expirationDay = 19746
+    ..extensions = (CardExtensions()
+      ..extensionBirthday = (BirthdayExtension()..birthday = 19746)
+      ..extensionNuernbergPassNumber = (NuernbergPassNumberExtension()..passNumber = 12323123)
+      ..extensionRegion = (RegionExtension()..regionId = 93)))
+  ..pepper = const Base64Decoder().convert("aGVsbG8gdGhpcyBpcyBhIHRlc3Q=")
+  ..totpSecret = base32.decode("MZLBSF6VHD56ROVG55J6OKJCZIPVDPCX");
 
 class DevSettingsView extends StatelessWidget {
   const DevSettingsView({super.key});
@@ -195,11 +181,10 @@ class DevSettingsView extends StatelessWidget {
             throw const ActivationInvalidTotpSecretException();
           }
           final totpSecret = const Base64Decoder().convert(activationResult.totpSecret!);
-          final userCode = DynamicUserCode(
-            info: activationCode.info,
-            pepper: activationCode.pepper,
-            totpSecret: totpSecret,
-          );
+          final userCode = DynamicUserCode()
+            ..info = activationCode.info
+            ..pepper = activationCode.pepper
+            ..totpSecret = totpSecret;
           provider.setCode(userCode);
           break;
         case ActivationState.failed:
@@ -240,19 +225,19 @@ class DevSettingsView extends StatelessWidget {
     );
   }
 
-  // This is used to check the invalidation of a card because the verification with the backend couldn't be done lately (1 week plus UTC tolerance)
+// This is used to check the invalidation of a card because the verification with the backend couldn't be done lately (1 week plus UTC tolerance)
   void _setExpiredLastVerification(BuildContext context) {
     final provider = Provider.of<UserCodeModel>(context, listen: false);
     final DynamicUserCode userCode = provider.userCode!;
-    final CardVerification cardVerification = CardVerification(
-        verificationTimeStamp:
-            secondsSinceEpoch(DateTime.now().toUtc().subtract(Duration(seconds: cardValidationExpireSeconds + 3600))),
-        cardValid: true);
-    provider.setCode(DynamicUserCode(
-        info: userCode.info,
-        ecSignature: userCode.ecSignature,
-        pepper: userCode.pepper,
-        totpSecret: userCode.totpSecret,
-        cardVerification: cardVerification));
+    final CardVerification cardVerification = CardVerification()
+      ..verificationTimeStamp =
+          secondsSinceEpoch(DateTime.now().toUtc().subtract(Duration(seconds: cardValidationExpireSeconds + 3600)))
+      ..cardValid = true;
+    provider.setCode(DynamicUserCode()
+      ..info = userCode.info
+      ..ecSignature = userCode.ecSignature
+      ..pepper = userCode.pepper
+      ..totpSecret = userCode.totpSecret
+      ..cardVerification = cardVerification);
   }
 }

--- a/frontend/lib/identification/activation_workflow/activation_code_scanner_page.dart
+++ b/frontend/lib/identification/activation_workflow/activation_code_scanner_page.dart
@@ -101,13 +101,13 @@ class ActivationCodeScannerPage extends StatelessWidget {
         }
         final totpSecret = const Base64Decoder().convert(activationResult.totpSecret!);
 
-        provider.setCode(DynamicUserCode(
-            info: activationCode.info,
-            pepper: activationCode.pepper,
-            totpSecret: totpSecret,
-            cardVerification: CardVerification(
-                cardValid: true,
-                verificationTimeStamp: secondsSinceEpoch(DateTime.parse(activationResult.activationTimeStamp)))));
+        provider.setCode(DynamicUserCode()
+          ..info = activationCode.info
+          ..pepper = activationCode.pepper
+          ..totpSecret = totpSecret
+          ..cardVerification = (CardVerification()
+            ..cardValid = true
+            ..verificationTimeStamp = secondsSinceEpoch(DateTime.parse(activationResult.activationTimeStamp))));
         break;
       case ActivationState.failed:
         await QrParsingErrorDialog.showErrorDialog(

--- a/frontend/lib/identification/card_detail_view/verification_code_view.dart
+++ b/frontend/lib/identification/card_detail_view/verification_code_view.dart
@@ -115,22 +115,21 @@ class VerificationCodeViewState extends State<VerificationCodeView> {
     }
     final projectId = Configuration.of(context).projectId;
     final client = GraphQLProvider.of(context).value;
-    final DynamicVerificationCode qrCode = DynamicVerificationCode(
-      info: userCode.info,
-      pepper: userCode.pepper,
-      otp: otpCode.code,
-    );
+    final DynamicVerificationCode qrCode = DynamicVerificationCode()
+      ..info = userCode.info
+      ..pepper = userCode.pepper
+      ..otp = otpCode.code;
 
     final cardVerification = await queryDynamicServerVerification(client, projectId, qrCode);
     final provider = Provider.of<UserCodeModel>(context, listen: false);
 
-    provider.setCode(DynamicUserCode(
-        info: userCode.info,
-        ecSignature: userCode.ecSignature,
-        pepper: userCode.pepper,
-        totpSecret: userCode.totpSecret,
-        cardVerification: CardVerification(
-            cardValid: cardVerification.valid,
-            verificationTimeStamp: secondsSinceEpoch(DateTime.parse(cardVerification.verificationTimeStamp)))));
+    provider.setCode(DynamicUserCode()
+      ..info = userCode.info
+      ..ecSignature = userCode.ecSignature
+      ..pepper = userCode.pepper
+      ..totpSecret = userCode.totpSecret
+      ..cardVerification = (CardVerification()
+        ..cardValid = cardVerification.valid
+        ..verificationTimeStamp = secondsSinceEpoch(DateTime.parse(cardVerification.verificationTimeStamp))));
   }
 }

--- a/frontend/lib/identification/qr_content_parser.dart
+++ b/frontend/lib/identification/qr_content_parser.dart
@@ -37,11 +37,10 @@ Uint8List createDynamicVerificationQrCodeData(
   DynamicUserCode userCode,
   int otpCode,
 ) {
-  return QrCode(
-    dynamicVerificationCode: DynamicVerificationCode(
-      info: userCode.info,
-      pepper: userCode.pepper,
-      otp: otpCode,
-    ),
-  ).writeToBuffer();
+  return (QrCode()
+        ..dynamicVerificationCode = (DynamicVerificationCode()
+          ..info = userCode.info
+          ..pepper = userCode.pepper
+          ..otp = otpCode))
+      .writeToBuffer();
 }

--- a/frontend/lib/identification/verification_workflow/verification_qr_scanner_page.dart
+++ b/frontend/lib/identification/verification_workflow/verification_qr_scanner_page.dart
@@ -53,13 +53,11 @@ class VerificationQrScannerPage extends StatelessWidget {
               final provider = Provider.of<UserCodeModel>(context, listen: false);
               final userCode = provider.userCode!;
               final otp = OTPGenerator(userCode.totpSecret).generateOTP().code;
-              final verificationQrCode = QrCode(
-                dynamicVerificationCode: DynamicVerificationCode(
-                  info: userCode.info,
-                  pepper: userCode.pepper,
-                  otp: otp,
-                ),
-              );
+              final verificationQrCode = QrCode()
+                ..dynamicVerificationCode = (DynamicVerificationCode()
+                  ..info = userCode.info
+                  ..pepper = userCode.pepper
+                  ..otp = otp);
               final verificationCode = verificationQrCode.writeToBuffer();
               _handleQrCode(context, verificationCode);
             },

--- a/frontend/test/canonical_json_test.dart
+++ b/frontend/test/canonical_json_test.dart
@@ -13,18 +13,12 @@ void main() {
     });
 
     test("should map a cardInfo for a Bavarian Blue EAK correctly", () {
-      final cardInfo = CardInfo(
-        fullName: 'Max Mustermann',
-        expirationDay: 365 * 40, // Equals 14.600
-        extensions: CardExtensions(
-          extensionRegion: RegionExtension(
-            regionId: 16,
-          ),
-          extensionBavariaCardType: BavariaCardTypeExtension(
-            cardType: BavariaCardType.STANDARD,
-          ),
-        ),
-      );
+      final cardInfo = CardInfo()
+        ..fullName = 'Max Mustermann'
+        ..expirationDay = 365 * 40 // Equals 14.600
+        ..extensions = (CardExtensions()
+          ..extensionRegion = (RegionExtension()..regionId = 16)
+          ..extensionBavariaCardType = (BavariaCardTypeExtension()..cardType = BavariaCardType.STANDARD));
       expect(cardInfo.toCanonicalJsonObject(), {
         '1': 'Max Mustermann',
         '2': '14600',
@@ -36,17 +30,11 @@ void main() {
     });
 
     test("should map a cardInfo for a Bavarian Golden EAK correctly", () {
-      final cardInfo = CardInfo(
-        fullName: 'Max Mustermann',
-        extensions: CardExtensions(
-          extensionRegion: RegionExtension(
-            regionId: 16,
-          ),
-          extensionBavariaCardType: BavariaCardTypeExtension(
-            cardType: BavariaCardType.GOLD,
-          ),
-        ),
-      );
+      final cardInfo = CardInfo()
+        ..fullName = 'Max Mustermann'
+        ..extensions = (CardExtensions()
+          ..extensionRegion = (RegionExtension()..regionId = 16)
+          ..extensionBavariaCardType = (BavariaCardTypeExtension()..cardType = BavariaCardType.GOLD));
       expect(cardInfo.toCanonicalJsonObject(), {
         '1': 'Max Mustermann',
         '3': {
@@ -57,21 +45,13 @@ void main() {
     });
 
     test("should map a cardInfo for a Nuernberg Pass correctly", () {
-      final cardInfo = CardInfo(
-        fullName: 'Max Mustermann',
-        expirationDay: 365 * 40, // Equals 14.600
-        extensions: CardExtensions(
-          extensionRegion: RegionExtension(
-            regionId: 93,
-          ),
-          extensionBirthday: BirthdayExtension(
-            birthday: -365 * 10,
-          ),
-          extensionNuernbergPassNumber: NuernbergPassNumberExtension(
-            passNumber: 99999999,
-          ),
-        ),
-      );
+      final cardInfo = CardInfo()
+        ..fullName = 'Max Mustermann'
+        ..expirationDay = 365 * 40 // Equals 14.600
+        ..extensions = (CardExtensions()
+          ..extensionRegion = (RegionExtension()..regionId = 93)
+          ..extensionBirthday = (BirthdayExtension()..birthday = -365 * 10)
+          ..extensionNuernbergPassNumber = (NuernbergPassNumberExtension()..passNumber = 99999999));
       expect(cardInfo.toCanonicalJsonObject(), {
         '1': 'Max Mustermann',
         '2': '14600',

--- a/frontend/test/card_info_util_test.dart
+++ b/frontend/test/card_info_util_test.dart
@@ -9,55 +9,35 @@ void main() {
     // Equivalent tests exist in administration to ensure that the algorithms produce the same hashes.
 
     test("should be stable for a Bavarian Blue EAK", () {
-      final cardInfo = CardInfo(
-        fullName: 'Max Mustermann',
-        expirationDay: 365 * 40, // Equals 14.600
-        extensions: CardExtensions(
-          extensionRegion: RegionExtension(
-            regionId: 16,
-          ),
-          extensionBavariaCardType: BavariaCardTypeExtension(
-            cardType: BavariaCardType.STANDARD,
-          ),
-        ),
-      );
+      final cardInfo = CardInfo()
+        ..fullName = 'Max Mustermann'
+        ..expirationDay = 365 * 40 // Equals 14.600
+        ..extensions = (CardExtensions()
+          ..extensionRegion = (RegionExtension()..regionId = 16)
+          ..extensionBavariaCardType = (BavariaCardTypeExtension()..cardType = BavariaCardType.STANDARD));
       final pepper = const Base64Decoder().convert("MvMjEqa0ulFDAgACElMjWA==");
       expect(cardInfo.hash(pepper), 'rS8nukf7S9j8V1j+PZEkBQWlAeM2WUKkmxBHi1k9hRo=');
     });
 
     test("should be stable for a Bavarian Golden EAK", () {
-      final cardInfo = CardInfo(
-        fullName: 'Max Mustermann',
-        expirationDay: 365 * 40, // Equals 14.600
-        extensions: CardExtensions(
-          extensionRegion: RegionExtension(
-            regionId: 16,
-          ),
-          extensionBavariaCardType: BavariaCardTypeExtension(
-            cardType: BavariaCardType.STANDARD,
-          ),
-        ),
-      );
+      final cardInfo = CardInfo()
+        ..fullName = 'Max Mustermann'
+        ..expirationDay = 365 * 40 // Equals 14.600
+        ..extensions = (CardExtensions()
+          ..extensionRegion = (RegionExtension()..regionId = 16)
+          ..extensionBavariaCardType = (BavariaCardTypeExtension()..cardType = BavariaCardType.STANDARD));
       final pepper = const Base64Decoder().convert("MvMjEqa0ulFDAgACElMjWA==");
       expect(cardInfo.hash(pepper), 'rS8nukf7S9j8V1j+PZEkBQWlAeM2WUKkmxBHi1k9hRo=');
     });
 
     test("should be stable for a Nuernberg Pass", () {
-      final cardInfo = CardInfo(
-        fullName: 'Max Mustermann',
-        expirationDay: 365 * 40, // Equals 14.600
-        extensions: CardExtensions(
-          extensionRegion: RegionExtension(
-            regionId: 93,
-          ),
-          extensionBirthday: BirthdayExtension(
-            birthday: -365 * 10,
-          ),
-          extensionNuernbergPassNumber: NuernbergPassNumberExtension(
-            passNumber: 99999999,
-          ),
-        ),
-      );
+      final cardInfo = CardInfo()
+        ..fullName = 'Max Mustermann'
+        ..expirationDay = 365 * 40 // Equals 14.600
+        ..extensions = (CardExtensions()
+          ..extensionRegion = (RegionExtension()..regionId = 93)
+          ..extensionBirthday = (BirthdayExtension()..birthday = -365 * 10)
+          ..extensionNuernbergPassNumber = (NuernbergPassNumberExtension()..passNumber = 99999999));
       final pepper = const Base64Decoder().convert("MvMjEqa0ulFDAgACElMjWA==");
       expect(cardInfo.hash(pepper), 'zogEJOhnSSp//8qhym/DdorQYgL/763Kfq4slWduxMg=');
     });


### PR DESCRIPTION
The CI broke due to an update of protoc_plugin.
Please also run `dart pub global activate protoc_plugin` locally and verify if version 21 is installed (You might have to upgrade your global flutter/dart installation).

See https://pub.dev/packages/protoc_plugin/changelog#2102 for the relevant changes of protoc_plugin.