### PR TITLE
fix-recreating-home-proposal

### DIFF
--- a/frontend/lib/about/language_change.dart
+++ b/frontend/lib/about/language_change.dart
@@ -1,8 +1,6 @@
 import 'package:ehrenamtskarte/build_config/build_config.dart' show buildConfig;
 import 'package:ehrenamtskarte/configuration/settings_model.dart';
-import 'package:ehrenamtskarte/home/home_page.dart';
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
-import 'package:ehrenamtskarte/routing.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -33,12 +31,7 @@ class LanguageChange extends StatelessWidget {
     final settings = Provider.of<SettingsModel>(context, listen: false);
     LocaleSettings.setLocaleRaw(language);
     settings.setLanguage(language: language);
-    Navigator.push(
-      context,
-      AppRoute(
-        builder: (context) => HomePage(),
-      ),
-    );
+    Navigator.of(context).pop(true);
     messengerState.showSnackBar(
       SnackBar(
         backgroundColor: Theme.of(context).colorScheme.primary,

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -46,6 +46,12 @@ final GoRouter router = GoRouter(
       ],
     ),
     GoRoute(
+      path: homeRouteName,
+      builder: (BuildContext context, GoRouterState state) {
+        return HomePage(initialTabIndex: int.parse(state.pathParameters[homeRouteParamTabIndexName]!));
+      },
+    ),
+    GoRoute(
       path: '$homeRouteName/:$homeRouteParamTabIndexName',
       builder: (BuildContext context, GoRouterState state) {
         return HomePage(initialTabIndex: int.parse(state.pathParameters[homeRouteParamTabIndexName]!));


### PR DESCRIPTION
### Short description

The fix of not recreating the router causes some issue for the language change -> duplicated bottomTabsMenu
When activating card with deep link and not confirming the intro slides and reopening the app, there is the home route missing when the user then accepts intro slides

### Proposed changes

<!-- Describe this PR in more detail. -->

- fix language change
- add missing home route


![image](https://github.com/digitalfabrik/entitlementcard/assets/37902063/238838ea-3c0f-451a-b09a-45be5791e1ff)
