### PR TITLE
1114: Sort applications by status

### DIFF
--- a/administration/package-lock.json
+++ b/administration/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "administration",
-  "version": "3.1.5",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "administration",
-      "version": "3.1.5",
+      "version": "3.2.0",
       "hasInstallScript": true,
       "dependencies": {
         "@apollo/client": "^3.7.16",

--- a/administration/src/bp-modules/applications/ApplicationsOverview.tsx
+++ b/administration/src/bp-modules/applications/ApplicationsOverview.tsx
@@ -178,13 +178,8 @@ export class ApplicationViewComponent extends React.Component<{
   }
 }
 
-const sortByStatus = (a: number, b: number): number => {
-  return a - b
-}
-
-const sortByDate = (a: Date, b: Date): number => {
-  return b.getTime() - a.getTime()
-}
+const sortByStatus = (a: number, b: number): number => a - b
+const sortByDateAsc = (a: Date, b: Date): number => a.getTime() - b.getTime()
 
 const getVerificationStatus = (status: number[]): VerificationStatus => {
   if (status.every(val => val === VerificationStatus.Verified)) return VerificationStatus.Verified
@@ -192,11 +187,11 @@ const getVerificationStatus = (status: number[]): VerificationStatus => {
   return VerificationStatus.Awaiting
 }
 
-// Applications will be sorted by unique status which means fully verified/rejected and within this status by creation date
+// Applications will be sorted by unique status which means fully verified/rejected and within this status by creation date asc
 const sortApplications = (applications: Application[]): Application[] =>
   applications
     .map(application => ({ ...application, status: getVerificationStatus(application.verifications.map(getStatus)) }))
-    .sort((a, b) => sortByStatus(a.status, b.status) || sortByDate(new Date(a.createdDate), new Date(b.createdDate)))
+    .sort((a, b) => sortByStatus(a.status, b.status) || sortByDateAsc(new Date(a.createdDate), new Date(b.createdDate)))
 
 const ApplicationsOverview = (props: { applications: Application[] }) => {
   const [updatedApplications, setUpdatedApplications] = useState(props.applications)

--- a/administration/src/bp-modules/applications/ApplicationsOverview.tsx
+++ b/administration/src/bp-modules/applications/ApplicationsOverview.tsx
@@ -15,6 +15,12 @@ import usePrintApplication from './hooks/usePrintApplication'
 
 export type Application = GetApplicationsQuery['applications'][number]
 
+enum ApplicationStatus {
+  fullyVerified,
+  fullyRejected,
+  ambiguous,
+}
+
 export const CARD_PADDING = 20
 const COLLAPSED_HEIGHT = 250
 
@@ -181,16 +187,16 @@ export class ApplicationViewComponent extends React.Component<{
 const sortByStatus = (a: number, b: number): number => a - b
 const sortByDateAsc = (a: Date, b: Date): number => a.getTime() - b.getTime()
 
-const getVerificationStatus = (status: number[]): VerificationStatus => {
-  if (status.every(val => val === VerificationStatus.Verified)) return VerificationStatus.Verified
-  if (status.every(val => val === VerificationStatus.Rejected)) return VerificationStatus.Rejected
-  return VerificationStatus.Awaiting
+const getApplicationStatus = (status: number[]): ApplicationStatus => {
+  if (status.every(val => val === VerificationStatus.Verified)) return ApplicationStatus.fullyVerified
+  if (status.every(val => val === VerificationStatus.Rejected)) return ApplicationStatus.fullyRejected
+  return ApplicationStatus.ambiguous
 }
 
 // Applications will be sorted by unique status which means fully verified/rejected and within this status by creation date asc
 const sortApplications = (applications: Application[]): Application[] =>
   applications
-    .map(application => ({ ...application, status: getVerificationStatus(application.verifications.map(getStatus)) }))
+    .map(application => ({ ...application, status: getApplicationStatus(application.verifications.map(getStatus)) }))
     .sort((a, b) => sortByStatus(a.status, b.status) || sortByDateAsc(new Date(a.createdDate), new Date(b.createdDate)))
 
 const ApplicationsOverview = (props: { applications: Application[] }) => {

--- a/administration/src/bp-modules/applications/ApplicationsOverview.tsx
+++ b/administration/src/bp-modules/applications/ApplicationsOverview.tsx
@@ -1,5 +1,5 @@
 import { Alert, Button, Callout, Card, Divider, H4, NonIdealState, ResizeSensor } from '@blueprintjs/core'
-import React, { FunctionComponent, useContext, useState } from 'react'
+import React, { FunctionComponent, useContext, useMemo, useState } from 'react'
 import FlipMove from 'react-flip-move'
 import styled, { css } from 'styled-components'
 
@@ -186,7 +186,6 @@ export class ApplicationViewComponent extends React.Component<{
 
 const sortByStatus = (a: number, b: number): number => a - b
 const sortByDateAsc = (a: Date, b: Date): number => a.getTime() - b.getTime()
-
 const getApplicationStatus = (status: number[]): ApplicationStatus => {
   if (status.every(val => val === VerificationStatus.Verified)) return ApplicationStatus.fullyVerified
   if (status.every(val => val === VerificationStatus.Rejected)) return ApplicationStatus.fullyRejected
@@ -196,16 +195,20 @@ const getApplicationStatus = (status: number[]): ApplicationStatus => {
 // Applications will be sorted by unique status which means fully verified/rejected and within this status by creation date asc
 const sortApplications = (applications: Application[]): Application[] =>
   applications
-    .map(application => ({ ...application, status: getApplicationStatus(application.verifications.map(getStatus)) }))
+    .map(application => ({
+      ...application,
+      status: getApplicationStatus(application.verifications.map(getStatus)),
+    }))
     .sort((a, b) => sortByStatus(a.status, b.status) || sortByDateAsc(new Date(a.createdDate), new Date(b.createdDate)))
 
 const ApplicationsOverview = (props: { applications: Application[] }) => {
   const [updatedApplications, setUpdatedApplications] = useState(props.applications)
   const { applicationIdForPrint, printApplicationById } = usePrintApplication()
+  const sortedApplications = useMemo(() => sortApplications(updatedApplications), [updatedApplications])
 
   return (
     <FlipMove style={{ display: 'flex', justifyContent: 'center', flexWrap: 'wrap' }}>
-      {sortApplications(updatedApplications).map(application => (
+      {sortedApplications.map(application => (
         <ApplicationViewComponent
           isSelectedForPrint={application.id === applicationIdForPrint}
           printApplicationById={printApplicationById}

--- a/administration/src/bp-modules/applications/VerificationsView.tsx
+++ b/administration/src/bp-modules/applications/VerificationsView.tsx
@@ -10,10 +10,10 @@ const verifiedIcon = 'tick-circle'
 const rejectedIcon = 'cross-circle'
 const awaitingIcon = 'help'
 
-enum VerificationStatus {
+export enum VerificationStatus {
   Verified,
-  Awaiting,
   Rejected,
+  Awaiting,
 }
 
 const getIconByStatus = (status: VerificationStatus) => {
@@ -46,7 +46,7 @@ const Indicator = ({ status, text }: { status: VerificationStatus; text: ReactNo
   )
 }
 
-const getStatus = (verification: Application['verifications'][number]) => {
+export const getStatus = (verification: Application['verifications'][number]) => {
   if (!!verification.verifiedDate) {
     return VerificationStatus.Verified
   } else if (!!verification.rejectedDate) {


### PR DESCRIPTION
resolves #1114 

Please properly test the sorting by creating some applications with different status.
Applications that are not fully approved or rejected will have the status "waiting" and put in the end, since they are not actionable