### PR TITLE
1175: Language switch

### DIFF
--- a/frontend/assets/l10n/app_de.json
+++ b/frontend/assets/l10n/app_de.json
@@ -15,6 +15,10 @@
     },
     "privacyDeclaration": "Datenschutzerklärung",
     "publisher": "Herausgeber",
+    "settings": {
+      "headline": "Einstellungen",
+      "languageChange": "Sprache wechseln"
+    },
     "sourceCode": "Quellcode der App",
     "title": "Über"
   },

--- a/frontend/assets/l10n/app_en.json
+++ b/frontend/assets/l10n/app_en.json
@@ -15,6 +15,10 @@
     },
     "privacyDeclaration": "Privacy policy",
     "publisher": "Publisher",
+    "settings": {
+      "headline": "Settings",
+      "languageChange": "Change language"
+    },
     "sourceCode": "Source code",
     "title": "About"
   },

--- a/frontend/assets/nuernberg/l10n/override_de.json
+++ b/frontend/assets/nuernberg/l10n/override_de.json
@@ -30,5 +30,8 @@
     "usageDescription": "Auf der Karte von Nürnberg können Sie alle Akzeptanzstellen finden. Tippen Sie auf einen Standort, um mehr Informationen sehen zu können.",
     "usageTitle": "Wo kann ich den Nürnberg-Pass nutzen?",
     "welcomeDescription": "Vielen Dank, dass Sie sich die App zum Nürnberg-Pass heruntergeladen haben!"
+  },
+  "about": {
+    "title": "Mehr"
   }
 }

--- a/frontend/assets/nuernberg/l10n/override_en.json
+++ b/frontend/assets/nuernberg/l10n/override_en.json
@@ -30,5 +30,8 @@
     "usageDescription": "On the map of Nürnberg you can find all acceptance points. Tap on a location to be able to see more information.",
     "usageTitle": "Where can I use my Nürnberg-Pass?",
     "welcomeDescription": "Thank you for downloading the app for the Nürnberg-Pass!"
+  },
+  "about": {
+    "title": "More"
   }
 }

--- a/frontend/build-configs/bayern/index.ts
+++ b/frontend/build-configs/bayern/index.ts
@@ -62,7 +62,8 @@ export const bayernCommon: CommonBuildConfigType = {
         "assets/bayern/intro_slides/search_with_location.png",
     ],
     featureFlags: {
-        verification: true
+        verification: true,
+        settings: false
     },
     applicationUrl: "https://bayern.ehrenamtskarte.app/beantragen",
     dataPrivacyPolicyUrl: "https://bayern.ehrenamtskarte.app/data-privacy-policy",

--- a/frontend/build-configs/nuernberg/index.ts
+++ b/frontend/build-configs/nuernberg/index.ts
@@ -62,7 +62,8 @@ export const nuernbergCommon: CommonBuildConfigType = {
         "assets/nuernberg/intro_slides/search_with_location.png",
     ],
     featureFlags: {
-        verification: true
+        verification: true,
+        settings: true
     },
     applicationUrl: "https://beantragen.nuernberg.sozialpass.app",
     publisherAddress:

--- a/frontend/build-configs/types.ts
+++ b/frontend/build-configs/types.ts
@@ -6,6 +6,7 @@ type BuildConfigType = {
 
 export type FeatureFlagsType = {
     verification: boolean
+    settings: boolean
 }
 
 export type ThemeType = {

--- a/frontend/lib/about/about_page.dart
+++ b/frontend/lib/about/about_page.dart
@@ -1,7 +1,9 @@
 import 'package:ehrenamtskarte/about/backend_switch_dialog.dart';
 import 'package:ehrenamtskarte/about/content_tile.dart';
 import 'package:ehrenamtskarte/about/dev_settings_view.dart';
+import 'package:ehrenamtskarte/about/language_change.dart';
 import 'package:ehrenamtskarte/about/license_page.dart';
+import 'package:ehrenamtskarte/about/section.dart';
 import 'package:ehrenamtskarte/about/texts.dart';
 import 'package:ehrenamtskarte/build_config/build_config.dart' show buildConfig;
 import 'package:ehrenamtskarte/configuration/configuration.dart';
@@ -95,53 +97,76 @@ class AboutPageState extends State<AboutPage> {
                 );
               },
             ),
+            if (buildConfig.featureFlags.settings)
+              Column(children: [
+                const Divider(
+                  height: 1,
+                  thickness: 1,
+                ),
+                Section(
+                  headline: t.about.settings.headline,
+                  children: [
+                    ContentTile(
+                        icon: Icons.language, title: t.about.settings.languageChange, children: [LanguageChange()]),
+                  ],
+                ),
+              ]),
             const Divider(
               height: 1,
               thickness: 1,
             ),
-            const SizedBox(height: 20),
-            ContentTile(icon: Icons.copyright, title: t.about.licenses(n: 1), children: getCopyrightText(context)),
-            ListTile(
-              leading: const Icon(Icons.privacy_tip_outlined),
-              title: Text(t.about.privacyDeclaration),
-              onTap: () => launchUrlString(buildConfig.dataPrivacyPolicyUrl, mode: LaunchMode.externalApplication),
-            ),
-            ContentTile(
-              icon: Icons.info_outline,
-              title: t.about.disclaimer,
-              children: getDisclaimerText(context),
-            ),
-            ListTile(
-              leading: const Icon(Icons.book_outlined),
-              title: Text(t.about.dependencies),
-              onTap: () {
-                Navigator.push(
-                  context,
-                  AppRoute(
-                    builder: (context) => const CustomLicensePage(),
-                  ),
-                );
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.code_outlined),
-              title: Text(t.about.sourceCode),
-              onTap: () {
-                launchUrlString(
-                  'https://github.com/digitalfabrik/entitlementcard',
-                  mode: LaunchMode.externalApplication,
-                );
-              },
-            ),
-            if (config.showDevSettings)
+            Section(headline: t.about.moreInformation, children: [
+              ContentTile(icon: Icons.copyright, title: t.about.licenses(n: 1), children: getCopyrightText(context)),
               ListTile(
-                leading: const Icon(Icons.build),
-                title: Text(t.about.developmentOptions),
-                onTap: () => showDialog(
-                  context: context,
-                  builder: (context) =>
-                      SimpleDialog(title: Text(t.about.developmentOptions), children: [DevSettingsView()]),
-                ),
+                leading: const Icon(Icons.privacy_tip_outlined),
+                title: Text(t.about.privacyDeclaration),
+                onTap: () => launchUrlString(buildConfig.dataPrivacyPolicyUrl, mode: LaunchMode.externalApplication),
+              ),
+              ContentTile(
+                icon: Icons.info_outline,
+                title: t.about.disclaimer,
+                children: getDisclaimerText(context),
+              ),
+              ListTile(
+                leading: const Icon(Icons.book_outlined),
+                title: Text(t.about.dependencies),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    AppRoute(
+                      builder: (context) => const CustomLicensePage(),
+                    ),
+                  );
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.code_outlined),
+                title: Text(t.about.sourceCode),
+                onTap: () {
+                  launchUrlString(
+                    'https://github.com/digitalfabrik/entitlementcard',
+                    mode: LaunchMode.externalApplication,
+                  );
+                },
+              ),
+            ]),
+            if (config.showDevSettings)
+              Column(
+                children: [
+                  const Divider(
+                    height: 1,
+                    thickness: 1,
+                  ),
+                  ListTile(
+                    leading: const Icon(Icons.build),
+                    title: Text(t.about.developmentOptions),
+                    onTap: () => showDialog(
+                      context: context,
+                      builder: (context) =>
+                          SimpleDialog(title: Text(t.about.developmentOptions), children: [DevSettingsView()]),
+                    ),
+                  )
+                ],
               )
           ];
         } else {

--- a/frontend/lib/about/language_change.dart
+++ b/frontend/lib/about/language_change.dart
@@ -1,0 +1,27 @@
+import 'package:ehrenamtskarte/build_config/build_config.dart' show buildConfig;
+import 'package:ehrenamtskarte/l10n/translations.g.dart';
+import 'package:flutter/material.dart';
+
+Map<String, String> languages = {'en': 'Englisch', 'de': 'Deutsch'};
+
+class LanguageChange extends StatelessWidget {
+  const LanguageChange({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(children: [
+      ...buildConfig.appLocales.map((item) => DecoratedBox(
+          decoration: BoxDecoration(
+              color: LocaleSettings.currentLocale.languageCode == item
+                  ? Theme.of(context).colorScheme.surfaceVariant
+                  : null),
+          child: ListTile(
+              title: Text(
+                languages[item]!,
+                textAlign: TextAlign.center,
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              onTap: () => LocaleSettings.setLocaleRaw(item))))
+    ]);
+  }
+}

--- a/frontend/lib/about/section.dart
+++ b/frontend/lib/about/section.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class Section extends StatelessWidget {
+  final String headline;
+  final List<Widget> children;
+
+  const Section({super.key, required this.headline, required this.children});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: EdgeInsets.only(top: 20, left: 20, right: 20),
+          child: Text(headline, style: TextStyle(color: Theme.of(context).colorScheme.primary)),
+        ),
+        Column(children: children),
+        const SizedBox(height: 10),
+      ],
+    );
+  }
+}

--- a/frontend/lib/home/home_page.dart
+++ b/frontend/lib/home/home_page.dart
@@ -55,8 +55,8 @@ class HomePageState extends State<HomePage> {
           (BuildContext context) => t.identification.title,
           GlobalKey<NavigatorState>(debugLabel: 'Auth tab key'),
         ),
-      AppFlow(const AboutPage(), Icons.info_outline, (BuildContext context) => t.about.title,
-          GlobalKey<NavigatorState>(debugLabel: 'About tab key')),
+      AppFlow(const AboutPage(), buildConfig.featureFlags.settings ? Icons.menu : Icons.info_outline,
+          (BuildContext context) => t.about.title, GlobalKey<NavigatorState>(debugLabel: 'About tab key')),
     ];
   }
 


### PR DESCRIPTION
### Short description

Since translations are available, the user want to switch the language in the app

### Proposed changes

- added a settings section with a language change
- adjusted the tabItem for sozialpass

### Side effects

- the title of the content page header is not affected when the language was changed. Everything else works properly. No clue why this is happening .

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1075
