### PR TITLE
1442: Add deb files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -822,6 +822,12 @@ jobs:
             - run:
                 command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/*.apk)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
                 name: Upload android apks to github release
+            - run:
+                command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/debs/administration/*.deb)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
+                name: Upload administration debian package to github release
+            - run:
+                command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/debs/backend/*.deb)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
+                name: Upload backend debian packages to github release
             - notify:
                 allow-all-branches: false
                 channel: releases

--- a/.circleci/src/jobs/notify_release.yml
+++ b/.circleci/src/jobs/notify_release.yml
@@ -16,6 +16,12 @@ steps:
   - run:
       name: Upload android apks to github release
       command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/*.apk)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
+  - run:
+      name: Upload administration debian package to github release
+      command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/debs/administration/*.deb)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
+  - run:
+      name: Upload backend debian packages to github release
+      command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/debs/backend/*.deb)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
   - notify:
       success_message: <<^ parameters.production_delivery >>[Beta] <</ parameters.production_delivery >>Ehrenamtskarte Bayern und Sozialpass Nürnberg ${NEW_VERSION_NAME} have been released successfully! https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/tag/${NEW_VERSION_NAME}-all
       channel: releases


### PR DESCRIPTION
### Short description

To be able to restore a certain backend and administration version, we should upload the debian packages to github releases, since they debian files will be cleaned for the servers every 31 days

### Proposed changes

<!-- Describe this PR in more detail. -->

- add upload step to notify release

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1442

Here you can find the "test" release
https://github.com/digitalfabrik/entitlementcard/releases/tag/2024.5.0-all
