### PR TITLE
Fix ios build commit main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,8 @@ commands:
             - run:
                 command: |
                     brew tap dart-lang/dart
-                    brew install dart
-                    brew link dart
+                    brew install dart@3.3.1
+                    brew link dart@3.3.1
                 name: Install Dart
             - save_cache:
                 key: brew-dart-4

--- a/.circleci/src/commands/install_dart_mac.yml
+++ b/.circleci/src/commands/install_dart_mac.yml
@@ -6,8 +6,8 @@ steps:
       name: Install Dart
       command: |
         brew tap dart-lang/dart
-        brew install dart
-        brew link dart
+        brew install dart@3.3.1
+        brew link dart@3.3.1
   - save_cache:
       key: brew-dart-4
       paths:


### PR DESCRIPTION
### Short description

Looks like protobuf flutter plugin fails with new dart version which was not locked for mac.

### Proposed changes

<!-- Describe this PR in more detail. -->

- lock dart version @3.3.1

Check working pipeline here: https://app.circleci.com/pipelines/github/digitalfabrik/entitlementcard/5331/workflows/20653ee9-54d6-48c7-b255-e6b03bd5c71d
