### PR TITLE
1155: Add deliver-production-ios

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -679,7 +679,7 @@ jobs:
                 condition: << parameters.production_delivery >>
                 steps:
                     - run:
-                        command: echo "not implemented yet"
+                        command: bundle exec fastlane ios appstoreconnect_upload build_config_name:<< parameters.buildConfig >> ipa_path:attached_workspace/<< parameters.buildConfig >>.ipa version_name:${NEW_VERSION_NAME}
                         name: '[FL] App Store Connect Upload'
                         working_directory: frontend/ios
             - unless:
@@ -862,6 +862,9 @@ parameters:
         default: false
         type: boolean
     run_delivery_beta_native:
+        default: false
+        type: boolean
+    run_delivery_production_native:
         default: false
         type: boolean
     run_frontend:
@@ -1142,6 +1145,50 @@ workflows:
                 requires:
                     - build_ios_nuernberg
         when: << pipeline.parameters.run_delivery_beta_native >>
+    delivery_production_native:
+        jobs:
+            - bump_version:
+                context:
+                    - deliverino
+                prepare_delivery: true
+            - check_frontend
+            - build_ios:
+                buildConfig: bayern
+                context:
+                    - tuerantuer-apple
+                    - fastlane-match
+                flutterFlavor: Bayern
+                name: build_ios_bayern
+                requires:
+                    - bump_version
+                    - check_frontend
+            - deliver_ios:
+                buildConfig: bayern
+                context:
+                    - tuerantuer-apple
+                name: deliver_bayern_ios
+                production_delivery: true
+                requires:
+                    - build_ios_bayern
+            - build_ios:
+                buildConfig: nuernberg
+                context:
+                    - tuerantuer-apple
+                    - fastlane-match
+                flutterFlavor: Nuernberg
+                name: build_ios_nuernberg
+                requires:
+                    - bump_version
+                    - check_frontend
+            - deliver_ios:
+                buildConfig: nuernberg
+                context:
+                    - tuerantuer-apple
+                name: deliver_nuernberg_ios
+                production_delivery: true
+                requires:
+                    - build_ios_nuernberg
+        when: << pipeline.parameters.run_delivery_production_native >>
     frontend:
         jobs:
             - check_frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1152,6 +1152,42 @@ workflows:
                     - deliverino
                 prepare_delivery: true
             - check_frontend
+            - build_android:
+                buildConfig: bayern
+                context:
+                    - credentials-repo
+                    - credentials-ehrenamtskarte
+                flutterFlavor: Bayern
+                name: build_android_bayern
+                requires:
+                    - bump_version
+                    - check_frontend
+            - deliver_android:
+                buildConfig: bayern
+                context:
+                    - tuerantuer-google-play
+                name: deliver_android_bayern
+                production_delivery: true
+                requires:
+                    - build_android_bayern
+            - build_android:
+                buildConfig: nuernberg
+                context:
+                    - credentials-repo
+                    - credentials-ehrenamtskarte
+                flutterFlavor: Nuernberg
+                name: build_android_nuernberg
+                requires:
+                    - bump_version
+                    - check_frontend
+            - deliver_android:
+                buildConfig: nuernberg
+                context:
+                    - tuerantuer-google-play
+                name: deliver_android_nuernberg
+                production_delivery: true
+                requires:
+                    - build_android_nuernberg
             - build_ios:
                 buildConfig: bayern
                 context:

--- a/.circleci/src/@common.yml
+++ b/.circleci/src/@common.yml
@@ -29,6 +29,9 @@ parameters:
   run_delivery_beta_native:
     default: false
     type: boolean
+  run_delivery_production_native:
+    default: false
+    type: boolean
   run_promote_native:
     default: false
     type: boolean

--- a/.circleci/src/jobs/deliver_ios.yml
+++ b/.circleci/src/jobs/deliver_ios.yml
@@ -23,7 +23,7 @@ steps:
       steps:
         - run:
             name: '[FL] App Store Connect Upload'
-            command: echo "not implemented yet" #bundle exec fastlane ios appstoreconnect_upload ipa_path:attached_workspace/<< parameters.buildConfig >>.ipa version_name:${NEW_VERSION_NAME} build_config_name:<< parameters.buildConfig >>
+            command: bundle exec fastlane ios appstoreconnect_upload build_config_name:<< parameters.buildConfig >> ipa_path:attached_workspace/<< parameters.buildConfig >>.ipa version_name:${NEW_VERSION_NAME}
             working_directory: frontend/ios
   - unless:
       condition: << parameters.production_delivery >>

--- a/.circleci/src/workflows/delivery_production_native.yml
+++ b/.circleci/src/workflows/delivery_production_native.yml
@@ -5,42 +5,42 @@ jobs:
       context:
         - deliverino
   - check_frontend
-#  - build_android:
-#      name: build_android_bayern
-#      buildConfig: "bayern"
-#      flutterFlavor: "Bayern"
-#      requires:
-#        - bump_version
-#        - check_frontend
-#      context:
-#        - credentials-repo
-#        - credentials-ehrenamtskarte
-#  - deliver_android:
-#      name: deliver_android_bayern
-#      buildConfig: "bayern"
-#      context:
-#        - tuerantuer-google-play
-#      production_delivery: true
-#      requires:
-#        - build_android_bayern
-#  - build_android:
-#      name: build_android_nuernberg
-#      buildConfig: "nuernberg"
-#      flutterFlavor: "Nuernberg"
-#      requires:
-#        - bump_version
-#        - check_frontend
-#      context:
-#        - credentials-repo
-#        - credentials-ehrenamtskarte
-#  - deliver_android:
-#      name: deliver_android_nuernberg
-#      buildConfig: "nuernberg"
-#      context:
-#        - tuerantuer-google-play
-#      production_delivery: true
-#      requires:
-#        - build_android_nuernberg
+  - build_android:
+      name: build_android_bayern
+      buildConfig: "bayern"
+      flutterFlavor: "Bayern"
+      requires:
+        - bump_version
+        - check_frontend
+      context:
+        - credentials-repo
+        - credentials-ehrenamtskarte
+  - deliver_android:
+      name: deliver_android_bayern
+      buildConfig: "bayern"
+      context:
+        - tuerantuer-google-play
+      production_delivery: true
+      requires:
+        - build_android_bayern
+  - build_android:
+      name: build_android_nuernberg
+      buildConfig: "nuernberg"
+      flutterFlavor: "Nuernberg"
+      requires:
+        - bump_version
+        - check_frontend
+      context:
+        - credentials-repo
+        - credentials-ehrenamtskarte
+  - deliver_android:
+      name: deliver_android_nuernberg
+      buildConfig: "nuernberg"
+      context:
+        - tuerantuer-google-play
+      production_delivery: true
+      requires:
+        - build_android_nuernberg
   - build_ios:
       name: build_ios_bayern
       buildConfig: "bayern"

--- a/.circleci/src/workflows/delivery_production_native.yml
+++ b/.circleci/src/workflows/delivery_production_native.yml
@@ -1,0 +1,79 @@
+when: << pipeline.parameters.run_delivery_production_native >>
+jobs:
+  - bump_version:
+      prepare_delivery: true
+      context:
+        - deliverino
+  - check_frontend
+#  - build_android:
+#      name: build_android_bayern
+#      buildConfig: "bayern"
+#      flutterFlavor: "Bayern"
+#      requires:
+#        - bump_version
+#        - check_frontend
+#      context:
+#        - credentials-repo
+#        - credentials-ehrenamtskarte
+#  - deliver_android:
+#      name: deliver_android_bayern
+#      buildConfig: "bayern"
+#      context:
+#        - tuerantuer-google-play
+#      production_delivery: true
+#      requires:
+#        - build_android_bayern
+#  - build_android:
+#      name: build_android_nuernberg
+#      buildConfig: "nuernberg"
+#      flutterFlavor: "Nuernberg"
+#      requires:
+#        - bump_version
+#        - check_frontend
+#      context:
+#        - credentials-repo
+#        - credentials-ehrenamtskarte
+#  - deliver_android:
+#      name: deliver_android_nuernberg
+#      buildConfig: "nuernberg"
+#      context:
+#        - tuerantuer-google-play
+#      production_delivery: true
+#      requires:
+#        - build_android_nuernberg
+  - build_ios:
+      name: build_ios_bayern
+      buildConfig: "bayern"
+      flutterFlavor: "Bayern"
+      requires:
+        - bump_version
+        - check_frontend
+      context:
+        - tuerantuer-apple
+        - fastlane-match
+  - deliver_ios:
+      name: deliver_bayern_ios
+      buildConfig: bayern
+      context:
+        - tuerantuer-apple
+      production_delivery: true
+      requires:
+        - build_ios_bayern
+  - build_ios:
+      name: build_ios_nuernberg
+      buildConfig: "nuernberg"
+      flutterFlavor: "Nuernberg"
+      requires:
+        - bump_version
+        - check_frontend
+      context:
+        - tuerantuer-apple
+        - fastlane-match
+  - deliver_ios:
+      name: deliver_nuernberg_ios
+      buildConfig: nuernberg
+      context:
+        - tuerantuer-apple
+      production_delivery: true
+      requires:
+        - build_ios_nuernberg

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -113,6 +113,36 @@ platform :ios do
     )
   end
 
+  desc "Deliver iOS App to production"
+  lane :appstoreconnect_upload do |options|
+    apple_auth()
+
+    version_name = options[:version_name]
+    build_config_name = options[:build_config_name]
+    ipa_path = options[:ipa_path]
+
+    if [build_config_name, ipa_path, version_name].include?(nil)
+      raise "'nil' passed as parameter! Aborting..."
+    end
+
+    puts("delivering #{build_config_name} v#{version_name}")
+
+    # https://docs.fastlane.tools/actions/deliver/
+    deliver(
+      ipa: "#{ENV['HOME']}/#{ipa_path}",
+      app_version: version_name,
+      submit_for_review: true,
+      automatic_release: false,
+      force: true,
+      skip_screenshots: true,
+      skip_metadata: true,
+      overwrite_screenshots: true,
+      precheck_include_in_app_purchases: false, # We do not have inapp purchases
+      submission_information: { add_id_info_uses_idfa: false }  # https://firebase.google.com/docs/analytics/configure-data-collection?platform=ios
+    # https://support.google.com/firebase/answer/6318039?hl=en
+    )
+  end
+
   desc "Generate new localized screenshots"
   lane :snap_bayern do
    sh "fvm flutter pub run build_runner build --define df_build_config=name=bayern"

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -132,7 +132,7 @@ platform :ios do
       ipa: "#{ENV['HOME']}/#{ipa_path}",
       app_version: version_name,
       submit_for_review: true,
-      automatic_release: false,
+      automatic_release: true,
       force: true,
       skip_screenshots: true,
       skip_metadata: true,

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{"versionName":"2024.2.6","versionCode":135}
+{"versionName":"2024.2.8","versionCode":137}


### PR DESCRIPTION
### Short description
Added the option to deliver to production for native app.

### Proposed changes
- added delivery_production_native workflow
- added lane for ios production delivery

### Side effects
- None, but I saw that on the first try, the bump_version commit started the commit workflow, when restarting it was not triggered. I guess this happend, because the commit message was not propery sent to circleci, see here: https://app.circleci.com/pipelines/github/digitalfabrik/entitlementcard/4493/workflows/57ba0bbf-7c35-46a1-b3ec-8ba7b86c6d46
Please let me know if you see this happening in the future again.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1155
