### PR TITLE
Upgrade debian images to bookworm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -966,8 +966,12 @@ parameters:
         default: true
         type: boolean
     run_commit_main:
-        default: true
-        type: boolean
+        default: run_if_on_main
+        enum:
+            - run_if_on_main
+            - run
+            - skip
+        type: enum
     run_deliver_beta_backend_administration:
         default: false
         type: boolean
@@ -1058,11 +1062,17 @@ workflows:
                     - bump_version
                     - check_frontend
         when:
-            and:
-                - << pipeline.parameters.run_commit_main >>
+            or:
                 - equal:
-                    - main
-                    - << pipeline.git.branch >>
+                    - << pipeline.parameters.run_commit_main >>
+                    - run
+                - and:
+                    - equal:
+                        - << pipeline.parameters.run_commit_main >>
+                        - run_if_on_main
+                    - equal:
+                        - main
+                        - << pipeline.git.branch >>
     deliver_beta_backend_administration:
         jobs:
             - bump_version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -438,7 +438,7 @@ jobs:
             - notify
     build_martin:
         docker:
-            - image: rust:bullseye
+            - image: rust:bookworm
         steps:
             - checkout:
                 path: ~/project
@@ -650,7 +650,7 @@ jobs:
             - notify
     check_health_backend:
         docker:
-            - image: debian:11
+            - image: debian:12
             - environment:
                 - POSTGRES_DB=ehrenamtskarte
                 - POSTGRES_USER=postgres
@@ -807,7 +807,7 @@ jobs:
                         name: Install package via webhook
     pack_administration:
         docker:
-            - image: debian:11
+            - image: debian:12
         steps:
             - checkout:
                 path: ~/project
@@ -829,7 +829,7 @@ jobs:
             - notify
     pack_backend:
         docker:
-            - image: debian:11
+            - image: debian:12
         steps:
             - checkout:
                 path: ~/project
@@ -851,7 +851,7 @@ jobs:
         working_directory: ~/project/backend
     pack_martin:
         docker:
-            - image: debian:11
+            - image: debian:12
         steps:
             - checkout:
                 path: ~/project
@@ -882,7 +882,7 @@ jobs:
         working_directory: ~/project/map-tiles/martin
     pack_meta:
         docker:
-            - image: debian:11
+            - image: debian:12
         steps:
             - checkout:
                 path: ~/project

--- a/.circleci/src/@common.yml
+++ b/.circleci/src/@common.yml
@@ -9,8 +9,9 @@ parameters:
     default: true
     type: boolean
   run_commit_main:
-    default: true
-    type: boolean
+    default: "run_if_on_main"
+    type: enum
+    enum: ["run_if_on_main", "run", "skip"]
   run_deliver_beta_backend_administration:
     default: false
     type: boolean

--- a/.circleci/src/jobs/build_martin.yml
+++ b/.circleci/src/jobs/build_martin.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: rust:bullseye
+  - image: rust:bookworm
 working_directory: ~/martin
 steps:
   - checkout:

--- a/.circleci/src/jobs/check_health_backend.yml
+++ b/.circleci/src/jobs/check_health_backend.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: debian:11
+  - image: debian:12
   - image: postgis/postgis:13-3.0
     environment:
       - POSTGRES_DB=ehrenamtskarte

--- a/.circleci/src/jobs/pack_administration.yml
+++ b/.circleci/src/jobs/pack_administration.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: debian:11 # We deploy on debian -> pack on debian
+  - image: debian:12 # We deploy on debian -> pack on debian
 steps:
   - checkout:
       path: ~/project

--- a/.circleci/src/jobs/pack_backend.yml
+++ b/.circleci/src/jobs/pack_backend.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: debian:11 # We deploy on debian -> pack on debian
+  - image: debian:12 # We deploy on debian -> pack on debian
 working_directory: ~/project/backend
 steps:
   - checkout:

--- a/.circleci/src/jobs/pack_martin.yml
+++ b/.circleci/src/jobs/pack_martin.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: debian:11 # We deploy on debian -> pack on debian
+  - image: debian:12 # We deploy on debian -> pack on debian
 working_directory: ~/project/map-tiles/martin
 steps:
   - checkout:

--- a/.circleci/src/jobs/pack_meta.yml
+++ b/.circleci/src/jobs/pack_meta.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: debian:11 # We deploy on debian -> pack on debian
+  - image: debian:12 # We deploy on debian -> pack on debian
 steps:
   - checkout:
       path: ~/project

--- a/.circleci/src/workflows/commit_main.yml
+++ b/.circleci/src/workflows/commit_main.yml
@@ -1,7 +1,9 @@
 when:
-  and:
-    - << pipeline.parameters.run_commit_main >>
-    - equal: [main, << pipeline.git.branch >>]
+  or:
+    - equal: [<< pipeline.parameters.run_commit_main >>, "run"]
+    - and:
+      - equal: [<< pipeline.parameters.run_commit_main >>, "run_if_on_main"]
+      - equal: [main, << pipeline.git.branch >>]
 jobs:
   - bump_version:
         prepare_delivery: false


### PR DESCRIPTION
### Short description

By now, we deploy the backend on debian 12 (bookworm).
This upgrades the debian CI images to v12.
This should fix problems related to extremely old Node versions on these builds.

### Side effects

- Likely none, except that CI warnings & errors related to old Node versions should be resolved.

### Resolved issues

Fixes: #1361 
