### PR TITLE
Construct GoRouter only once to prevent tree recreation on settings change

### DIFF
--- a/frontend/lib/about/language_change.dart
+++ b/frontend/lib/about/language_change.dart
@@ -31,7 +31,7 @@ class LanguageChange extends StatelessWidget {
     final settings = Provider.of<SettingsModel>(context, listen: false);
     LocaleSettings.setLocaleRaw(language);
     settings.setLanguage(language: language);
-    Navigator.of(context).pop(true);
+    Navigator.of(context).pop();
     messengerState.showSnackBar(
       SnackBar(
         backgroundColor: Theme.of(context).colorScheme.primary,

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -46,12 +46,6 @@ final GoRouter router = GoRouter(
       ],
     ),
     GoRoute(
-      path: homeRouteName,
-      builder: (BuildContext context, GoRouterState state) {
-        return HomePage(initialTabIndex: int.parse(state.pathParameters[homeRouteParamTabIndexName]!));
-      },
-    ),
-    GoRoute(
       path: '$homeRouteName/:$homeRouteParamTabIndexName',
       builder: (BuildContext context, GoRouterState state) {
         return HomePage(initialTabIndex: int.parse(state.pathParameters[homeRouteParamTabIndexName]!));

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -23,6 +23,46 @@ const homeRouteParamTabIndexName = 'tabIndex';
 const homeRouteName = '/home';
 const introRouteName = '/intro';
 
+final GoRouter router = GoRouter(
+  routes: <RouteBase>[
+    GoRoute(
+      path: initialRouteName,
+      builder: (BuildContext context, GoRouterState state) {
+        final settings = Provider.of<SettingsModel>(context);
+        return settings.firstStart
+            ? IntroScreen(
+                onFinishedCallback: () => settings.setFirstStart(enabled: false),
+              )
+            : HomePage();
+      },
+      routes: [
+        GoRoute(
+          path: '$activationRouteName/:$activationRouteCodeParamName',
+          builder: (BuildContext context, GoRouterState state) {
+            print(state.uri.fragment);
+            return DeepLinkActivation(base64qrcode: Uri.decodeFull(state.uri.fragment));
+          },
+        ),
+      ],
+    ),
+    GoRoute(
+      path: '$homeRouteName/:$homeRouteParamTabIndexName',
+      builder: (BuildContext context, GoRouterState state) {
+        return HomePage(initialTabIndex: int.parse(state.pathParameters[homeRouteParamTabIndexName]!));
+      },
+    ),
+    GoRoute(
+      path: introRouteName,
+      builder: (BuildContext context, GoRouterState state) {
+        final settings = Provider.of<SettingsModel>(context, listen: false);
+        return IntroScreen(
+          onFinishedCallback: () => settings.setFirstStart(enabled: false),
+        );
+      },
+    ),
+  ],
+);
+
 class App extends StatelessWidget {
   const App({super.key});
 
@@ -50,44 +90,6 @@ class App extends StatelessWidget {
         : isLocal()
             ? buildConfig.projectId.local
             : buildConfig.projectId.showcase;
-
-    final GoRouter router = GoRouter(
-      routes: <RouteBase>[
-        GoRoute(
-          path: initialRouteName,
-          builder: (BuildContext context, GoRouterState state) {
-            return settings.firstStart
-                ? IntroScreen(
-                    onFinishedCallback: () => settings.setFirstStart(enabled: false),
-                  )
-                : HomePage();
-          },
-          routes: [
-            GoRoute(
-              path: '$activationRouteName/:$activationRouteCodeParamName',
-              builder: (BuildContext context, GoRouterState state) {
-                print(state.uri.fragment);
-                return DeepLinkActivation(base64qrcode: Uri.decodeFull(state.uri.fragment));
-              },
-            ),
-          ],
-        ),
-        GoRoute(
-          path: '$homeRouteName/:$homeRouteParamTabIndexName',
-          builder: (BuildContext context, GoRouterState state) {
-            return HomePage(initialTabIndex: int.parse(state.pathParameters[homeRouteParamTabIndexName]!));
-          },
-        ),
-        GoRoute(
-          path: introRouteName,
-          builder: (BuildContext context, GoRouterState state) {
-            return IntroScreen(
-              onFinishedCallback: () => settings.setFirstStart(enabled: false),
-            );
-          },
-        ),
-      ],
-    );
 
     // Load default language from settings
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -46,6 +46,11 @@ final GoRouter router = GoRouter(
       ],
     ),
     GoRoute(
+        path: homeRouteName,
+        builder: (BuildContext context, GoRouterState state) {
+          return HomePage();
+        }),
+    GoRoute(
       path: '$homeRouteName/:$homeRouteParamTabIndexName',
       builder: (BuildContext context, GoRouterState state) {
         return HomePage(initialTabIndex: int.parse(state.pathParameters[homeRouteParamTabIndexName]!));


### PR DESCRIPTION
### Short description

After #179, the whole app tree was constantly recreated if the location feature was enabled.
This was because GoRouter recreated the whole app tree every time any the settingsmodel notified about changes. 

### Proposed changes

Do not recreate GoRouter after every Settings change. It seems this is the recommended way to use GoRouter.
(see this sample usage https://github.com/flutter/packages/blob/main/packages/go_router/example/lib/main.dart)

### Side effects

Hopefully none, except for fixing the bug.
