### PR TITLE
Show time out of sync error

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/service/CardVerifier.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/service/CardVerifier.kt
@@ -36,6 +36,7 @@ object CardVerifier {
         if (generateTotp(secret) == totp) return true
 
         // current TOTP is invalid, but we are also happy with the previous/next one
+        // This means, we tolerate that the device time is shifted by 30s from the server time.
         val previousValidTotp = generateTotp(secret, Instant.now().minus(TIME_STEP))
         if (previousValidTotp == totp) return true
         val nextValidTotp = generateTotp(secret, Instant.now().plus(TIME_STEP))

--- a/frontend/lib/about/dev_settings_view.dart
+++ b/frontend/lib/about/dev_settings_view.dart
@@ -9,6 +9,7 @@ import 'package:ehrenamtskarte/graphql/graphql_api.graphql.dart';
 import 'package:ehrenamtskarte/identification/activation_workflow/activate_code.dart';
 import 'package:ehrenamtskarte/identification/activation_workflow/activation_code_parser.dart';
 import 'package:ehrenamtskarte/identification/activation_workflow/activation_exception.dart';
+import 'package:ehrenamtskarte/identification/card_detail_view/self_verify_card.dart';
 import 'package:ehrenamtskarte/identification/qr_code_scanner/qr_code_processor.dart';
 import 'package:ehrenamtskarte/identification/qr_code_scanner/qr_parsing_error_dialog.dart';
 import 'package:ehrenamtskarte/identification/user_code_model.dart';
@@ -50,6 +51,8 @@ class DevSettingsView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final settings = Provider.of<SettingsModel>(context);
+    final client = GraphQLProvider.of(context).value;
+    final userCodeModel = Provider.of<UserCodeModel>(context);
     return Padding(
       padding: const EdgeInsets.all(15.0),
       child: Column(
@@ -73,6 +76,10 @@ class DevSettingsView extends StatelessWidget {
           ListTile(
             title: const Text('Set expired last card verification'),
             onTap: () => _setExpiredLastVerification(context),
+          ),
+          ListTile(
+            title: const Text('Trigger self-verification'),
+            onTap: () => selfVerifyCard(userCodeModel, Configuration.of(context).projectId, client),
           ),
           ListTile(
             title: const Text('Log sample exception'),

--- a/frontend/lib/identification/card_detail_view/card_detail_view.dart
+++ b/frontend/lib/identification/card_detail_view/card_detail_view.dart
@@ -141,6 +141,8 @@ enum CardStatus {
   expired,
   // The card was not verified lately by the server.
   notVerifiedLately,
+  // The time of the device was out of sync with the server.
+  timeOutOfSync,
   // The card was verified lately by the server and it responded that the card is invalid.
   invalid,
   // In any other case, we assume the card is valid and show the dynamic QR code
@@ -151,6 +153,8 @@ enum CardStatus {
       return CardStatus.expired;
     } else if (!cardWasVerifiedLately(code.cardVerification)) {
       return CardStatus.notVerifiedLately;
+    } else if (code.cardVerification.outOfSync) {
+      return CardStatus.timeOutOfSync;
     } else if (!code.cardVerification.cardValid) {
       return CardStatus.invalid;
     } else {
@@ -191,6 +195,16 @@ class QrCodeAndStatus extends StatelessWidget {
                     label: Text("Erneut prüfen"),
                   ),
                 ),
+              ],
+            CardStatus.timeOutOfSync => [
+                _PaddedText(
+                    'Die Uhrzeit Ihres Geräts scheint nicht zu stimmen. Bitte synchronisieren Sie die Uhrzeit in den Systemeinstellungen.'),
+                Flexible(
+                    child: TextButton.icon(
+                  icon: const Icon(Icons.refresh),
+                  onPressed: onSelfVerifyPressed,
+                  label: Text("Erneut prüfen"),
+                ))
               ],
             CardStatus.invalid => [
                 _PaddedText(

--- a/frontend/lib/identification/card_detail_view/self_verify_card.dart
+++ b/frontend/lib/identification/card_detail_view/self_verify_card.dart
@@ -21,7 +21,8 @@ Future<void> selfVerifyCard(UserCodeModel userCodeModel, String projectId, Graph
 
   debugPrint("Card Self-Verification: Requesting server");
 
-  final cardVerification = await queryDynamicServerVerification(client, projectId, qrCode);
+  final (outOfSync: outOfSync, result: cardVerification) =
+      await queryDynamicServerVerification(client, projectId, qrCode);
 
   // If the user code has changed during the server request, we abort.
   if (userCodeModel.userCode != userCode) {
@@ -38,5 +39,6 @@ Future<void> selfVerifyCard(UserCodeModel userCodeModel, String projectId, Graph
     ..totpSecret = userCode.totpSecret
     ..cardVerification = (CardVerification()
       ..cardValid = cardVerification.valid
-      ..verificationTimeStamp = secondsSinceEpoch(DateTime.parse(cardVerification.verificationTimeStamp))));
+      ..verificationTimeStamp = secondsSinceEpoch(DateTime.parse(cardVerification.verificationTimeStamp))
+      ..outOfSync = outOfSync));
 }

--- a/frontend/lib/identification/verification_workflow/query_server_verification.dart
+++ b/frontend/lib/identification/verification_workflow/query_server_verification.dart
@@ -20,11 +20,14 @@ Future<({bool outOfSync, CardVerificationByHash$Query$CardVerificationResultMode
     CodeType.kw$DYNAMIC,
   );
   stopWatch.stop();
+  // We assume that the server captured the verificationTimeStamp in the middle of the request:
   final estimatedTimeOfVerification = timeBeforeRequest.add(Duration(milliseconds: stopWatch.elapsedMilliseconds ~/ 2));
   final actualTimeOfVerification = DateTime.parse(result.verificationTimeStamp);
   final timeOffset =
       (estimatedTimeOfVerification.millisecondsSinceEpoch - actualTimeOfVerification.millisecondsSinceEpoch).abs() /
           1000;
+  // The server tolerates a time offset of 30 seconds
+  // (see backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/service/CardVerifier.kt)
   final outOfSync = timeOffset >= 30;
   return (outOfSync: outOfSync, result: result);
 }

--- a/frontend/lib/identification/verification_workflow/verification_qr_code_processor.dart
+++ b/frontend/lib/identification/verification_workflow/verification_qr_code_processor.dart
@@ -31,7 +31,13 @@ Future<CardInfo?> verifyDynamicVerificationCode(
 ) async {
   assertConsistentCardInfo(code.info);
   _assertConsistentDynamicVerificationCode(code);
-  if (!(await queryDynamicServerVerification(client, projectId, code)).valid) {
+  final (outOfSync: outOfSync, result: result) = await queryDynamicServerVerification(client, projectId, code);
+  if (outOfSync) {
+    debugPrint("Verification: This device's time is out of sync with the server."
+        "Ignoring, as only the time of the device that generates the QR code is relevant for the verification process.");
+  }
+
+  if (!result.valid) {
     return null;
   }
   return code.info;

--- a/specs/card.proto
+++ b/specs/card.proto
@@ -62,11 +62,14 @@ message CardInfo {
 message CardVerification {
   optional bool cardValid = 1;
 
-  // Verification timestamp in seconds (calculated from 1970-01-01 UTC).
+  // Verification timestamp in seconds (calculated from 1970-01-01 UTC) as reported by the server.
   // Using uint64 should be good for 584,942,417,355 years after 1970.
   // This timestamp is used to invalidate the card after a certain time period not verified with the backend (in this case 7 days).
   // This timestamp will be updated after card activation and card validation on app start.
   optional uint64 verificationTimeStamp = 2;
+
+  // If the verificationTimeStamp was out of sync with the local date time (at time of request) by at least 30 seconds.
+  optional bool outOfSync = 3;
 }
 
 message QrCode {


### PR DESCRIPTION
This should resolve #1065, #1056, #1049

When during self-verification, the time of the device is out of sync with the sever, the device would generate a wrong otp code and, thus, the server would respond that the card is not valid. The current app-store version (<= 3.1.3) of the app had the additional problem, that if the server responded once with "invalid", the app would not try to self-verify again the next time the app launches. This was already fixed by #1071 . This means, in the current dev-version (also before this PR), if you landed in this screen, resynced your local time, and restarted the app, the error would go away.

The solution I implemented here, is to simply analyze whether the time of the local device is out of sync at the time of self-verification. If so, we show a simple error like "Die Zeit deines Geräts scheint nicht zu stimmen. Synchronisiere deine Uhrzeit in den Geräte-Einstellungen."