### PR TITLE
1388: Add the Others category to the filter bar in the app

### DIFF
--- a/frontend/lib/search/filter_bar.dart
+++ b/frontend/lib/search/filter_bar.dart
@@ -14,13 +14,10 @@ class FilterBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final t = context.t;
-    final sortedCategories = [...categoryAssets(context)];
-    sortedCategories.sort((a, b) => a.shortName.length.compareTo(b.shortName.length));
 
-    // Move the "Others" category to the end of the list
-    final othersCategory = sortedCategories.where((category) => category.id == 9).single;
-    sortedCategories.remove(othersCategory);
-    sortedCategories.add(othersCategory);
+    final sortedCategories = [...categoryAssets(context).where((category) => category.id != 9)];
+    sortedCategories.sort((a, b) => a.shortName.length.compareTo(b.shortName.length));
+    sortedCategories.add(categoryAssets(context).where((category) => category.id == 9).single);
 
     final filteredCategories = sortedCategories.where((element) => buildConfig.categories.contains(element.id));
 

--- a/frontend/lib/search/filter_bar.dart
+++ b/frontend/lib/search/filter_bar.dart
@@ -15,8 +15,13 @@ class FilterBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final t = context.t;
     final sortedCategories = [...categoryAssets(context)];
-    sortedCategories.removeWhere((category) => category.id == 9);
     sortedCategories.sort((a, b) => a.shortName.length.compareTo(b.shortName.length));
+
+    // Move the "Others" category to the end of the list
+    final othersCategory = sortedCategories.where((category) => category.id == 9).single;
+    sortedCategories.remove(othersCategory);
+    sortedCategories.add(othersCategory);
+
     final filteredCategories = sortedCategories.where((element) => buildConfig.categories.contains(element.id));
 
     return SliverToBoxAdapter(


### PR DESCRIPTION
### Short description
Add the "Others" category button to the filter bar.


### Proposed changes
- return the Others category in the filter bar


### Side effects
Actually this category was removed intentionally in this PR https://github.com/digitalfabrik/entitlementcard/pull/709/files
But I didn't find why?
Maybe it shouldn't be displayed in Nürnberg, but then we could remove it from the config probably?


### Resolved issues
Fixes: #1388
