### PR TITLE
Show error if activation with override fails

### DIFF
--- a/frontend/lib/identification/activation_workflow/activate_code.dart
+++ b/frontend/lib/identification/activation_workflow/activate_code.dart
@@ -25,14 +25,14 @@ Future<ActivateCard$Mutation$CardActivationResultModel> activateCode({
   try {
     final mutationResult = await client.mutate(mutationOptions);
     final exception = mutationResult.exception;
-    if (exception != null && mutationResult.hasException) {
+    if (exception != null) {
       throw exception;
     }
 
     final data = mutationResult.data;
 
     if (data == null) {
-      throw const ServerCardActivationException("No connection to the server");
+      throw const ServerCardActivationException("Server returned null.");
     }
 
     final parsedResult = activateCard.parse(data);

--- a/frontend/lib/identification/activation_workflow/activation_overwrite_existing_dialog.dart
+++ b/frontend/lib/identification/activation_workflow/activation_overwrite_existing_dialog.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 
 class ActivationOverwriteExistingDialog extends StatelessWidget {
-  final VoidCallback overrideExistingCard;
-
-  const ActivationOverwriteExistingDialog({super.key, required this.overrideExistingCard});
+  const ActivationOverwriteExistingDialog({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -22,25 +20,25 @@ class ActivationOverwriteExistingDialog extends StatelessWidget {
         TextButton(
           child: const Text('Abbrechen'),
           onPressed: () {
-            Navigator.of(context).pop();
+            Navigator.of(context).pop(false);
           },
         ),
         TextButton(
           child: const Text('Aktivieren'),
           onPressed: () {
-            overrideExistingCard();
-            Navigator.of(context).pop();
+            Navigator.of(context).pop(true);
           },
         ),
       ],
     );
   }
 
-  static Future<void> showActivationOverwriteExistingDialog(
-      BuildContext context, VoidCallback overrideExistingCard) async {
-    return showDialog<void>(
-      context: context,
-      builder: (context) => ActivationOverwriteExistingDialog(overrideExistingCard: overrideExistingCard),
-    );
+  /// Returns true, if the user wants to override the existing device
+  static Future<bool> showActivationOverwriteExistingDialog(BuildContext context) async {
+    return await showDialog<bool>(
+          context: context,
+          builder: (context) => ActivationOverwriteExistingDialog(),
+        ) ??
+        false;
   }
 }


### PR DESCRIPTION
Previously, errors that happened after the user confirms overriding an existing device, were not shown to the user.