### PR TITLE
1115: Trim search text

### DIFF
--- a/frontend/lib/widgets/app_bars.dart
+++ b/frontend/lib/widgets/app_bars.dart
@@ -127,7 +127,7 @@ class SearchSliverAppBarState extends State<SearchSliverAppBar> {
   }
 
   _onSearchFieldTextChanged(String text) {
-    widget.debouncer.run(() => widget.onChanged(text));
+    widget.debouncer.run(() => widget.onChanged(text.trim()));
   }
 
   _clearInput() {


### PR DESCRIPTION
resolves #1115 

Test with: "Museum der Stadt Augsburg " -> now works
If you use auto complete on soft keyboard the additional empty space resulted in not getting a search result