### PR TITLE
1232: Create github release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -818,7 +818,7 @@ jobs:
             - restore_environment_variables
             - install_app_toolbelt
             - run:
-                command: echo "export RELEASE_ID='$(app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} --production-release << parameters.production_delivery >> --should-use-predefined-release-notes false)'" >> ${BASH_ENV}
+                command: echo "export RELEASE_ID='$(app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} --production-release << parameters.production_delivery >>)'" >> ${BASH_ENV}
                 name: Create github release
             - run:
                 command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/*.apk)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -805,6 +805,31 @@ jobs:
                         command: |
                             curl https://webhook.entitlementcard-test.tuerantuer.org/hooks/install-<< parameters.bundle >>-$EAK_WEBHOOK
                         name: Install package via webhook
+    notify_release:
+        docker:
+            - image: cimg/node:19.1.0
+        parameters:
+            production_delivery:
+                description: Whether builds are delivered to the production or beta lane of the play store.
+                type: boolean
+        resource_class: small
+        steps:
+            - prepare_workspace
+            - restore_environment_variables
+            - install_app_toolbelt
+            - run:
+                command: echo "export RELEASE_ID='$(app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} --production-release << parameters.production_delivery >> --should-use-predefined-release-notes false)'" >> ${BASH_ENV}
+                name: Create github release
+            - run:
+                command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/*.apk)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
+                name: Upload android apks to github release
+            - run:
+                command: app-toolbelt v0 github-release-asset upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/*.ipa)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
+                name: Upload ios ipas to github release
+            - notify:
+                allow-all-branches: true
+                channel: releases
+                success_message: <<^ parameters.production_delivery >>[Beta] <</ parameters.production_delivery >>Ehrenamtskarte Bayern und Sozialpass Nürnberg ${NEW_VERSION_NAME} have been released successfully! https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/tag/${NEW_VERSION_NAME}-all
     pack_administration:
         docker:
             - image: debian:11
@@ -1235,7 +1260,7 @@ workflows:
                 buildConfig: bayern
                 context:
                     - tuerantuer-apple
-                name: deliver_bayern_ios
+                name: deliver_ios_bayern
                 production_delivery: false
                 requires:
                     - build_ios_bayern
@@ -1253,10 +1278,19 @@ workflows:
                 buildConfig: nuernberg
                 context:
                     - tuerantuer-apple
-                name: deliver_nuernberg_ios
+                name: deliver_ios_nuernberg
                 production_delivery: false
                 requires:
                     - build_ios_nuernberg
+            - notify_release:
+                context:
+                    - deliverino
+                production_delivery: false
+                requires:
+                    - deliver_android_bayern
+                    - deliver_android_nuernberg
+                    - deliver_ios_bayern
+                    - deliver_ios_nuernberg
         when: << pipeline.parameters.run_delivery_beta_native >>
     delivery_production_native:
         jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -818,7 +818,7 @@ jobs:
             - restore_environment_variables
             - install_app_toolbelt
             - run:
-                command: echo "export RELEASE_ID='$(app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} --production-release << parameters.production_delivery >>)'" >> ${BASH_ENV}
+                command: echo "export RELEASE_ID='$(app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} <<# parameters.production_delivery >>--production-release<</ parameters.production_delivery >>)'" >> ${BASH_ENV}
                 name: Create github release
             - run:
                 command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/*.apk)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -823,11 +823,8 @@ jobs:
             - run:
                 command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/*.apk)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
                 name: Upload android apks to github release
-            - run:
-                command: app-toolbelt v0 github-release-asset upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/*.ipa)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
-                name: Upload ios ipas to github release
             - notify:
-                allow-all-branches: true
+                allow-all-branches: false
                 channel: releases
                 success_message: <<^ parameters.production_delivery >>[Beta] <</ parameters.production_delivery >>Ehrenamtskarte Bayern und Sozialpass Nürnberg ${NEW_VERSION_NAME} have been released successfully! https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/tag/${NEW_VERSION_NAME}-all
     pack_administration:

--- a/.circleci/src/jobs/notify_release.yml
+++ b/.circleci/src/jobs/notify_release.yml
@@ -1,0 +1,25 @@
+# Create a release (with release notes) on github and send a mattermost notification.
+parameters:
+  production_delivery:
+    description: Whether builds are delivered to the production or beta lane of the play store.
+    type: boolean
+docker:
+  - image: cimg/node:19.1.0
+resource_class: small
+steps:
+  - prepare_workspace
+  - restore_environment_variables
+  - install_app_toolbelt
+  - run:
+      name: Create github release
+      command: echo "export RELEASE_ID='$(app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} --production-release << parameters.production_delivery >> --should-use-predefined-release-notes false)'" >> ${BASH_ENV}
+  - run:
+      name: Upload android apks to github release
+      command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/*.apk)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
+  - run:
+      name: Upload ios ipas to github release
+      command: app-toolbelt v0 github-release-asset upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/*.ipa)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
+  - notify:
+      success_message: <<^ parameters.production_delivery >>[Beta] <</ parameters.production_delivery >>Ehrenamtskarte Bayern und Sozialpass Nürnberg ${NEW_VERSION_NAME} have been released successfully! https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/tag/${NEW_VERSION_NAME}-all
+      channel: releases
+      allow-all-branches: true

--- a/.circleci/src/jobs/notify_release.yml
+++ b/.circleci/src/jobs/notify_release.yml
@@ -12,7 +12,7 @@ steps:
   - install_app_toolbelt
   - run:
       name: Create github release
-      command: echo "export RELEASE_ID='$(app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} --production-release << parameters.production_delivery >>)'" >> ${BASH_ENV}
+      command: echo "export RELEASE_ID='$(app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} <<# parameters.production_delivery >>--production-release<</ parameters.production_delivery >>)'" >> ${BASH_ENV}
   - run:
       name: Upload android apks to github release
       command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/*.apk)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}

--- a/.circleci/src/jobs/notify_release.yml
+++ b/.circleci/src/jobs/notify_release.yml
@@ -12,7 +12,7 @@ steps:
   - install_app_toolbelt
   - run:
       name: Create github release
-      command: echo "export RELEASE_ID='$(app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} --production-release << parameters.production_delivery >> --should-use-predefined-release-notes false)'" >> ${BASH_ENV}
+      command: echo "export RELEASE_ID='$(app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} --production-release << parameters.production_delivery >>)'" >> ${BASH_ENV}
   - run:
       name: Upload android apks to github release
       command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/*.apk)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}

--- a/.circleci/src/jobs/notify_release.yml
+++ b/.circleci/src/jobs/notify_release.yml
@@ -16,10 +16,7 @@ steps:
   - run:
       name: Upload android apks to github release
       command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/*.apk)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
-  - run:
-      name: Upload ios ipas to github release
-      command: app-toolbelt v0 github-release-asset upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/*.ipa)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
   - notify:
       success_message: <<^ parameters.production_delivery >>[Beta] <</ parameters.production_delivery >>Ehrenamtskarte Bayern und Sozialpass Nürnberg ${NEW_VERSION_NAME} have been released successfully! https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/tag/${NEW_VERSION_NAME}-all
       channel: releases
-      allow-all-branches: true
+      allow-all-branches: false

--- a/.circleci/src/workflows/delivery_beta_native.yml
+++ b/.circleci/src/workflows/delivery_beta_native.yml
@@ -55,7 +55,7 @@ jobs:
         - tuerantuer-apple
         - fastlane-match
   - deliver_ios:
-      name: deliver_bayern_ios
+      name: deliver_ios_bayern
       buildConfig: bayern
       context:
         - tuerantuer-apple
@@ -73,10 +73,19 @@ jobs:
         - tuerantuer-apple
         - fastlane-match
   - deliver_ios:
-      name: deliver_nuernberg_ios
+      name: deliver_ios_nuernberg
       buildConfig: nuernberg
       context:
         - tuerantuer-apple
       production_delivery: false
       requires:
         - build_ios_nuernberg
+  - notify_release:
+      production_delivery: false
+      context:
+        - deliverino
+      requires:
+        - deliver_android_bayern
+        - deliver_android_nuernberg
+        - deliver_ios_bayern
+        - deliver_ios_nuernberg


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
As a dev i want that after successful delivery a github release with release notes will be created.

### Proposed changes

<!-- Describe this PR in more detail. -->

- add `notify_release` job to create a release, generate release notes, upload artifacts and send mattermost notification to release channel

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

https://github.com/digitalfabrik/app-toolbelt/pull/13 (merged)
resolves #1232, resolves #1319, resolves #1331, resolves #1165

### Testing (dev only)
1. Important deactivate delivery tasks in `deliver_beta_native`(!!!)
2. Push your commit
3. 
```sh
 curl -X POST https://circleci.com/api/v2/project/github/digitalfabrik/entitlementcard/pipeline \
  --header "Circle-Token: <"your token">" \
  --header "content-type: application/json" \
  --data '{"branch":"1232-create-github-release", "parameters":{"run_delivery_beta_native":true, "run_commit":false}}'

```
