### PR TITLE
1226: Fix duckerei cache

### DIFF
--- a/administration/public/index.html
+++ b/administration/public/index.html
@@ -4,6 +4,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <!-- Prevent index.html to be cached at all -->
+    <meta http-equiv="pragma" content="no-cache" />
+    <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate" />
   </head>
   <body>
     <script>


### PR DESCRIPTION
### Short description

After an update on some browsers the new version of the druckerei will not be loaded from the server but the old version from the cache. This issue leads to error with api interactions.

### Proposed changes

<!-- Describe this PR in more detail. -->

- add cache control headers in meta tags that avoid caching of the index.html file

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1226
