### PR TITLE
1176: Configure locales in build config

### DIFF
--- a/frontend/build-configs/bayern/index.ts
+++ b/frontend/build-configs/bayern/index.ts
@@ -31,6 +31,7 @@ export const bayernCommon: CommonBuildConfigType = {
         showcase: "https://api.entitlementcard.app",
         local: "http://localhost:8000",
     },
+    appLocales: ['de'],
     cardBranding: {
         headerTextColor: "#008dc9",
         headerColor: "#F5F5FFF5",

--- a/frontend/build-configs/nuernberg/index.ts
+++ b/frontend/build-configs/nuernberg/index.ts
@@ -31,6 +31,7 @@ export const nuernbergCommon: CommonBuildConfigType = {
         showcase: "https://api.entitlementcard.app",
         local: "http://localhost:8000",
     },
+    appLocales: ['de', 'en'],
     cardBranding: {
         headerTextColor: "#000000",
         headerTextFontSize: 9,

--- a/frontend/build-configs/types.ts
+++ b/frontend/build-configs/types.ts
@@ -78,6 +78,7 @@ export type CommonBuildConfigType = {
         production: string
         local: string
     }
+    appLocales: string[]
     cardBranding: {
         headerTextColor: string
         headerColor: string

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -73,7 +73,7 @@ class App extends StatelessWidget {
               GlobalWidgetsLocalizations.delegate,
               GlobalCupertinoLocalizations.delegate,
             ],
-            supportedLocales: const [Locale('de')],
+            supportedLocales: buildConfig.appLocales.map((locale) => Locale(locale)),
             initialRoute: initialRoute,
             routes: routes,
           ),

--- a/frontend/pubs/df_build_config/lib/builder.dart
+++ b/frontend/pubs/df_build_config/lib/builder.dart
@@ -54,6 +54,8 @@ void pairToField(String k, dynamic v, StringBuffer root, StringBuffer output) {
 
       if (element is int) {
         output.write('  List<int> get $k => $v;\n');
+      } else if (element is String) {
+        output.write('  List<String> get $k => [\'${v.join('\', \'')}\'];\n');
       } else {
         throw "invalid list ${v.runtimeType}";
       }


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Add the available locales to the build config and use them to configure the app locales.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Add `appLocales` to build config
- Fix builder.dart script
- Use `appLocales` to configure the app locales

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
None.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1176.
