### PR TITLE
1170: Use root navigator when pushing subroutes

### DIFF
--- a/frontend/analysis_options.yaml
+++ b/frontend/analysis_options.yaml
@@ -163,6 +163,7 @@ linter:
     sort_pub_dependencies: false
 
     prefer_single_quotes: true
+    always_use_package_imports: true
 
     # TODO: Enable in #435
     use_build_context_synchronously: false

--- a/frontend/lib/about/about_page.dart
+++ b/frontend/lib/about/about_page.dart
@@ -89,8 +89,7 @@ class AboutPageState extends State<AboutPage> {
                 ),
               ),
               onTap: () {
-                Navigator.push(
-                  context,
+                Navigator.of(context, rootNavigator: true).push(
                   AppRoute(
                     builder: (context) => ContentPage(title: t.about.publisher, children: getPublisherText(context)),
                   ),
@@ -130,8 +129,7 @@ class AboutPageState extends State<AboutPage> {
                 leading: const Icon(Icons.book_outlined),
                 title: Text(t.about.dependencies),
                 onTap: () {
-                  Navigator.push(
-                    context,
+                  Navigator.of(context, rootNavigator: true).push(
                     AppRoute(
                       builder: (context) => const CustomLicensePage(),
                     ),

--- a/frontend/lib/about/content_tile.dart
+++ b/frontend/lib/about/content_tile.dart
@@ -15,8 +15,7 @@ class ContentTile extends StatelessWidget {
   }
 
   void _showContent(BuildContext context) {
-    Navigator.push(
-      context,
+    Navigator.of(context, rootNavigator: true).push(
       AppRoute(
         builder: (context) => ContentPage(title: title, children: children),
       ),

--- a/frontend/lib/about/language_change.dart
+++ b/frontend/lib/about/language_change.dart
@@ -1,8 +1,6 @@
 import 'package:ehrenamtskarte/build_config/build_config.dart' show buildConfig;
 import 'package:ehrenamtskarte/configuration/settings_model.dart';
-import 'package:ehrenamtskarte/home/home_page.dart';
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
-import 'package:ehrenamtskarte/routing.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -28,17 +26,12 @@ class LanguageChange extends StatelessWidget {
     ]);
   }
 
-  switchLanguage(BuildContext context, String language) {
+  Future<void> switchLanguage(BuildContext context, String language) async {
     final messengerState = ScaffoldMessenger.of(context);
     final settings = Provider.of<SettingsModel>(context, listen: false);
     LocaleSettings.setLocaleRaw(language);
-    settings.setLanguage(language: language);
-    Navigator.push(
-      context,
-      AppRoute(
-        builder: (context) => HomePage(),
-      ),
-    );
+    await settings.setLanguage(language: language);
+    Navigator.pop(context);
     messengerState.showSnackBar(
       SnackBar(
         backgroundColor: Theme.of(context).colorScheme.primary,

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -14,7 +14,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
-import 'home/home_page.dart';
+import 'package:ehrenamtskarte/home/home_page.dart';
 
 const initialRouteName = '/';
 const activationRouteCodeParamName = 'base64qrcode';

--- a/frontend/lib/identification/card_detail_view/card_detail_view.dart
+++ b/frontend/lib/identification/card_detail_view/card_detail_view.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
-import 'verification_code_view.dart';
+import 'package:ehrenamtskarte/identification/card_detail_view/verification_code_view.dart';
 
 class CardDetailView extends StatefulWidget {
   final DynamicUserCode userCode;

--- a/frontend/lib/identification/card_detail_view/self_verify_card.dart
+++ b/frontend/lib/identification/card_detail_view/self_verify_card.dart
@@ -3,10 +3,10 @@ import 'package:flutter/widgets.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:provider/provider.dart';
 
-import '../../proto/card.pb.dart';
-import '../../util/date_utils.dart';
-import '../otp_generator.dart';
-import '../verification_workflow/query_server_verification.dart';
+import 'package:ehrenamtskarte/proto/card.pb.dart';
+import 'package:ehrenamtskarte/util/date_utils.dart';
+import 'package:ehrenamtskarte/identification/otp_generator.dart';
+import 'package:ehrenamtskarte/identification/verification_workflow/query_server_verification.dart';
 
 Future<void> selfVerifyCard(
     BuildContext context, DynamicUserCode? userCode, String projectId, GraphQLClient client) async {

--- a/frontend/lib/intro_slides/intro_screen.dart
+++ b/frontend/lib/intro_slides/intro_screen.dart
@@ -6,7 +6,7 @@ import 'package:intro_slider/intro_slider.dart';
 
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
 
-import '../app.dart';
+import 'package:ehrenamtskarte/app.dart';
 
 typedef OnFinishedCallback = void Function();
 

--- a/frontend/lib/map/preview/accepting_store_preview_card.dart
+++ b/frontend/lib/map/preview/accepting_store_preview_card.dart
@@ -54,7 +54,7 @@ class AcceptingStorePreviewCard extends StatelessWidget {
                       store: currentAcceptingStore,
                       showLocation: false,
                       key: ValueKey(currentAcceptingStore.id),
-                      showMapButtonOnDetails: false,
+                      showOnMap: null,
                     ),
         ),
       ),

--- a/frontend/lib/search/results_loader.dart
+++ b/frontend/lib/search/results_loader.dart
@@ -8,7 +8,7 @@ import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
 
-import '../home/home_page.dart';
+import 'package:ehrenamtskarte/home/home_page.dart';
 
 class ResultsLoader extends StatefulWidget {
   final CoordinatesInput? coordinates;

--- a/frontend/lib/search/results_loader.dart
+++ b/frontend/lib/search/results_loader.dart
@@ -8,6 +8,8 @@ import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
 
+import '../home/home_page.dart';
+
 class ResultsLoader extends StatefulWidget {
   final CoordinatesInput? coordinates;
   final String? searchText;
@@ -126,7 +128,7 @@ class ResultsLoaderState extends State<ResultsLoader> {
                 item.physicalStore?.address.location,
               ),
               coordinates: widget.coordinates,
-              showMapButtonOnDetails: true,
+              showOnMap: (it) => HomePageData.of(context)?.navigateToMapTab(it),
             ),
           );
         },

--- a/frontend/lib/store_widgets/accepting_store_summary.dart
+++ b/frontend/lib/store_widgets/accepting_store_summary.dart
@@ -11,18 +11,20 @@ import 'package:intl/intl.dart';
 
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
 
+import '../map/map_page.dart';
+
 class AcceptingStoreSummary extends StatelessWidget {
   final AcceptingStoreSummaryModel store;
   final CoordinatesInput? coordinates;
   final double wideDepictionThreshold;
-  final bool showMapButtonOnDetails;
+  final void Function(PhysicalStoreFeatureData)? showOnMap;
   final bool showLocation;
 
   const AcceptingStoreSummary({
     super.key,
     required this.store,
     this.coordinates,
-    required this.showMapButtonOnDetails,
+    required this.showOnMap,
     this.showLocation = true,
     this.wideDepictionThreshold = 400,
   });
@@ -88,10 +90,9 @@ class AcceptingStoreSummary extends StatelessWidget {
   }
 
   void _openDetailView(BuildContext context) {
-    Navigator.push(
-      context,
+    Navigator.of(context, rootNavigator: true).push(
       AppRoute(
-        builder: (context) => DetailPage(store.id, hideShowOnMapButton: !showMapButtonOnDetails),
+        builder: (context) => DetailPage(store.id, showOnMap: showOnMap),
       ),
     );
   }

--- a/frontend/lib/store_widgets/accepting_store_summary.dart
+++ b/frontend/lib/store_widgets/accepting_store_summary.dart
@@ -11,7 +11,7 @@ import 'package:intl/intl.dart';
 
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
 
-import '../map/map_page.dart';
+import 'package:ehrenamtskarte/map/map_page.dart';
 
 class AcceptingStoreSummary extends StatelessWidget {
   final AcceptingStoreSummaryModel store;

--- a/frontend/lib/store_widgets/detail/detail_content.dart
+++ b/frontend/lib/store_widgets/detail/detail_content.dart
@@ -1,7 +1,7 @@
+import 'dart:developer';
 import 'dart:io' show Platform;
 
 import 'package:ehrenamtskarte/graphql/graphql_api.graphql.dart';
-import 'package:ehrenamtskarte/home/home_page.dart';
 import 'package:ehrenamtskarte/map/map_page.dart';
 import 'package:ehrenamtskarte/store_widgets/detail/contact_info_row.dart';
 import 'package:ehrenamtskarte/util/color_utils.dart';
@@ -15,14 +15,14 @@ import 'package:ehrenamtskarte/l10n/translations.g.dart';
 
 class DetailContent extends StatelessWidget {
   final AcceptingStoreById$Query$PhysicalStore acceptingStore;
-  final bool hideShowOnMapButton;
+  final void Function(PhysicalStoreFeatureData)? showOnMap;
   final Color? accentColor;
   final Color? readableOnAccentColor;
 
   const DetailContent(
     this.acceptingStore, {
     super.key,
-    this.hideShowOnMapButton = false,
+    this.showOnMap,
     this.accentColor,
     this.readableOnAccentColor,
   });
@@ -98,7 +98,7 @@ class DetailContent extends StatelessWidget {
                   ),
               ],
             ),
-            if (!hideShowOnMapButton) ...[
+            if (showOnMap != null) ...[
               Divider(
                 thickness: 0.7,
                 height: 48,
@@ -130,9 +130,15 @@ class DetailContent extends StatelessWidget {
     }
   }
 
-  void _showOnMap(BuildContext context) {
+  Future<void> _showOnMap(BuildContext context) async {
     // Hint: The promise here is unused
-    HomePageData.of(context)?.navigateToMapTab(
+    final showOnMapProp = showOnMap;
+    if (showOnMapProp == null) {
+      log('Error: showOnMap is null, but button was pressed.');
+      return;
+    }
+    Navigator.of(context).pop();
+    showOnMapProp(
       PhysicalStoreFeatureData(
         acceptingStore.id,
         LatLng(acceptingStore.coordinates.lat, acceptingStore.coordinates.lng),

--- a/frontend/lib/store_widgets/detail/detail_page.dart
+++ b/frontend/lib/store_widgets/detail/detail_page.dart
@@ -11,11 +11,13 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
 
+import '../../map/map_page.dart';
+
 class DetailPage extends StatelessWidget {
   final int _acceptingStoreId;
-  final bool hideShowOnMapButton;
+  final void Function(PhysicalStoreFeatureData)? showOnMap;
 
-  const DetailPage(this._acceptingStoreId, {super.key, this.hideShowOnMapButton = false});
+  const DetailPage(this._acceptingStoreId, {super.key, this.showOnMap});
 
   @override
   Widget build(BuildContext context) {
@@ -49,7 +51,7 @@ class DetailPage extends StatelessWidget {
               Expanded(
                 child: DetailContent(
                   matchingStore,
-                  hideShowOnMapButton: hideShowOnMapButton,
+                  showOnMap: showOnMap,
                   accentColor: accentColor,
                 ),
               )

--- a/frontend/lib/store_widgets/detail/detail_page.dart
+++ b/frontend/lib/store_widgets/detail/detail_page.dart
@@ -11,7 +11,7 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
 
-import '../../map/map_page.dart';
+import 'package:ehrenamtskarte/map/map_page.dart';
 
 class DetailPage extends StatelessWidget {
   final int _acceptingStoreId;


### PR DESCRIPTION
### Short description

Subroutes are pushed to the root navigator.

### Proposed changes

Subroutes are pushed to the root navigator.

When navigating to map from the detail page of a search result, we have to first pop the detail page from the navigator stack and then navigate to the map tab.

### Side effects

None

### Resolved issues

Fixes: #1170 #1288 
