### PR TITLE
Fix run configs

### DIFF
--- a/.idea/runConfigurations/Run__env_local_buildConfig_bayern_.xml
+++ b/.idea/runConfigurations/Run__env_local_buildConfig_bayern_.xml
@@ -4,7 +4,7 @@
     <option name="attachArgs" value="--dart-define=environment=local" />
     <option name="filePath" value="$PROJECT_DIR$/frontend/lib/main.dart" />
     <method v="2">
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Select &quot;bayern&quot;" run_configuration_type="ShConfigurationType" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Set build config bayern" run_configuration_type="ShConfigurationType" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Run__env_local_buildConfig_nuernberg_.xml
+++ b/.idea/runConfigurations/Run__env_local_buildConfig_nuernberg_.xml
@@ -4,7 +4,7 @@
     <option name="attachArgs" value="--dart-define=environment=local" />
     <option name="filePath" value="$PROJECT_DIR$/frontend/lib/main.dart" />
     <method v="2">
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Select &quot;nuernberg&quot;" run_configuration_type="ShConfigurationType" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Set build config nuernberg" run_configuration_type="ShConfigurationType" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Run__env_production_buildConfig_bayern_.xml
+++ b/.idea/runConfigurations/Run__env_production_buildConfig_bayern_.xml
@@ -4,7 +4,7 @@
     <option name="attachArgs" value="--dart-define=environment=production" />
     <option name="filePath" value="$PROJECT_DIR$/frontend/lib/main.dart" />
     <method v="2">
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Select &quot;bayern&quot;" run_configuration_type="ShConfigurationType" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Set build config bayern" run_configuration_type="ShConfigurationType" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Run__env_production_buildConfig_bayern_floss_.xml
+++ b/.idea/runConfigurations/Run__env_production_buildConfig_bayern_floss_.xml
@@ -4,7 +4,7 @@
     <option name="attachArgs" value="--dart-define=environment=production" />
     <option name="filePath" value="$PROJECT_DIR$/frontend/lib/main.dart" />
     <method v="2">
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Select &quot;bayern-floss&quot;" run_configuration_type="ShConfigurationType" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Set build config bayern-floss" run_configuration_type="ShConfigurationType" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/Run__env_production_buildConfig_nuernberg_.xml
+++ b/.idea/runConfigurations/Run__env_production_buildConfig_nuernberg_.xml
@@ -5,7 +5,7 @@
     <option name="buildFlavor" value="Nuernberg" />
     <option name="filePath" value="$PROJECT_DIR$/frontend/lib/main.dart" />
     <method v="2">
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Select &quot;nuernberg&quot;" run_configuration_type="ShConfigurationType" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Set build config nuernberg" run_configuration_type="ShConfigurationType" />
     </method>
   </configuration>
 </component>

--- a/docs/graphql_generation.md
+++ b/docs/graphql_generation.md
@@ -6,5 +6,5 @@ Queries are specified in [frontend/graphql_queries](../frontend/graphql_queries)
 ## Generate API Files
 1. If schema changed: Generate updated GraphQL schema into [schema.graphql](../frontend/schema.graphql)
    Run "Generate GraphQL" in Intellij (or `./gradlew run --args="graphql-export ../specs/backend-api.graphql"` in the backend folder)
-2. Run any "Select" configuration in IntelliJ e.g. "Select bayern" (or `flutter pub run build_runner build` in the `frontend` directory)
+2. Run any "Set build config" configuration in IntelliJ e.g. "Set build config bayern" (or `flutter pub run build_runner build` in the `frontend` directory)
 3. Run "Generate GraphQL React Client" (or `npm generate-graphql` in the `administration` directory)


### PR DESCRIPTION
The flutter run configs did have a "before" task, that was linking to a non-existing run configuration. I assume the "Select bayern" is now the "Set build config bayern" task. I fixed the linking, so the selection is correctly executed before flutter run.