### PR TITLE
1210: Add hint to contact person of organization

### DIFF
--- a/administration/src/mui-modules/application/forms/ApplicationForm.tsx
+++ b/administration/src/mui-modules/application/forms/ApplicationForm.tsx
@@ -81,7 +81,7 @@ const ApplicationForm: Form<State, Options, ValidatedInput, AdditionalProps> = {
       setState,
       'stepRequirements',
       { cardType: state.stepCardType.cardType.selectedValue },
-      {}
+      { applicantName: `${state.stepPersonalData.forenames.shortText} ${state.stepPersonalData.surname.shortText}` }
     )
     const sendStep = useFormAsStep(
       'Antrag Senden',

--- a/administration/src/mui-modules/application/forms/BlueCardEntitlementForm.tsx
+++ b/administration/src/mui-modules/application/forms/BlueCardEntitlementForm.tsx
@@ -42,7 +42,7 @@ const SubForms = {
 type State = CompoundState<typeof SubForms>
 type ValidatedInput = BlueCardEntitlementInput
 type Options = {}
-type AdditionalProps = {}
+type AdditionalProps = { applicantName: string }
 const BlueCardEntitlementForm: Form<State, Options, ValidatedInput, AdditionalProps> = {
   initialState: createCompoundInitialState(SubForms),
   getArrayBufferKeys: createCompoundGetArrayBufferKeys(SubForms),
@@ -53,7 +53,7 @@ const BlueCardEntitlementForm: Form<State, Options, ValidatedInput, AdditionalPr
     WORK_AT_DEPARTMENT: 'workAtDepartmentEntitlement',
     WORK_AT_ORGANIZATIONS: 'workAtOrganizationsEntitlement',
   }),
-  Component: ({ state, setState }) => (
+  Component: ({ state, setState, applicantName }) => (
     <>
       <SubForms.entitlementType.Component
         state={state.entitlementType}
@@ -68,6 +68,7 @@ const BlueCardEntitlementForm: Form<State, Options, ValidatedInput, AdditionalPr
             <SubForms.workAtOrganizationsEntitlement.Component
               state={state.workAtOrganizationsEntitlement}
               setState={useUpdateStateCallback(setState, 'workAtOrganizationsEntitlement')}
+              applicantName={applicantName}
             />
           ),
           [BlueCardEntitlementType.Juleica]: (
@@ -80,6 +81,7 @@ const BlueCardEntitlementForm: Form<State, Options, ValidatedInput, AdditionalPr
             <SubForms.workAtDepartmentEntitlement.Component
               state={state.workAtDepartmentEntitlement}
               setState={useUpdateStateCallback(setState, 'workAtDepartmentEntitlement')}
+              applicantName={applicantName}
             />
           ),
           [BlueCardEntitlementType.MilitaryReserve]: (

--- a/administration/src/mui-modules/application/forms/GoldenCardEntitlementForm.tsx
+++ b/administration/src/mui-modules/application/forms/GoldenCardEntitlementForm.tsx
@@ -40,7 +40,7 @@ const SubForms = {
 type State = CompoundState<typeof SubForms>
 type ValidatedInput = GoldenCardEntitlementInput
 type Options = {}
-type AdditionalProps = {}
+type AdditionalProps = { applicantName: string }
 const GoldenCardEntitlementForm: Form<State, Options, ValidatedInput, AdditionalProps> = {
   initialState: createCompoundInitialState(SubForms),
   getArrayBufferKeys: createCompoundGetArrayBufferKeys(SubForms),
@@ -50,7 +50,7 @@ const GoldenCardEntitlementForm: Form<State, Options, ValidatedInput, Additional
     MILITARY_RESERVE: 'militaryReserveEntitlement',
     HONORED_BY_MINISTER_PRESIDENT: 'honoredByMinisterPresidentEntitlement',
   }),
-  Component: ({ state, setState }) => (
+  Component: ({ state, setState, applicantName }) => (
     <>
       <SubForms.entitlementType.Component
         state={state.entitlementType}
@@ -65,6 +65,7 @@ const GoldenCardEntitlementForm: Form<State, Options, ValidatedInput, Additional
             <SubForms.workAtOrganizationsEntitlement.Component
               state={state.workAtOrganizationsEntitlement}
               setState={useUpdateStateCallback(setState, 'workAtOrganizationsEntitlement')}
+              applicantName={applicantName}
             />
           ),
           [GoldenCardEntitlementType.HonoredByMinisterPresident]: (
@@ -77,6 +78,7 @@ const GoldenCardEntitlementForm: Form<State, Options, ValidatedInput, Additional
             <SubForms.workAtDepartmentEntitlement.Component
               state={state.workAtDepartmentEntitlement}
               setState={useUpdateStateCallback(setState, 'workAtDepartmentEntitlement')}
+              applicantName={applicantName}
             />
           ),
           [GoldenCardEntitlementType.MilitaryReserve]: (

--- a/administration/src/mui-modules/application/forms/OrganizationForm.tsx
+++ b/administration/src/mui-modules/application/forms/OrganizationForm.tsx
@@ -1,3 +1,5 @@
+import { Alert, Typography } from '@mui/material'
+
 import { OrganizationInput } from '../../../generated/graphql'
 import { useUpdateStateCallback } from '../hooks/useUpdateStateCallback'
 import CheckboxForm from '../primitive-inputs/CheckboxForm'
@@ -51,7 +53,7 @@ const getValidatedCompoundInput = createCompoundValidate(SubForms, {
 type State = CompoundState<typeof SubForms>
 type ValidatedInput = OrganizationInput
 type Options = {}
-type AdditionalProps = {}
+type AdditionalProps = { applicantName: string }
 const OrganizationForm: Form<State, Options, ValidatedInput, AdditionalProps> = {
   initialState: createCompoundInitialState(SubForms),
   getArrayBufferKeys: createCompoundGetArrayBufferKeys(SubForms),
@@ -73,7 +75,7 @@ const OrganizationForm: Form<State, Options, ValidatedInput, AdditionalProps> = 
       },
     }
   },
-  Component: ({ state, setState }) => (
+  Component: ({ state, setState, applicantName }) => (
     <>
       <h4>Angaben zur Organisation</h4>
       <ShortTextForm.Component
@@ -88,11 +90,17 @@ const OrganizationForm: Form<State, Options, ValidatedInput, AdditionalProps> = 
         label='Einsatzgebiet'
         options={organizationCategoryOptions}
       />
-      <h4>Kontaktperson der Organisation</h4>
+      <h4>Kontaktperson in der Organisation</h4>
+      <Typography>
+        Bitte geben Sie hier die Daten der Person an, die ihr ehrenamtliches Engagement bestätigen kann.
+      </Typography>
+      {applicantName === state.contactName.shortText && (
+        <Alert severity='warning'>Die Kontaktperson in der Organisation darf nicht der Antragssteller sein.</Alert>
+      )}
       <ShortTextForm.Component
         state={state.contactName}
         setState={useUpdateStateCallback(setState, 'contactName')}
-        label='Vor- und Nachname'
+        label='Vor- und Nachname der Kontaktperson in der Organisation'
       />
       <EmailForm.Component
         state={state.contactEmail}

--- a/administration/src/mui-modules/application/forms/OrganizationForm.tsx
+++ b/administration/src/mui-modules/application/forms/OrganizationForm.tsx
@@ -1,4 +1,4 @@
-import { Alert, Typography } from '@mui/material'
+import { Alert, Typography, styled } from '@mui/material'
 
 import { OrganizationInput } from '../../../generated/graphql'
 import { useUpdateStateCallback } from '../hooks/useUpdateStateCallback'
@@ -14,6 +14,10 @@ import {
   createCompoundValidate,
 } from '../util/compoundFormUtils'
 import AddressForm from './AddressForm'
+
+const WarningContactPersonSamePerson = styled(Alert)`
+  margin: 8px 0;
+`
 
 const organizationCategoryOptions = {
   items: [
@@ -95,7 +99,9 @@ const OrganizationForm: Form<State, Options, ValidatedInput, AdditionalProps> = 
         Bitte geben Sie hier die Daten der Person an, die ihr ehrenamtliches Engagement bestätigen kann.
       </Typography>
       {applicantName === state.contactName.shortText && (
-        <Alert severity='warning'>Die Kontaktperson in der Organisation darf nicht der Antragssteller sein.</Alert>
+        <WarningContactPersonSamePerson severity='warning'>
+          Die Kontaktperson in der Organisation darf nicht der Antragssteller sein.
+        </WarningContactPersonSamePerson>
       )}
       <ShortTextForm.Component
         state={state.contactName}

--- a/administration/src/mui-modules/application/forms/StepRequirementsForm.tsx
+++ b/administration/src/mui-modules/application/forms/StepRequirementsForm.tsx
@@ -15,7 +15,7 @@ type ValidatedInput =
   | { type: BavariaCardType.Blue; value: BlueCardEntitlementInput }
   | { type: BavariaCardType.Golden; value: GoldenCardEntitlementInput }
 type Options = { cardType: BavariaCardType | null }
-type AdditionalProps = {}
+type AdditionalProps = { applicantName: string }
 const StepRequirementsForm: Form<StepRequirementsFormState, Options, ValidatedInput, AdditionalProps> = {
   initialState: createCompoundInitialState(SubForms),
   getArrayBufferKeys: createCompoundGetArrayBufferKeys(SubForms),
@@ -35,19 +35,21 @@ const StepRequirementsForm: Form<StepRequirementsFormState, Options, ValidatedIn
         return { type: 'error' }
     }
   },
-  Component: ({ state, setState, options }) => (
+  Component: ({ state, setState, options, applicantName }) => (
     <SwitchComponent value={options.cardType}>
       {{
         [BavariaCardType.Blue]: (
           <SubForms.blueCardEntitlement.Component
             state={state.blueCardEntitlement}
             setState={useUpdateStateCallback(setState, 'blueCardEntitlement')}
+            applicantName={applicantName}
           />
         ),
         [BavariaCardType.Golden]: (
           <SubForms.goldenCardEntitlement.Component
             state={state.goldenCardEntitlement}
             setState={useUpdateStateCallback(setState, 'goldenCardEntitlement')}
+            applicantName={applicantName}
           />
         ),
       }}

--- a/administration/src/mui-modules/application/forms/WorkAtDepartmentEntitlementForm.tsx
+++ b/administration/src/mui-modules/application/forms/WorkAtDepartmentEntitlementForm.tsx
@@ -21,17 +21,18 @@ const SubForms = {
 type State = CompoundState<typeof SubForms>
 type ValidatedInput = BlueCardWorkAtDepartmentEntitlementInput
 type Options = {}
-type AdditionalProps = {}
+type AdditionalProps = { applicantName: string }
 const WorkAtDepartmentEntitlementForm: Form<State, Options, ValidatedInput, AdditionalProps> = {
   initialState: createCompoundInitialState(SubForms),
   getArrayBufferKeys: createCompoundGetArrayBufferKeys(SubForms),
   validate: createCompoundValidate(SubForms, {}),
-  Component: ({ state, setState }) => (
+  Component: ({ state, setState, applicantName }) => (
     <>
       <CustomDivider label='Angaben zur Tätigkeit' />
       <SubForms.organization.Component
         state={state.organization}
         setState={useUpdateStateCallback(setState, 'organization')}
+        applicantName={applicantName}
       />
       <h4>Angaben zur Tätigkeit</h4>
       <SubForms.responsibility.Component

--- a/administration/src/mui-modules/application/forms/WorkAtOrganizationForm.tsx
+++ b/administration/src/mui-modules/application/forms/WorkAtOrganizationForm.tsx
@@ -55,7 +55,7 @@ const SubForms = {
 type State = CompoundState<typeof SubForms>
 type ValidatedInput = WorkAtOrganizationInput
 type Options = {}
-type AdditionalProps = { onDelete?: () => void }
+type AdditionalProps = { onDelete?: () => void; applicantName: string }
 const WorkAtOrganizationForm: Form<State, Options, ValidatedInput, AdditionalProps> = {
   initialState: createCompoundInitialState(SubForms),
   getArrayBufferKeys: createCompoundGetArrayBufferKeys(SubForms),
@@ -64,7 +64,7 @@ const WorkAtOrganizationForm: Form<State, Options, ValidatedInput, AdditionalPro
     payment: paymentOptions,
     workSinceDate: { maximumDate: null },
   }),
-  Component: ({ state, setState, onDelete }) => (
+  Component: ({ state, setState, onDelete, applicantName }) => (
     <>
       <ActivityDivider onDelete={onDelete} />
       <h4>Angaben zu Ihrer ehrenamtlichen Tätigkeit</h4>
@@ -95,6 +95,7 @@ const WorkAtOrganizationForm: Form<State, Options, ValidatedInput, AdditionalPro
       <SubForms.organization.Component
         state={state.organization}
         setState={useUpdateStateCallback(setState, 'organization')}
+        applicantName={applicantName}
       />
       <SubForms.payment.Component
         state={state.payment}

--- a/administration/src/mui-modules/application/forms/WorkAtOrganizationsEntitlementForm.tsx
+++ b/administration/src/mui-modules/application/forms/WorkAtOrganizationsEntitlementForm.tsx
@@ -14,11 +14,13 @@ const WorkAtOrganizationFormHelper = ({
   listKey,
   setStateByKey,
   deleteByKey,
+  applicantName,
   ...otherProps
 }: {
   listKey: number
   setStateByKey: (key: number) => SetState<WorkAtOrganizationFormState>
   deleteByKey?: (key: number) => void
+  applicantName: string
   state: WorkAtOrganizationFormState
 }) => {
   const setState = useMemo(() => setStateByKey(listKey), [setStateByKey, listKey])
@@ -26,7 +28,14 @@ const WorkAtOrganizationFormHelper = ({
     () => (deleteByKey === undefined ? undefined : () => deleteByKey(listKey)),
     [deleteByKey, listKey]
   )
-  return <WorkAtOrganizationForm.Component setState={setState} onDelete={onDelete} {...otherProps} />
+  return (
+    <WorkAtOrganizationForm.Component
+      setState={setState}
+      onDelete={onDelete}
+      applicantName={applicantName}
+      {...otherProps}
+    />
+  )
 }
 
 function replaceAt<T>(array: T[], index: number, newItem: T): T[] {
@@ -44,7 +53,7 @@ function removeAt<T>(array: T[], index: number): T[] {
 type State = { key: number; value: WorkAtOrganizationFormState }[]
 type ValidatedInput = BlueCardWorkAtOrganizationsEntitlementInput
 type Options = {}
-type AdditionalProps = {}
+type AdditionalProps = { applicantName: string }
 const WorkAtOrganizationsEntitlementForm: Form<State, Options, ValidatedInput, AdditionalProps> = {
   initialState: [{ key: 0, value: WorkAtOrganizationForm.initialState }],
   getArrayBufferKeys: state => state.map(({ value }) => WorkAtOrganizationForm.getArrayBufferKeys(value)).flat(),
@@ -65,7 +74,7 @@ const WorkAtOrganizationsEntitlementForm: Form<State, Options, ValidatedInput, A
       },
     }
   },
-  Component: ({ state, setState }) => {
+  Component: ({ state, setState, applicantName }) => {
     const addActivity = () =>
       setState(state => {
         const newKey = Math.max(...state.map(({ key }) => key), 0) + 1
@@ -101,6 +110,7 @@ const WorkAtOrganizationsEntitlementForm: Form<State, Options, ValidatedInput, A
             state={value}
             deleteByKey={deleteByKey}
             setStateByKey={setStateByKey}
+            applicantName={applicantName}
           />
         ))}
         <CustomDivider />


### PR DESCRIPTION
### Short description

Currently it is possible to set yourself as contact person in an application. The user should be informed that this will very likely not lead to a successful application.

### Proposed changes

<!-- Describe this PR in more detail. -->

- added hint about who this person is supposed to be
- added hint when applicant names are identical to the contact persons name

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1210 