### PR TITLE
Harden queryServerVerification

### DIFF
--- a/frontend/lib/identification/verification_workflow/query_server_verification.dart
+++ b/frontend/lib/identification/verification_workflow/query_server_verification.dart
@@ -59,13 +59,13 @@ Future<CardVerificationByHash$Query$CardVerificationResultModel> _queryServerVer
   try {
     final queryResult = await client.query(queryOptions);
     final exception = queryResult.exception;
-    if (exception != null && queryResult.hasException) {
+    if (exception != null) {
       throw exception;
     }
     final data = queryResult.data;
 
     if (data == null) {
-      return CardVerificationByHash$Query$CardVerificationResultModel();
+      throw ServerVerificationException("Returned data is null.");
     }
 
     final parsedResult = byCardDetailsHash.parse(data);


### PR DESCRIPTION
Apply some hardening to `queryServerVerification`.
I believe, this PR does *not* fix the recent problems with card activations, where cards could successfully be activated, but were then shown as invalid.

Related:
#1049, #1065, #1056