### PR TITLE
Untangle card status in app

### DIFF
--- a/frontend/lib/identification/card_detail_view/self_verify_card.dart
+++ b/frontend/lib/identification/card_detail_view/self_verify_card.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/widgets.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+
+import '../../proto/card.pb.dart';
+import '../../util/date_utils.dart';
+import '../otp_generator.dart';
+import '../user_code_model.dart';
+import '../verification_workflow/query_server_verification.dart';
+
+Future<void> selfVerifyCard(UserCodeModel userCodeModel, String projectId, GraphQLClient client) async {
+  final userCode = userCodeModel.userCode;
+  if (userCode == null) {
+    return;
+  }
+
+  final otpCode = OTPGenerator(userCode.totpSecret).generateOTP();
+  final DynamicVerificationCode qrCode = DynamicVerificationCode()
+    ..info = userCode.info
+    ..pepper = userCode.pepper
+    ..otp = otpCode.code;
+
+  debugPrint("Card Self-Verification: Requesting server");
+
+  final cardVerification = await queryDynamicServerVerification(client, projectId, qrCode);
+
+  // If the user code has changed during the server request, we abort.
+  if (userCodeModel.userCode != userCode) {
+    debugPrint("Card Self-Verification: The user code has been changed during server request for the old user code.");
+    return;
+  }
+
+  debugPrint("Card Self-Verification: Persisting response. Card is ${cardVerification.valid ? "valid." : "INVALID."}");
+
+  userCodeModel.setCode(DynamicUserCode()
+    ..info = userCode.info
+    ..ecSignature = userCode.ecSignature
+    ..pepper = userCode.pepper
+    ..totpSecret = userCode.totpSecret
+    ..cardVerification = (CardVerification()
+      ..cardValid = cardVerification.valid
+      ..verificationTimeStamp = secondsSinceEpoch(DateTime.parse(cardVerification.verificationTimeStamp))));
+}

--- a/frontend/lib/identification/card_detail_view/verification_code_view.dart
+++ b/frontend/lib/identification/card_detail_view/verification_code_view.dart
@@ -1,61 +1,56 @@
+import 'dart:async';
 import 'dart:math';
 
-import 'package:ehrenamtskarte/configuration/configuration.dart';
 import 'package:ehrenamtskarte/identification/card_detail_view/animated_progressbar.dart';
 import 'package:ehrenamtskarte/identification/otp_generator.dart';
 import 'package:ehrenamtskarte/identification/qr_content_parser.dart';
 import 'package:ehrenamtskarte/identification/user_code_model.dart';
-import 'package:ehrenamtskarte/identification/verification_workflow/query_server_verification.dart';
 import 'package:ehrenamtskarte/proto/card.pb.dart';
-import 'package:ehrenamtskarte/util/date_utils.dart';
-import 'package:ehrenamtskarte/widgets/small_button_spinner.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
-import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:qr_flutter/qr_flutter.dart' as qr;
 
+/// Displays the dynamic QR code.
+/// Should only be rendered, if we know that the user code is valid (and has been self-verified recently).
 class VerificationCodeView extends StatefulWidget {
   final DynamicUserCode userCode;
   final OTPGenerator _otpGenerator;
-  final bool isCardVerificationExpired;
 
-  VerificationCodeView({super.key, required this.userCode, required this.isCardVerificationExpired})
-      : _otpGenerator = OTPGenerator(userCode.totpSecret);
+  VerificationCodeView({super.key, required this.userCode}) : _otpGenerator = OTPGenerator(userCode.totpSecret);
 
   @override
   VerificationCodeViewState createState() => VerificationCodeViewState();
 }
 
 class VerificationCodeViewState extends State<VerificationCodeView> {
-  OTPCode? _otpCode;
+  late OTPCode _otpCode;
+  Timer? _otpResetTimer;
 
   @override
   void initState() {
     super.initState();
-    _otpCode = widget._otpGenerator.generateOTP(_resetQrCode);
-    // On every app start when this widget will be initialized, we verify with the backend if the card is valid, in order to detect if one of the following events happened:
-    // - the card was activated on another device
-    // - the card was revoked
-    // - the card expired (on backend's system time)
-    SchedulerBinding.instance.addPostFrameCallback((_) => verifyCard(_otpCode, widget.userCode, context));
+    _resetQrCode();
   }
 
   _resetQrCode() {
-    setState(() {
-      _otpCode = widget._otpGenerator.generateOTP(_resetQrCode);
-    });
+    final otpCode = widget._otpGenerator.generateOTP();
+    _otpCode = otpCode;
+    _otpResetTimer = Timer(
+        Duration(milliseconds: otpCode.validUntilMilliSeconds - DateTime.now().millisecondsSinceEpoch),
+        () => setState(_resetQrCode));
+  }
+
+  @override
+  void dispose() {
+    _otpResetTimer?.cancel();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     final otpCode = _otpCode;
     final userCode = widget.userCode;
-    final isCardVerificationExpired = widget.isCardVerificationExpired;
 
-    if (otpCode == null) {
-      return const SmallButtonSpinner();
-    }
     final time = DateTime.now().millisecondsSinceEpoch;
     final animationDuration = otpCode.validUntilMilliSeconds - time;
     return LayoutBuilder(
@@ -68,68 +63,36 @@ class VerificationCodeViewState extends State<VerificationCodeView> {
               errorCorrectLevel: qr.QrErrorCorrectLevel.L,
             );
 
-            return isCardVerificationExpired
-                ? TextButton.icon(
-                    icon: const Icon(Icons.refresh),
-                    onPressed: () {
-                      verifyCard(otpCode, userCode, context);
-                    },
-                    label: Text("Erneut prüfen"),
-                  )
-                : ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 600, maxHeight: 600),
-                    child: Material(
-                      clipBehavior: Clip.hardEdge,
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                      child: Stack(
-                        children: [
-                          Padding(
-                            padding: EdgeInsets.all(padding),
-                            child: qr.QrImageView.withQr(
-                              qr: qrCode,
-                              version: qr.QrVersions.auto,
-                              gapless: false,
-                              dataModuleStyle: qr.QrDataModuleStyle(
-                                  dataModuleShape: qr.QrDataModuleShape.square,
-                                  color: Theme.of(context).textTheme.bodyMedium?.color),
-                              eyeStyle: qr.QrEyeStyle(
-                                  eyeShape: qr.QrEyeShape.square, color: Theme.of(context).textTheme.bodyMedium?.color),
-                            ),
-                          ),
-                          Positioned.fill(
-                            child: AnimatedProgressbar(initialProgress: Duration(milliseconds: animationDuration)),
-                          ),
-                        ],
+            return ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 600, maxHeight: 600),
+              child: Material(
+                clipBehavior: Clip.hardEdge,
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                child: Stack(
+                  children: [
+                    Padding(
+                      padding: EdgeInsets.all(padding),
+                      child: qr.QrImageView.withQr(
+                        qr: qrCode,
+                        version: qr.QrVersions.auto,
+                        gapless: false,
+                        dataModuleStyle: qr.QrDataModuleStyle(
+                            dataModuleShape: qr.QrDataModuleShape.square,
+                            color: Theme.of(context).textTheme.bodyMedium?.color),
+                        eyeStyle: qr.QrEyeStyle(
+                            eyeShape: qr.QrEyeShape.square, color: Theme.of(context).textTheme.bodyMedium?.color),
                       ),
                     ),
-                  );
+                    Positioned.fill(
+                      child: AnimatedProgressbar(initialProgress: Duration(milliseconds: animationDuration)),
+                    ),
+                  ],
+                ),
+              ),
+            );
           },
         );
       },
     );
-  }
-
-  Future<void> verifyCard(OTPCode? otpCode, DynamicUserCode userCode, BuildContext context) async {
-    if (otpCode == null) {
-      throw Exception("otp code is not available");
-    }
-    final projectId = Configuration.of(context).projectId;
-    final client = GraphQLProvider.of(context).value;
-    final DynamicVerificationCode qrCode = DynamicVerificationCode()
-      ..info = userCode.info
-      ..pepper = userCode.pepper
-      ..otp = otpCode.code;
-
-    final cardVerification = await queryDynamicServerVerification(client, projectId, qrCode);
-    final provider = Provider.of<UserCodeModel>(context, listen: false);
-
-    provider.setCode(DynamicUserCode()
-      ..info = userCode.info
-      ..ecSignature = userCode.ecSignature
-      ..pepper = userCode.pepper
-      ..totpSecret = userCode.totpSecret
-      ..cardVerification = (CardVerification()
-        ..cardValid = cardVerification.valid
-        ..verificationTimeStamp = secondsSinceEpoch(DateTime.parse(cardVerification.verificationTimeStamp))));
   }
 }

--- a/frontend/lib/identification/otp_generator.dart
+++ b/frontend/lib/identification/otp_generator.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:base32/base32.dart';
 import 'package:flutter/foundation.dart';
 import 'package:otp/otp.dart';
@@ -12,13 +10,10 @@ class OTPGenerator {
 
   OTPGenerator(List<int> totpSecret) : _totpSecretBase32 = base32.encode(Uint8List.fromList(totpSecret));
 
-  OTPCode generateOTP([VoidCallback? onTimeout]) {
+  OTPCode generateOTP() {
     final time = DateTime.now().millisecondsSinceEpoch;
     const intervalMilliSeconds = _otpIntervalSeconds * 1000;
     final validUntilMilliSeconds = (time ~/ intervalMilliSeconds + 1) * intervalMilliSeconds;
-    if (onTimeout != null) {
-      Timer(Duration(milliseconds: validUntilMilliSeconds - time), onTimeout);
-    }
     return OTPCode(
       int.parse(
         OTP.generateTOTPCodeString(


### PR DESCRIPTION
This PR untangles how the app determines the status of a persisted card.
It should be clearer to see what is shown in the "Ausweisen" tab.

The only functional change:
* We initiate self-verification in any status (previously, we did not self-verify if the card expired (according to local clock) or if it the backend ever responded with `invalid`). 
* Try to detect race-conditions in self-verification (possibly conflicting with activation): If the UserCode was set while doing the server request, then ignore the result.

Minor change:
* VerificationCodeView sets its own timer (instead of OTPGenerator setting it), in order to be able to cancel it in case it is being disposed. Previously, we had an error in the console, when the VerificationCodeView was unmounted.