### PR TITLE
1354: Migrate to declarative gradle plugins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ jobs:
                 command: mkdir -p attached_workspace
                 name: Make attached_workspace dir
             - run:
-                command: mv ~/project/frontend/build/app/outputs/bundle/<< parameters.buildConfig >>Release/app-<< parameters.buildConfig >>-release.aab ~/attached_workspace/<< parameters.buildConfig >>.aab
+                command: mv ~/project/frontend/build/app/outputs/bundle/<< parameters.flutterFlavor >>Release/app-<< parameters.flutterFlavor >>-release.aab ~/attached_workspace/<< parameters.buildConfig >>.aab
                 name: Move aab
             - run:
                 command: mv ~/project/frontend/build/app/outputs/apk/<< parameters.flutterFlavor >>/release/app-<< parameters.flutterFlavor >>-release.apk ~/attached_workspace/<< parameters.buildConfig >>.apk

--- a/.circleci/src/jobs/build_android.yml
+++ b/.circleci/src/jobs/build_android.yml
@@ -46,7 +46,7 @@ steps:
       command: mkdir -p attached_workspace
   - run:
       name: Move aab
-      command: mv ~/project/frontend/build/app/outputs/bundle/<< parameters.buildConfig >>Release/app-<< parameters.buildConfig >>-release.aab ~/attached_workspace/<< parameters.buildConfig >>.aab
+      command: mv ~/project/frontend/build/app/outputs/bundle/<< parameters.flutterFlavor >>Release/app-<< parameters.flutterFlavor >>-release.aab ~/attached_workspace/<< parameters.buildConfig >>.aab
   - run:
       name: Move apk
       command: mv ~/project/frontend/build/app/outputs/apk/<< parameters.flutterFlavor >>/release/app-<< parameters.flutterFlavor >>-release.apk ~/attached_workspace/<< parameters.buildConfig >>.apk

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -1,17 +1,19 @@
 import kotlin.Pair
 import com.android.build.api.dsl.ApplicationProductFlavor
 
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+    id "idea"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -24,11 +26,7 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 apply from: "buildConfigs.gradle"
-apply plugin: 'idea'
 
 idea {
     module {
@@ -167,20 +165,6 @@ android {
 flutter {
     source '../..'
     target 'lib/main.dart'
-}
-
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    // https://github.com/maplibre/flutter-maplibre-gl/issues/370
-    constraints {
-        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0") {
-            because("kotlin-stdlib-jdk7 is now a part of kotlin-stdlib")
-        }
-        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0") {
-            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
-        }
-    }
-
 }
 
 // Workaround to fix wrong path lookup by flutter tools, can be removed after upgrading flutter

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -166,21 +166,3 @@ flutter {
     source '../..'
     target 'lib/main.dart'
 }
-
-// Workaround to fix wrong path lookup by flutter tools, can be removed after upgrading flutter
-// see: https://github.com/flutter/flutter/pull/127133
-// when removing, make sure the release is written to the same directory as before or adjust build_android step to look at the new directory
-tasks.whenTaskAdded { task ->
-    if (task.name.startsWith("bundle") && task.name.endsWith("Release")) {
-        def renameTaskName = "rename${task.name.capitalize()}Aab"
-        def oldDir = task.name.substring("bundle".length())
-        def flavor = task.name.substring("bundle".length(), task.name.length() - "Release".length())
-        def flavorLowerCase = flavor.uncapitalize()
-        tasks.create(renameTaskName, Copy) {
-            from("${buildDir}/outputs/bundle/${oldDir}/")
-            into "${buildDir}/outputs/bundle/${flavorLowerCase}Release/"
-            rename "app-${flavor}-release.aab", "app-${flavorLowerCase}-release.aab"
-        }
-        task.finalizedBy(renameTaskName)
-    }
-}

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -1,20 +1,7 @@
-buildscript {
-    ext.kotlin_version = '1.7.10'
-    repositories {
-        google()
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/frontend/android/settings.gradle
+++ b/frontend/android/settings.gradle
@@ -1,11 +1,25 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "7.3.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+}
+
+include ":app"


### PR DESCRIPTION
### Changes

* Applied migration according to [Flutter's migration guide](https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply) 
* Removed some dependencies workaround
* Removed a path lookup workaround

### Side effects

Hopefully none.

### Resolved issues

Fixes: #1354

