### PR TITLE
1141: add route for map and styles to our reverse_proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     ports:
       - 127.0.0.1:5002:80
     volumes:
-      - ./map-tiles/styles:/usr/share/nginx/html
+      - ./backend/ehrenamtskarte-maplibre-style:/usr/share/nginx/html
       - ./docker/nginx-development.conf:/etc/nginx/conf.d/default.conf
     depends_on:
       - martin

--- a/docker/nginx-development.conf
+++ b/docker/nginx-development.conf
@@ -10,6 +10,19 @@ server {
 
     root /usr/share/nginx/html;
 
+    location = /map.html {
+    }
+
+    location = /style.json {
+        add_header 'Access-Control-Allow-Origin' '*';
+
+        sub_filter_once off;
+        sub_filter_types application/json;
+        sub_filter "https://tiles.staging.ehrenamtskarte.app" "http://localhost:5002";
+
+        try_files $uri /style.json;
+    }
+
     location ~ /(?<fwd_path>.*) {
         proxy_set_header X-Rewrite-URL $request_uri;
         proxy_set_header X-Forwarded-Host $host;

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -54,7 +54,7 @@ adb reverse tcp:8000 tcp:8000
 9. Run the backend: `cd backend && ./gradlew run --args="execute"` or `.\backend\gradlew.bat run --args="execute"` on Windows
 10. Create an admin account using `./gradlew run --args="create-admin <project> <role> <email> <password> <region>"`
 11. Take a look at the martin endpoints: [http://localhost:5002/tiles/accepting_stores/index.json](http://localhost:5002/tiles/accepting_stores/index.json) and [http://localhost:5002/tiles/accepting_stores/rpc/index.json](http://localhost:5002/tiles/accepting_stores/rpc/index.json). The data shown on the map is fetched from a hardcoded url and is not using the data from the local martin!
-12. Take a look at the style by viewing the test map: [http://localhost:5002](http://localhost:5002)
+12. Take a look at the style by viewing the test map: [http://localhost:5002/map.html](http://localhost:5002/map.html)
 13. Take a look at the backend: [http://localhost:8000](http://localhost:8000) (The public version is available at
     api.entitlementcard.app)
 14. Set up the matomo instance [http://localhost:5003](http://localhost:5003) (The public version is available at https://matomo-entitlementcard.tuerantuer.org)


### PR DESCRIPTION
### Short description

In #1134 we realized, that some urls did not work. This should be fixed in this PR.

### Proposed changes

<!-- Describe this PR in more detail. -->

- add route for map and styles to our nginx server
- mount submodule to nginx output

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- there shouldn't be anythin
-

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1141 
