### PR TITLE
1346: Fix deep link test

### DIFF
--- a/administration/src/util/getDeepLinkFromQrCode.test.ts
+++ b/administration/src/util/getDeepLinkFromQrCode.test.ts
@@ -17,6 +17,8 @@ import { LOCAL_STORAGE_PROJECT_KEY } from '../project-configs/constants'
 import { getBuildConfig } from './getBuildConfig'
 import getDeepLinkFromQrCode from './getDeepLinkFromQrCode'
 
+jest.useFakeTimers({ now: new Date('2024-01-01T00:00:00.000Z') })
+
 describe('DeepLink generation', () => {
   const region: Region = {
     id: 0,
@@ -44,7 +46,7 @@ describe('DeepLink generation', () => {
     value: code.dynamicActivationCode,
   }
 
-  const encodedActivationCodeBase64 = 'ChsKGQoJVGhlYSBUZXN0EJijARoICgIIACICCAA%3D'
+  const encodedActivationCodeBase64 = 'ChsKGQoJVGhlYSBUZXN0ENOiARoICgIIACICCAA%3D'
   const overrideHostname = (hostname: string) =>
     Object.defineProperty(window, 'location', {
       value: {


### PR DESCRIPTION
### Short description

Activation codes in this test depend on timestamp, because the default expiry date will be calculated. So different runtime generate different activationCodes. This shouldn't be the case

### Proposed changes

<!-- Describe this PR in more detail. -->

- add fix timestamp for tests

Fixes: #1346
