### PR TITLE
850: Increase allowed email length to 254

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/Schema.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/Schema.kt
@@ -14,7 +14,7 @@ import org.jetbrains.exposed.sql.lowerCase
 import org.jetbrains.exposed.sql.or
 
 object Administrators : IntIdTable() {
-    val email = varchar("email", 100)
+    val email = varchar("email", 254)
     val projectId = reference("projectId", Projects)
     val regionId = optReference("regionId", Regions)
     val role = varchar("role", 32)

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/MigrationsRegistry.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/MigrationsRegistry.kt
@@ -8,6 +8,7 @@ object MigrationsRegistry {
         V0004_AddNotificationSettings(),
         V0005_AddRegionApplicationActivation(),
         V0006_AddStoreCreatedDate(),
-        V0007_AddStartDay()
+        V0007_AddStartDay(),
+        V0008_IncreaseAdministratorEmailLength()
     )
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/V0008_IncreaseAdministratorEmailLength.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/V0008_IncreaseAdministratorEmailLength.kt
@@ -1,0 +1,17 @@
+package app.ehrenamtskarte.backend.migration.migrations
+
+import app.ehrenamtskarte.backend.migration.Migration
+import app.ehrenamtskarte.backend.migration.Statement
+
+/**
+ * Increase email varchar length to 254.
+ */
+class V0008_IncreaseAdministratorEmailLength: Migration() {
+    override val migrate: Statement = {
+        exec(
+            """
+            ALTER TABLE administrators ALTER COLUMN "email" TYPE character varying(254);
+            """.trimIndent()
+        )
+    }
+}


### PR DESCRIPTION
### Short description

Apparently emails can be longer than 100 characters. An email length of 254 characters can be considered the maximum length, therefore this PR increases the allowed length to 254.

### Proposed changes

<!-- Describe this PR in more detail. -->

- add migration to increase allowed email length

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #850 