### PR TITLE
1266: Adjust reactivation message card active on another device

### DIFF
--- a/frontend/assets/l10n/app_de.json
+++ b/frontend/assets/l10n/app_de.json
@@ -80,7 +80,7 @@
   },
   "identification": {
     "activate": "Aktivieren",
-    "activateCurrentDeviceDescription": "Ihre Karte ist bereits auf einem anderen Gerät aktiviert. Wenn Sie Ihre Karte auf diesem Gerät aktivieren, wird sie auf Ihrem anderen Gerät automatisch deaktiviert.",
+    "activateCurrentDeviceDescription": "Ihre Karte wurde bereits auf einem anderen Gerät aktiviert. Wenn Sie fortfahren, wird Ihre Karte automatisch auf dem anderen Gerät deaktiviert, falls sie dort noch aktiv ist.",
     "activateCurrentDeviceTitle": "Karte auf diesem Gerät aktivieren?",
     "activateDescription": "Sie haben die Ehrenamtskarte bereits beantragt und den Aktivierungscode Ihrer digitalen Ehrenamtskarte erhalten? Scannen Sie den Code hier ein.",
     "activateTitle": "Karte aktivieren",

--- a/frontend/assets/l10n/app_en.json
+++ b/frontend/assets/l10n/app_en.json
@@ -80,7 +80,7 @@
   },
   "identification": {
     "activate": "Activate",
-    "activateCurrentDeviceDescription": "Your card is already activated on another device. If you activate your card on this device, it will be automatically deactivated on your other device.",
+    "activateCurrentDeviceDescription": "Your card has already been activated on another device. If you continue, your card will be automatically deactivated on the other device if it is still active there.",
     "activateCurrentDeviceTitle": "Activate card on this device?",
     "activateDescription": "You have already applied for the Ehrenamtskarte and received the activation code for your digital Ehrenamtskarte? Scan the code here.",
     "activateTitle": "Activate card",

--- a/frontend/assets/nuernberg/l10n/override_de.json
+++ b/frontend/assets/nuernberg/l10n/override_de.json
@@ -1,6 +1,6 @@
 {
   "identification": {
-    "activateCurrentDeviceDescription": "Ihr Pass ist bereits auf einem anderen Gerät aktiviert. Wenn Sie Ihren Pass auf diesem Gerät aktivieren, wird er auf Ihrem anderen Gerät automatisch deaktiviert.",
+    "activateCurrentDeviceDescription": "Ihr Pass wurde bereits auf einem anderen Gerät aktiviert. Wenn Sie fortfahren, wird Ihr Pass automatisch auf dem anderen Gerät deaktiviert, falls er dort noch aktiv ist.",
     "activateCurrentDeviceTitle": "Pass auf diesem Gerät aktivieren?",
     "activateDescription": "Sie haben den Nürnberg-Pass bereits beantragt und einen Aktivierungscode erhalten? Scannen Sie den Code hier ein.",
     "activateTitle": "Pass aktivieren",

--- a/frontend/assets/nuernberg/l10n/override_en.json
+++ b/frontend/assets/nuernberg/l10n/override_en.json
@@ -1,6 +1,6 @@
 {
   "identification": {
-    "activateCurrentDeviceDescription": "Your pass is already activated on another device. If you activate your pass on this device, it will be automatically deactivated on your other device.",
+    "activateCurrentDeviceDescription": "Your pass has been already activated on another device. If you continue, your pass will be automatically deactivated on the other device if it is still active there.",
     "activateCurrentDeviceTitle": "Activate pass on this device?",
     "activateDescription": "You have already applied for the Nürnberg-Pass and received an activation code? Scan the code here.",
     "activateTitle": "Activate pass",

--- a/frontend/assets/nuernberg/l10n/override_en.json
+++ b/frontend/assets/nuernberg/l10n/override_en.json
@@ -1,6 +1,6 @@
 {
   "identification": {
-    "activateCurrentDeviceDescription": "Your pass has been already activated on another device. If you continue, your pass will be automatically deactivated on the other device if it is still active there.",
+    "activateCurrentDeviceDescription": "Your pass has already been activated on another device. If you continue, your pass will be automatically deactivated on the other device if it is still active there.",
     "activateCurrentDeviceTitle": "Activate pass on this device?",
     "activateDescription": "You have already applied for the Nürnberg-Pass and received an activation code? Scan the code here.",
     "activateTitle": "Activate pass",


### PR DESCRIPTION
### Short description
Adjust reactivation message if the card has already been activated on another device.

Currently the user might be confused if the card was activated on another device and then deleted and activated on a new device that a message will be shown that the card will be deactivated on the other device.


### Proposed changes
I have adjusted the message suggested in the task to keep it a couple words shorter, but feel free to object.
![image](https://github.com/digitalfabrik/entitlementcard/assets/115008338/1349e05e-9aaf-4d51-ab69-bf011140fa56)


### Side effects
- No?


### Resolved issues
Fixes: #1266
