### PR TITLE
1144: Add base64 cards

### DIFF
--- a/administration/src/cards/pdf/PdfQrCodeElement.ts
+++ b/administration/src/cards/pdf/PdfQrCodeElement.ts
@@ -1,6 +1,8 @@
 import { PDFPage } from 'pdf-lib'
 
 import { QrCode } from '../../generated/card_pb'
+import { uint8ArrayToBase64 } from '../../util/base64'
+import { isDevMode } from '../../util/helper'
 import { drawQRCode } from '../../util/qrcode'
 import { Coordinates, PdfElement, mmToPt } from './PdfElements'
 
@@ -26,6 +28,11 @@ const pdfQrCodeElement: PdfElement<PdfQrCodeElementProps, PdfQrCodeElementRender
   const qrCodeContent = new QrCode({
     qrCode: qrCode,
   }).toBinary()
+
+  // Log base64 activationCode for development purposes
+  if (qrCode.case === 'dynamicActivationCode' && isDevMode()) {
+    console.log(uint8ArrayToBase64(qrCodeContent))
+  }
 
   drawQRCode(qrCodeContent, qrCodeXPdf, qrCodeYPdf, qrCodeSizePdf, page, false)
 }

--- a/administration/src/util/helper.ts
+++ b/administration/src/util/helper.ts
@@ -1,0 +1,1 @@
+export const isDevMode = (): boolean => window.location.hostname === 'localhost'

--- a/frontend/lib/about/dev_settings_view.dart
+++ b/frontend/lib/about/dev_settings_view.dart
@@ -142,7 +142,7 @@ class DevSettingsView extends StatelessWidget {
               child: Column(
                 children: <Widget>[
                   const SelectableText(
-                    'Create a QR code from a PDF: pdftoppm berechtigungskarten.pdf | zbarimg -q --raw  -',
+                    'Create a card in druckerei & copy/paste the base64 code from console',
                   ),
                   TextFormField(
                     controller: base64Controller,
@@ -168,6 +168,7 @@ class DevSettingsView extends StatelessWidget {
     );
   }
 
+// You can either copy/paste from clipboard on ios or type 'adb shell input text <text>' in terminal for android
   Future<void> _activateCard(BuildContext context, String base64qrcode) async {
     final messengerState = ScaffoldMessenger.of(context);
     final provider = Provider.of<UserCodeModel>(context, listen: false);
@@ -194,7 +195,10 @@ class DevSettingsView extends StatelessWidget {
           final userCode = DynamicUserCode()
             ..info = activationCode.info
             ..pepper = activationCode.pepper
-            ..totpSecret = totpSecret;
+            ..totpSecret = totpSecret
+            ..cardVerification = (CardVerification()
+              ..cardValid = true
+              ..verificationTimeStamp = secondsSinceEpoch(DateTime.parse(activationResult.activationTimeStamp)));
           provider.setCode(userCode);
           break;
         case ActivationState.failed:


### PR DESCRIPTION
### Short description

It was not possible to add a base64 card in dev settings anymore, because the verification failed and the libraries to read the barcode didn't work properly anymore to get even a proper base64 string. so i simplified this.

### Proposed changes

<!-- Describe this PR in more detail. -->

- log base64 string to avoid using the additional libraries (like before) to gain the base64 string
- added missing CardVerification in dev settings

Testing:
- create a card in the druckerei, check console for base64 string
- go to "Über" -> DevSettings -> Add base64 card

Note: Some ui issues exists on ios for the multi cards slider and will be fixed in #1142 

### Resolved issues

Fixes: #1144 
