### PR TITLE
887: Hash PasswordResetKey

### DIFF
--- a/administration/src/errors/getMessageFromApolloError.tsx
+++ b/administration/src/errors/getMessageFromApolloError.tsx
@@ -16,7 +16,7 @@ const getMessageFromApolloError = (error: ApolloError): GraphQLErrorMessage => {
   }
 
   const codesEqual = error.graphQLErrors.every(
-    (value, index, array) => value.extensions.code === array[0].extensions.code
+    (value, index, array) => value.extensions?.code === array[0].extensions?.code
   )
   if (error.graphQLErrors.length < 1 || (error.graphQLErrors.length > 1 && !codesEqual)) {
     return { title: defaultMessage }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/PasswordCrypto.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/PasswordCrypto.kt
@@ -1,6 +1,7 @@
 package app.ehrenamtskarte.backend.auth.database
 
 import at.favre.lib.crypto.bcrypt.BCrypt
+import at.favre.lib.crypto.bcrypt.LongPasswordStrategies
 
 object PasswordCrypto {
     private const val cost = 11
@@ -10,4 +11,10 @@ object PasswordCrypto {
 
     fun verifyPassword(password: String, hash: ByteArray) =
         BCrypt.verifyer().verify(password.toCharArray(), hash).verified
+
+    fun hashPasswordResetKey(passwordResetKey: String): ByteArray =
+        BCrypt.with(LongPasswordStrategies.none()).hash(cost, passwordResetKey.toCharArray())
+
+    fun verifyPasswordResetKey(passwordResetKey: String, hash: ByteArray) =
+        BCrypt.verifyer(null, LongPasswordStrategies.none()).verify(passwordResetKey.toCharArray(), hash).verified
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/Schema.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/Schema.kt
@@ -19,7 +19,7 @@ object Administrators : IntIdTable() {
     val regionId = optReference("regionId", Regions)
     val role = varchar("role", 32)
     val passwordHash = binary("passwordHash").nullable()
-    val passwordResetKey = varchar("passwordResetKey", 100).nullable()
+    val passwordResetKeyHash = binary("passwordResetKeyHash").nullable()
     val passwordResetKeyExpiry = timestamp("passwordResetKeyExpiry").nullable()
     val notificationOnApplication = bool("notificationOnApplication").default(false)
     val notificationOnVerification = bool("notificationOnVerification").default(false)
@@ -48,7 +48,7 @@ class AdministratorEntity(id: EntityID<Int>) : IntEntity(id) {
     var regionId by Administrators.regionId
     var role by Administrators.role
     var passwordHash by Administrators.passwordHash
-    var passwordResetKey by Administrators.passwordResetKey
+    var passwordResetKeyHash by Administrators.passwordResetKeyHash
     var passwordResetKeyExpiry by Administrators.passwordResetKeyExpiry
     var notificationOnApplication by Administrators.notificationOnApplication
     var notificationOnVerification by Administrators.notificationOnVerification

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/repos/AdministratorsRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/repos/AdministratorsRepository.kt
@@ -95,7 +95,7 @@ object AdministratorsRepository {
         }
 
         administrator.passwordHash = PasswordCrypto.hashPasswort(newPassword)
-        administrator.passwordResetKey = null
+        administrator.passwordResetKeyHash = null
         administrator.passwordResetKeyExpiry = null
     }
 
@@ -109,7 +109,7 @@ object AdministratorsRepository {
         val byteArray = ByteArray(64)
         SecureRandom.getInstanceStrong().nextBytes(byteArray)
         val key = Base64.getUrlEncoder().encodeToString(byteArray)
-        administrator.passwordResetKey = key
+        administrator.passwordResetKeyHash = PasswordCrypto.hashPasswort(key)
         administrator.passwordResetKeyExpiry = Instant.now().plus(Period.ofDays(1))
         return key
     }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/repos/AdministratorsRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/repos/AdministratorsRepository.kt
@@ -20,10 +20,8 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.transactions.transaction
-import java.security.SecureRandom
 import java.time.Instant
 import java.time.Period
-import java.util.Base64
 import java.util.UUID
 
 object AdministratorsRepository {
@@ -106,12 +104,10 @@ object AdministratorsRepository {
     }
 
     fun setNewPasswordResetKey(administrator: AdministratorEntity): String {
-        val byteArray = ByteArray(64)
-        SecureRandom.getInstanceStrong().nextBytes(byteArray)
-        val key = Base64.getUrlEncoder().encodeToString(byteArray)
-        administrator.passwordResetKeyHash = PasswordCrypto.hashPasswordResetKey(key)
+        val passwordResetKey = PasswordCrypto.generatePasswordResetKey()
+        administrator.passwordResetKeyHash = PasswordCrypto.hashPasswordResetKey(passwordResetKey)
         administrator.passwordResetKeyExpiry = Instant.now().plus(Period.ofDays(1))
-        return key
+        return passwordResetKey
     }
 
     fun updateNotificationSettings(

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/repos/AdministratorsRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/database/repos/AdministratorsRepository.kt
@@ -109,7 +109,7 @@ object AdministratorsRepository {
         val byteArray = ByteArray(64)
         SecureRandom.getInstanceStrong().nextBytes(byteArray)
         val key = Base64.getUrlEncoder().encodeToString(byteArray)
-        administrator.passwordResetKeyHash = PasswordCrypto.hashPasswort(key)
+        administrator.passwordResetKeyHash = PasswordCrypto.hashPasswordResetKey(key)
         administrator.passwordResetKeyExpiry = Instant.now().plus(Period.ofDays(1))
         return key
     }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/schema/ResetPasswordMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/schema/ResetPasswordMutationService.kt
@@ -33,7 +33,7 @@ class ResetPasswordMutationService {
             // We don't send error messages for empty collection to the user to avoid scraping of mail addresses
             if (user != null) {
                 val key = AdministratorsRepository.setNewPasswordResetKey(user)
-                Mailer.sendResetPasswodMail(backendConfig, projectConfig, key, email)
+                Mailer.sendResetPasswordMail(backendConfig, projectConfig, key, email)
             }
         }
         return true

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/schema/ResetPasswordMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/schema/ResetPasswordMutationService.kt
@@ -2,6 +2,7 @@ package app.ehrenamtskarte.backend.auth.webservice.schema
 
 import app.ehrenamtskarte.backend.auth.database.AdministratorEntity
 import app.ehrenamtskarte.backend.auth.database.Administrators
+import app.ehrenamtskarte.backend.auth.database.PasswordCrypto
 import app.ehrenamtskarte.backend.auth.database.repos.AdministratorsRepository
 import app.ehrenamtskarte.backend.common.webservice.GraphQLContext
 import app.ehrenamtskarte.backend.exception.service.ProjectNotFoundException
@@ -53,13 +54,14 @@ class ResetPasswordMutationService {
                 .select((Projects.project eq project) and (LowerCase(Administrators.email) eq email.lowercase()) and (Administrators.deleted eq false))
                 .singleOrNull()?.let { AdministratorEntity.wrapRow(it) }
 
+            val passwordResetKeyHash = user?.passwordResetKeyHash
             // We don't send error messages for empty collection to the user to avoid scraping of mail addresses
-            if (user === null) {
+            if (user === null || passwordResetKeyHash === null) {
                 return@transaction
             }
             if (user.passwordResetKeyExpiry!!.isBefore(Instant.now())) {
                 throw PasswordResetKeyExpiredException()
-            } else if (user.passwordResetKey != passwordResetKey) {
+            } else if (!PasswordCrypto.verifyPassword(passwordResetKey, passwordResetKeyHash)) {
                 throw InvalidLinkException()
             }
 

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/schema/ResetPasswordMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/schema/ResetPasswordMutationService.kt
@@ -48,7 +48,7 @@ class ResetPasswordMutationService {
         newPassword: String
     ): Boolean {
         val backendConfig = dfe.getContext<GraphQLContext>().backendConfiguration
-        if (!backendConfig.projects.any { it.id === project }) throw ProjectNotFoundException(project)
+        if (!backendConfig.projects.any { it.id == project }) throw ProjectNotFoundException(project)
         transaction {
             val user = Administrators.innerJoin(Projects).slice(Administrators.columns)
                 .select((Projects.project eq project) and (LowerCase(Administrators.email) eq email.lowercase()) and (Administrators.deleted eq false))
@@ -61,7 +61,7 @@ class ResetPasswordMutationService {
             }
             if (user.passwordResetKeyExpiry!!.isBefore(Instant.now())) {
                 throw PasswordResetKeyExpiredException()
-            } else if (!PasswordCrypto.verifyPassword(passwordResetKey, passwordResetKeyHash)) {
+            } else if (!PasswordCrypto.verifyPasswordResetKey(passwordResetKey, passwordResetKeyHash)) {
                 throw InvalidLinkException()
             }
 

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/schema/ResetPasswordQueryService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/schema/ResetPasswordQueryService.kt
@@ -29,7 +29,7 @@ class ResetPasswordQueryService {
                     Administrators.passwordResetKeyHash.isNotNull() and (Administrators.projectId eq projectId) and not(
                         Administrators.deleted
                     )
-                }.firstOrNull { PasswordCrypto.verifyPassword(resetKey, it.passwordResetKeyHash!!) }
+                }.firstOrNull { PasswordCrypto.verifyPasswordResetKey(resetKey, it.passwordResetKeyHash!!) }
             if (admin == null) {
                 throw InvalidPasswordResetLinkException()
             } else if (admin.passwordResetKeyExpiry!!.isBefore(Instant.now())) {

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/mail/Mailer.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/mail/Mailer.kt
@@ -182,7 +182,7 @@ object Mailer {
         )
     }
 
-    fun sendResetPasswodMail(
+    fun sendResetPasswordMail(
         backendConfig: BackendConfiguration,
         projectConfig: ProjectConfig,
         passwortResetKey: String,

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/MigrationsRegistry.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/MigrationsRegistry.kt
@@ -9,6 +9,7 @@ object MigrationsRegistry {
         V0005_AddRegionApplicationActivation(),
         V0006_AddStoreCreatedDate(),
         V0007_AddStartDay(),
-        V0008_IncreaseAdministratorEmailLength()
+        V0008_IncreaseAdministratorEmailLength(),
+        V0009_HashPasswordResetKey()
     )
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/V0009_HashPasswordResetKey.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/V0009_HashPasswordResetKey.kt
@@ -1,0 +1,20 @@
+package app.ehrenamtskarte.backend.migration.migrations
+
+import app.ehrenamtskarte.backend.migration.Migration
+import app.ehrenamtskarte.backend.migration.Statement
+
+/**
+ * Change type and name of passwordResetKey column
+ */
+@Suppress("ClassName")
+internal class V0009_HashPasswordResetKey : Migration() {
+    override val migrate: Statement = {
+        exec(
+            """
+            UPDATE administrators SET "passwordResetKeyExpiry" = null WHERE "passwordResetKey" IS NOT NULL;
+            ALTER TABLE administrators ALTER COLUMN "passwordResetKey" TYPE bytea USING NULL;
+            ALTER TABLE administrators RENAME COLUMN "passwordResetKey" TO "passwordResetKeyHash";
+            """.trimIndent()
+        )
+    }
+}


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
To ensure that the password reset keys are safe even if the DB is somehow exposed we only want to store the hash of the password reset key.

### Proposed changes

<!-- Describe this PR in more detail. -->

- migrate db 1) change datatype to bytea 2) change column name
- add hashing logic
- change referential equality check on project to structural equality check this actually fixes #821 
- correctly handle runtime errors in frontend

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- existing passwordResetKeys become invalid

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #887 
