### PR TITLE
Avoid DB race condition when activating

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/webservice/schema/CardMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/webservice/schema/CardMutationService.kt
@@ -19,6 +19,7 @@ import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import graphql.schema.DataFetchingEnvironment
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.slf4j.LoggerFactory
+import java.sql.Connection.TRANSACTION_REPEATABLE_READ
 import java.util.Base64
 
 @Suppress("unused")
@@ -78,30 +79,33 @@ class CardMutationService {
                 ?: throw ProjectNotFoundException(project)
         val cardHash = Base64.getDecoder().decode(cardInfoHashBase64)
         val rawActivationSecret = Base64.getDecoder().decode(activationSecretBase64)
-        val card = transaction { CardRepository.findByHash(project, cardHash) }
-        val activationSecretHash = card?.activationSecretHash
+        // Avoid race conditions when activating a card.
+        return transaction(TRANSACTION_REPEATABLE_READ, repetitionAttempts = 0) t@{
+            val card = CardRepository.findByHash(project, cardHash)
+            val activationSecretHash = card?.activationSecretHash
 
-        if (card == null || activationSecretHash == null) {
-            return CardActivationResultModel(ActivationState.failed)
+            if (card == null || activationSecretHash == null) {
+                return@t CardActivationResultModel(ActivationState.failed)
+            }
+
+            if (!CardActivator.verifyActivationSecret(rawActivationSecret, activationSecretHash)) {
+                logger.info("${context.remoteIp} failed to activate entitlement card")
+                return@t CardActivationResultModel(ActivationState.failed)
+            }
+
+            if (CardVerifier.isExpired(card.expirationDay, projectConfig.timezone) || card.revoked) {
+                return@t CardActivationResultModel(ActivationState.failed)
+            }
+
+            if (!overwrite && card.totpSecret != null) {
+                return@t CardActivationResultModel(ActivationState.did_not_overwrite_existing)
+            }
+
+            val totpSecret = CardActivator.generateTotpSecret()
+            val encodedTotpSecret = Base64.getEncoder().encodeToString(totpSecret)
+            CardRepository.activate(card, totpSecret)
+            return@t CardActivationResultModel(ActivationState.success, encodedTotpSecret)
         }
-
-        if (!CardActivator.verifyActivationSecret(rawActivationSecret, activationSecretHash)) {
-            logger.info("${context.remoteIp} failed to activate entitlement card")
-            return CardActivationResultModel(ActivationState.failed)
-        }
-
-        if (CardVerifier.isExpired(card.expirationDay, projectConfig.timezone) || card.revoked) {
-            return CardActivationResultModel(ActivationState.failed)
-        }
-
-        if (!overwrite && card.totpSecret != null) {
-            return CardActivationResultModel(ActivationState.did_not_overwrite_existing)
-        }
-
-        val totpSecret = CardActivator.generateTotpSecret()
-        val encodedTotpSecret = Base64.getEncoder().encodeToString(totpSecret)
-        transaction { CardRepository.activate(card, totpSecret) }
-        return CardActivationResultModel(ActivationState.success, encodedTotpSecret)
     }
 
     private fun isCodeTypeValid(card: CardGenerationModel): Boolean {


### PR DESCRIPTION
To avoid race conditions when activating a card (e.g. if the app somehow requests activation too often), this PR introduces DB transaction isolation for the activation transaction.