### PR TITLE
Fix-ci-environment-variable

### DIFF
--- a/frontend/android/fastlane/Fastfile
+++ b/frontend/android/fastlane/Fastfile
@@ -88,7 +88,7 @@ platform :android do
       gradle(
         task: task,
         flavor: flavor,
-        flags: " -Ptarget=lib/main.dart -Pdart-defines='#{env_prod}'",
+        flags: " -Ptarget=lib/main.dart -Pdart-defines=#{env_prod}",
         build_type: "Release",
         properties: {
           :VERSION_CODE => version_code,

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -85,7 +85,6 @@ platform :ios do
     # DO NOT OVERWRITE THE BUNDLE_CONFIG ENV VARIABLE! It is used by ruby bundle.
 
     sh("fvm flutter pub run build_runner build --define df_build_config=name=#{build_config_name}")
-    env_prod = sh("echo -n environment=production | base64")
 
     build_app(
        workspace: "Runner.xcworkspace",
@@ -93,7 +92,8 @@ platform :ios do
        output_directory: "#{ENV['HOME']}",
        output_name: "#{build_config_name}.ipa",
        export_method: "app-store",
-       xcargs: "DART_DEFINES='#{env_prod}'"
+       # pass base64 encoded env variable "environment=production" directly, because shell result does not work for gym as it does for gradle (android/Fastfile)
+       xcargs: "DART_DEFINES='ZW52aXJvbm1lbnQ9cHJvZHVjdGlvbg=='"
      )
   end
 

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -85,6 +85,7 @@ platform :ios do
     # DO NOT OVERWRITE THE BUNDLE_CONFIG ENV VARIABLE! It is used by ruby bundle.
 
     sh("fvm flutter pub run build_runner build --define df_build_config=name=#{build_config_name}")
+    env_prod = sh("echo -n environment=production | base64")
 
     build_app(
        workspace: "Runner.xcworkspace",
@@ -92,6 +93,7 @@ platform :ios do
        output_directory: "#{ENV['HOME']}",
        output_name: "#{build_config_name}.ipa",
        export_method: "app-store",
+       xcargs: "DART_DEFINES='#{env_prod}'"
      )
   end
 

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -85,6 +85,8 @@ platform :ios do
     # DO NOT OVERWRITE THE BUNDLE_CONFIG ENV VARIABLE! It is used by ruby bundle.
 
     sh("fvm flutter pub run build_runner build --define df_build_config=name=#{build_config_name}")
+     # use base64 encoded variable "environment=production" directly, because shell result does not work for gym as it does for gradle (android/Fastfile)
+    env_prod_base64 = "ZW52aXJvbm1lbnQ9cHJvZHVjdGlvbg=="
 
     build_app(
        workspace: "Runner.xcworkspace",
@@ -92,8 +94,7 @@ platform :ios do
        output_directory: "#{ENV['HOME']}",
        output_name: "#{build_config_name}.ipa",
        export_method: "app-store",
-       # pass base64 encoded env variable "environment=production" directly, because shell result does not work for gym as it does for gradle (android/Fastfile)
-       xcargs: "DART_DEFINES='ZW52aXJvbm1lbnQ9cHJvZHVjdGlvbg=='"
+       xcargs: "DART_DEFINES='#{env_prod_base64}'"
      )
   end
 

--- a/frontend/lib/configuration/definitions.dart
+++ b/frontend/lib/configuration/definitions.dart
@@ -1,7 +1,7 @@
 const String showcase = 'showcase';
 const String production = 'production';
 const String local = 'local';
-const String appEnvironment = String.fromEnvironment('environment', defaultValue: showcase);
+const String appEnvironment = String.fromEnvironment('environment', defaultValue: production);
 
 bool isProduction() {
   return appEnvironment == production;


### PR DESCRIPTION
### Short description

The environment variable for production builds was not passed correctly to android and ios in the ci, so the environment fallback `showcase` was used instead production. That caused loading wrong stores

### Proposed changes

<!-- Describe this PR in more detail. -->

- remove quotes for base64 string for android
- pass the environment variable via xcargs for ios

### Testing
- check uploaded artifacts in browserstack (ipa testing)
- or get the artifacts here:
[Android](https://app.circleci.com/pipelines/github/digitalfabrik/entitlementcard/4720/workflows/4788f1e6-f79b-4195-831b-967c36ec4123/jobs/35992/artifacts)
[iOS](https://app.circleci.com/pipelines/github/digitalfabrik/entitlementcard/4738/workflows/c13863ab-e88b-4a34-9188-bd5b4fefa292/jobs/36053/artifacts)
- now the correct stores should be displayed in SearchList and Map
