### PR TITLE
Fix compilation of martin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,10 +458,8 @@ jobs:
                     - v1-cargo-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
             - prepare_workspace
             - run:
-                command: |
-                    apt update
-                    apt install -y openssl libssl-dev
-                name: Install OpenSSL
+                command: cargo update openssl --precise 0.10.64
+                name: Update OpenSSL library due to failed compilation
             - run:
                 command: |
                     cargo build --release --target x86_64-unknown-linux-gnu

--- a/.circleci/src/jobs/build_martin.yml
+++ b/.circleci/src/jobs/build_martin.yml
@@ -20,10 +20,8 @@ steps:
         - v1-cargo-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}
   - prepare_workspace
   - run:
-      name: "Install OpenSSL"
-      command: |
-        apt update
-        apt install -y openssl libssl-dev
+      name: "Update OpenSSL library due to failed compilation"
+      command: cargo update openssl --precise 0.10.64
   - run:
       name: "Build"
       command: |


### PR DESCRIPTION
### Short description

This fixes the compilation of martin by upgrading the open ssl dependency while keeping the same version of martin. (I don't exactly know why this began to fail, though)

### Proposed changes

While this fixes the compilation error short term, we should still upgrade Martin middle-term :)

### Side effects

Likely none, except  that we can build martin again.

### Resolved issues

Fixes: #1439 
