### PR TITLE
Fix cache path for fvm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
                       echo "The CircleCI config is up to date."
                       exit 0;
                     else
-                      echo "The CircleCI config is not up to date. You can update it by running `yarn run circleci:update-config`."
+                      echo "The CircleCI config is not up to date. You can update it by running the `./scripts/circleci-update-config.sh` script."
                       exit 1;
                     fi
                 name: CircleCI config up to date
@@ -80,7 +80,6 @@ commands:
                 paths:
                     - .fvm
                     - ~/fvm/
-                working_directory: ~/project/frontend/
             - run:
                 command: fvm flutter --version
                 name: Show Flutter version
@@ -468,27 +467,31 @@ jobs:
             - run:
                 command: fvm flutter pub get --enforce-lockfile
                 name: Install Flutter Packages
+                working_directory: ~/project/frontend/
             - run:
                 command: fvm dart format -l 120 -o none --set-exit-if-changed .
                 name: Check Formatting
+                working_directory: ~/project/frontend/
             - run:
                 command: |
                     # Statically use "bayern" build config for analyzing here
                     fvm flutter pub run build_runner build --define "df_build_config=name=bayern"
                 name: Build Runner
+                working_directory: ~/project/frontend/
             - run:
                 command: |
                     fvm flutter analyze --fatal-infos --fatal-warnings
                     fvm flutter analyze pubs/df_build_config --fatal-infos --fatal-warnings
                     fvm flutter analyze pubs/df_protobuf --fatal-infos --fatal-warnings
                 name: Check Analyzer and Linting
+                working_directory: ~/project/frontend/
             - run:
-                command: |-
+                command: |
                     fvm flutter test
                     fvm flutter test pubs/df_build_config
                     fvm flutter test pubs/df_protobuf
                 name: Tests
-        working_directory: ~/project/frontend
+                working_directory: ~/project/frontend/
     check_health_backend:
         docker:
             - image: cimg/base:2023.03

--- a/.circleci/src/commands/check_circleci_config.yml
+++ b/.circleci/src/commands/check_circleci_config.yml
@@ -20,7 +20,7 @@ steps:
           echo "The CircleCI config is up to date."
           exit 0;
         else
-          echo "The CircleCI config is not up to date. You can update it by running `yarn run circleci:update-config`."
+          echo "The CircleCI config is not up to date. You can update it by running the `./scripts/circleci-update-config.sh` script."
           exit 1;
         fi
   - run:

--- a/.circleci/src/commands/install_fvm.yml
+++ b/.circleci/src/commands/install_fvm.yml
@@ -17,7 +17,6 @@ steps:
       paths:
         - .fvm
         - ~/fvm/
-      working_directory: ~/project/frontend/
   - run:
       name: Show Flutter version
       command: fvm flutter --version

--- a/.circleci/src/jobs/check_frontend.yml
+++ b/.circleci/src/jobs/check_frontend.yml
@@ -1,7 +1,6 @@
 docker:
   - image: cimg/node:19.1.0-browsers
 resource_class: small
-working_directory: ~/project/frontend
 steps:
   - checkout:
       path: ~/project
@@ -13,23 +12,28 @@ steps:
   - run:
       name: Install Flutter Packages
       command: fvm flutter pub get --enforce-lockfile
+      working_directory: ~/project/frontend/
   - run:
       name: Check Formatting
       command: fvm dart format -l 120 -o none --set-exit-if-changed .
+      working_directory: ~/project/frontend/
   - run:
       name: Build Runner
       command: |
         # Statically use "bayern" build config for analyzing here
         fvm flutter pub run build_runner build --define "df_build_config=name=bayern"
+      working_directory: ~/project/frontend/
   - run:
       name: Check Analyzer and Linting
       command: |
         fvm flutter analyze --fatal-infos --fatal-warnings
         fvm flutter analyze pubs/df_build_config --fatal-infos --fatal-warnings
         fvm flutter analyze pubs/df_protobuf --fatal-infos --fatal-warnings
+      working_directory: ~/project/frontend/
   - run:
       name: Tests
       command: |
         fvm flutter test
         fvm flutter test pubs/df_build_config
         fvm flutter test pubs/df_protobuf
+      working_directory: ~/project/frontend/


### PR DESCRIPTION
### Short description

The whole `check_frontend` job was running from working directory `frontend`. While the `build_android` and `build_ios` were not. This lead to the result that the cached file at `frontend/.fvm

### Proposed changes

<!-- Describe this PR in more detail. -->

- remove working directory from `check_frontend` job
- add working directory to the commands instead
