### PR TITLE
1265: Workaround empty secure storage

### DIFF
--- a/frontend/lib/identification/user_code_store.dart
+++ b/frontend/lib/identification/user_code_store.dart
@@ -34,8 +34,10 @@ class UserCodeStore {
       String? userCodesBase64FirstRead = await storage.read(key: _userCodesBase64Key);
       userCodesBase64 = await storage.read(key: _userCodesBase64Key);
       // report error if first read is null but second read contains data to collect sentry data for reproduction
-      if (userCodesBase64FirstRead == null && userCodesBase64 != null) {
-        reportError('First read from secure storage is null but user data exists', null);
+      if (userCodesBase64FirstRead != userCodesBase64) {
+        bool firstIsNull = userCodesBase64FirstRead == null;
+        bool secondIsNull = userCodesBase64 == null;
+        reportError("First read from secure storage differs from second: firstNull=${firstIsNull}, secondNull=${secondIsNull}", null);
       }
     } else {
       userCodesBase64 = await storage.read(key: _userCodesBase64Key);

--- a/frontend/lib/identification/user_code_store.dart
+++ b/frontend/lib/identification/user_code_store.dart
@@ -37,7 +37,9 @@ class UserCodeStore {
       if (userCodesBase64FirstRead != userCodesBase64) {
         bool firstIsNull = userCodesBase64FirstRead == null;
         bool secondIsNull = userCodesBase64 == null;
-        reportError("First read from secure storage differs from second: firstNull=${firstIsNull}, secondNull=${secondIsNull}", null);
+        reportError(
+            'First read from secure storage differs from second: firstNull=$firstIsNull, secondNull=$secondIsNull',
+            null);
       }
     } else {
       userCodesBase64 = await storage.read(key: _userCodesBase64Key);

--- a/frontend/lib/identification/user_code_store.dart
+++ b/frontend/lib/identification/user_code_store.dart
@@ -1,16 +1,20 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:ehrenamtskarte/identification/user_code_model.dart';
 import 'package:ehrenamtskarte/proto/card.pb.dart';
+import 'package:ehrenamtskarte/sentry.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 class UserCodeStore {
   const UserCodeStore();
 
   static const _userCodesBase64Key = 'userCodesBase64';
+
   // legacy key for single card
   static const _userCodeBase64Key = 'userCodeBase64';
   static const _storageDelimiter = ',';
+
   Future<void> store(List<DynamicUserCode> userCodes) async {
     const storage = FlutterSecureStorage();
     Iterable<String> userCodeString = userCodes.map((code) => const Base64Encoder().convert(code.writeToBuffer()));
@@ -24,7 +28,19 @@ class UserCodeStore {
 
   Future<List<DynamicUserCode>> load() async {
     const storage = FlutterSecureStorage();
-    final String? userCodesBase64 = await storage.read(key: _userCodesBase64Key);
+    String? userCodesBase64;
+    // make fake read on android - workaround for https://github.com/mogol/flutter_secure_storage/issues/653
+    if (Platform.isAndroid) {
+      String? userCodesBase64FirstRead = await storage.read(key: _userCodesBase64Key);
+      userCodesBase64 = await storage.read(key: _userCodesBase64Key);
+      // report error if first read is null but second read contains data to collect sentry data for reproduction
+      if (userCodesBase64FirstRead == null && userCodesBase64 != null) {
+        reportError('First read from secure storage is null but user data exists', null);
+      }
+    } else {
+      userCodesBase64 = await storage.read(key: _userCodesBase64Key);
+    }
+
     if (userCodesBase64 == null) return [];
     return userCodesBase64
         .split(_storageDelimiter)


### PR DESCRIPTION
### Short description

We are facing some not reproducible issue on android devices that the user data (stored cards) can't be read from secure storage after app restart. This relies on an issue from `flutter secure storage`
https://github.com/mogol/flutter_secure_storage/issues/653
Some devs report that a fake read could solve this issue.

### Proposed changes
- add a fake read for android devices
- add a second read for android devices that may contain the user data
- report error to sentry if first read is null but second read contains data to collect more information

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- the initialization of the cards may be a bit slower for android but it shouldn't be a big performance issue

### Resolved issues

related to #1265

**Note:** We have to contact users that facing the issue if it was solved by this workaround, since we can not really test it
Just test if a saved card will be restored/loaded (still) properly 