### PR TITLE
1173: Do not close camera on error

### DIFF
--- a/frontend/lib/identification/activation_workflow/activation_code_scanner_page.dart
+++ b/frontend/lib/identification/activation_workflow/activation_code_scanner_page.dart
@@ -53,6 +53,7 @@ class ActivationCodeScannerPage extends StatelessWidget {
       final activationCode = const ActivationCodeParser().parseQrCodeContent(code);
 
       await _activateCode(context, activationCode);
+      if (Navigator.canPop(context)) Navigator.maybePop(context);
     } on ActivationDidNotOverwriteExisting catch (_) {
       await showError(t.identification.cardAlreadyActivated, null);
     } on QrCodeFieldMissingException catch (e) {

--- a/frontend/lib/identification/qr_code_scanner/qr_code_scanner_page.dart
+++ b/frontend/lib/identification/qr_code_scanner/qr_code_scanner_page.dart
@@ -27,7 +27,5 @@ class QrCodeScannerPage extends StatelessWidget {
     } on QrCodeParseException catch (e, stackTrace) {
       debugPrintStack(stackTrace: stackTrace, label: e.toString());
     }
-
-    if (Navigator.canPop(context)) Navigator.maybePop(context);
   }
 }

--- a/frontend/lib/identification/qr_code_scanner/qr_parsing_error_dialog.dart
+++ b/frontend/lib/identification/qr_code_scanner/qr_parsing_error_dialog.dart
@@ -23,7 +23,7 @@ class QrParsingErrorDialog extends StatelessWidget {
         TextButton(
           child: Text(t.common.ok),
           onPressed: () {
-            Navigator.of(context).pop();
+            Navigator.of(context, rootNavigator: true).pop();
           },
         ),
       ],


### PR DESCRIPTION
### Short description
Camera is not closed after reading an invalid QRCode

### Proposed changes
- Move closing on success to activation_code_scanner_page
- Remove closing for every action from qr code scanner
- Close the correct page on dismissing the dialog

### Side effects
- Verification of cards with valid and invalid cards should work as previously

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1173
