### PR TITLE
1238: Missing permission strings

### DIFF
--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -14,6 +14,11 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>de</string>
+	</array>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
@@ -28,12 +33,14 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>CFBundleLocalizations</key>
-    <array>
-       <string>en</string>
-       <string>de</string>
-    </array>
-
+	<key>NSCameraUsageDescription</key>
+	<string>Einlesen von QR-Codes.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Standort auf der Karte und Akzeptanzstellen in der Umgebung anzeigen.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Standort auf der Karte und Akzeptanzstellen in der Umgebung anzeigen.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Standort auf der Karte und Akzeptanzstellen in der Umgebung anzeigen.</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/ios/Runner/de.lproj/InfoPlist.strings
+++ b/frontend/ios/Runner/de.lproj/InfoPlist.strings
@@ -1,3 +1,4 @@
 NSCameraUsageDescription="Einlesen von QR-Codes";
 NSLocationAlwaysUsageDescription="Standort auf der Karte und Akzeptanzstellen in der Umgebung anzeigen";
 NSLocationWhenInUseUsageDescription="Standort auf der Karte und Akzeptanzstellen in der Umgebung anzeigen";
+NSLocationAlwaysAndWhenInUseUsageDescription="Standort auf der Karte und Akzeptanzstellen in der Umgebung anzeigen";

--- a/frontend/ios/Runner/en.lproj/InfoPlist.strings
+++ b/frontend/ios/Runner/en.lproj/InfoPlist.strings
@@ -1,3 +1,4 @@
 NSCameraUsageDescription="Scanning QR codes";
 NSLocationAlwaysUsageDescription="Show location on the map and acceptance points in the surrounding area";
 NSLocationWhenInUseUsageDescription="Show location on the map and acceptance points in the surrounding area";
+NSLocationAlwaysAndWhenInUseUsageDescription="Show location on the map and acceptance points in the surrounding area";


### PR DESCRIPTION
### Short description

Our app was rejected since apple couldn't find the permission strings, since they were moved to localizations. 

### Proposed changes

<!-- Describe this PR in more detail. -->

- readd the strings in info.plist
- added missing `NSLocationAlwaysAndWhenInUseUsageDescription` to localizations and info.plist



### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1238
