### PR TITLE
1396: Hide keyboard when navigating to the map

### DIFF
--- a/frontend/lib/widgets/app_bars.dart
+++ b/frontend/lib/widgets/app_bars.dart
@@ -84,17 +84,12 @@ class SearchSliverAppBarState extends State<SearchSliverAppBar> {
   final TextEditingController textEditingController = TextEditingController();
   final FocusNode focusNode = FocusNode();
 
-  var keyboardToggler = false;
-
   @override
   Widget build(BuildContext context) {
     final t = context.t;
     final foregroundColor = Theme.of(context).appBarTheme.foregroundColor;
     return SliverAppBar(
       title: TextField(
-        onTap: () {
-          keyboardToggler = true;
-        },
         onTapOutside: (PointerDownEvent event) {
           focusNode.nextFocus();
         },
@@ -115,7 +110,7 @@ class SearchSliverAppBarState extends State<SearchSliverAppBar> {
           IconButton(icon: const Icon(Icons.clear), onPressed: _clearInput, color: foregroundColor),
         IconButton(
           icon: const Icon(Icons.search),
-          onPressed: _onSearchPressed,
+          onPressed: () {},
           color: foregroundColor,
         )
       ],
@@ -127,15 +122,6 @@ class SearchSliverAppBarState extends State<SearchSliverAppBar> {
     super.dispose();
     focusNode.dispose();
     textEditingController.dispose();
-  }
-
-  _onSearchPressed() {
-    if (keyboardToggler && !focusNode.hasPrimaryFocus) {
-      keyboardToggler = false;
-    } else {
-      focusNode.requestFocus();
-      keyboardToggler = true;
-    }
   }
 
   _onSearchFieldTextChanged(String text) {

--- a/frontend/lib/widgets/app_bars.dart
+++ b/frontend/lib/widgets/app_bars.dart
@@ -108,11 +108,10 @@ class SearchSliverAppBarState extends State<SearchSliverAppBar> {
       actions: [
         if (textEditingController.value.text.isNotEmpty)
           IconButton(icon: const Icon(Icons.clear), onPressed: _clearInput, color: foregroundColor),
-        IconButton(
-          icon: const Icon(Icons.search),
-          onPressed: () {},
-          color: foregroundColor,
-        )
+        Padding(
+          padding: const EdgeInsets.only(right: 15.0),
+          child: Icon(Icons.search, color: foregroundColor?.withOpacity(0.50)),
+        ),
       ],
     );
   }

--- a/frontend/lib/widgets/app_bars.dart
+++ b/frontend/lib/widgets/app_bars.dart
@@ -84,12 +84,20 @@ class SearchSliverAppBarState extends State<SearchSliverAppBar> {
   final TextEditingController textEditingController = TextEditingController();
   final FocusNode focusNode = FocusNode();
 
+  var keyboardToggler = false;
+
   @override
   Widget build(BuildContext context) {
     final t = context.t;
     final foregroundColor = Theme.of(context).appBarTheme.foregroundColor;
     return SliverAppBar(
       title: TextField(
+        onTap: () {
+          keyboardToggler = true;
+        },
+        onTapOutside: (PointerDownEvent event) {
+          focusNode.nextFocus();
+        },
         onChanged: _onSearchFieldTextChanged,
         controller: textEditingController,
         focusNode: focusNode,
@@ -122,10 +130,11 @@ class SearchSliverAppBarState extends State<SearchSliverAppBar> {
   }
 
   _onSearchPressed() {
-    if (focusNode.hasPrimaryFocus) {
-      focusNode.nextFocus();
+    if (keyboardToggler && !focusNode.hasPrimaryFocus) {
+      keyboardToggler = false;
     } else {
       focusNode.requestFocus();
+      keyboardToggler = true;
     }
   }
 


### PR DESCRIPTION
### Short description
Bugfix:
After using the search function (and displaying the on-screen keyboard), when you subsequently open the location on the map, the on-screen keyboard opens again, even though there is no input field


### Proposed changes
- set the onTapOutside property for the search text box to hide the keyboard (i.e. to remove the focus from the field) when the user clicks outside the text box
- add the keyboardToggler variable and update _onSearchPressed() to preserve the current behavior of the search button - toggling the keyboard on click


### Side effects
- no?


### Resolved issues
Fixes: #1396
