### PR TITLE
1191: Fix mail content type header charset

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/mail/Mailer.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/mail/Mailer.kt
@@ -55,7 +55,7 @@ object Mailer {
                         .from(fromName, smtpConfig.username)
                         .withSubject(subject)
                         .withPlainText(message)
-                        .withHeader("Content-Type", "text/plain; charset=utf8")
+                        .withHeader("Content-Type", "text/plain; charset=UTF-8")
                         .buildEmail()
                 ).join()
         } catch (exception: MailException) {
@@ -160,6 +160,7 @@ object Mailer {
         personalData: PersonalData,
         accessKey: String
     ) {
+        println("MAIL SENT")
         val message = """
         Guten Tag ${personalData.forenames.shortText} ${personalData.surname.shortText},
 

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/mail/Mailer.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/mail/Mailer.kt
@@ -160,7 +160,6 @@ object Mailer {
         personalData: PersonalData,
         accessKey: String
     ) {
-        println("MAIL SENT")
         val message = """
         Guten Tag ${personalData.forenames.shortText} ${personalData.surname.shortText},
 


### PR DESCRIPTION
### Short description

Changed encoding

### More info

This is an encoding problem, the mail in the screenshot is displayed in `iso 8859-1`, but we have a header saying it should be displayed in `utf8`. I opened a PR change dit to `UTF-8` as this is the correct wording, as this can fix the error for some users, see:

> The charset value should be utf-8, not any other values such as utf8. Using utf8, for example, is a common mistake, and even though it is valid nowadays as the [specifications](https://encoding.spec.whatwg.org/#names-and-labels) and browsers now alias utf8 to utf-8, that wasn’t the case in the past, so things might break in [some older browsers](https://twitter.com/jacobrossi/status/591435377291866112). The same may be true for other agents (non-browsers) that may scan/get the content and may not have the alias.
[source](https://webhint.io/docs/user-guide/hints/hint-meta-charset-utf-8/#:~:text=The%20charset%20value%20should%20be,break%20in%20some%20older%20browsers.)

But this error can also occure when users force their mail client to use another encoding as we put in the header. So if this error will not disappear for the user by my changes, i recommend checking the settings or updating the client.

We also can make sure the link only contains ASCI chars, but I think it alread does, to at least ensure the link is always working.


### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1191
