### PR TITLE
1391: Notes only queryable by admins

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/database/repos/ApplicationRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/database/repos/ApplicationRepository.kt
@@ -89,11 +89,11 @@ object ApplicationRepository {
         return mapper.writeValueAsString(obj)
     }
 
-    fun getApplications(regionId: Int): List<ApplicationView> {
+    fun getApplicationsByAdmin(regionId: Int): List<ApplicationView> {
         return transaction {
             ApplicationEntity.find { Applications.regionId eq regionId }
                 .orderBy(Applications.createdDate to SortOrder.ASC)
-                .map { ApplicationView.fromDbEntity(it) }
+                .map { ApplicationView.fromDbEntity(it, true) }
         }
     }
 

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/EakApplicationQueryService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/EakApplicationQueryService.kt
@@ -29,7 +29,7 @@ class EakApplicationQueryService {
                 throw ForbiddenException()
             }
 
-            ApplicationRepository.getApplications(regionId)
+            ApplicationRepository.getApplicationsByAdmin(regionId)
         }
     }
 

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/schema/view/ApplicationView.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/schema/view/ApplicationView.kt
@@ -9,8 +9,12 @@ import java.util.concurrent.CompletableFuture
 @Suppress("unused")
 data class ApplicationView(val id: Int, val regionId: Int, val createdDate: String, val jsonValue: String, val withdrawalDate: String?, val note: String?) {
     companion object {
-        fun fromDbEntity(entity: ApplicationEntity): ApplicationView =
-            ApplicationView(entity.id.value, entity.regionId.value, entity.createdDate.toString(), entity.jsonValue, entity.withdrawalDate?.toString(), entity.note)
+        fun fromDbEntity(entity: ApplicationEntity, includePrivateInformation: Boolean = false): ApplicationView {
+            if (includePrivateInformation) {
+                return ApplicationView(entity.id.value, entity.regionId.value, entity.createdDate.toString(), entity.jsonValue, entity.withdrawalDate?.toString(), entity.note)
+            }
+            return ApplicationView(entity.id.value, entity.regionId.value, entity.createdDate.toString(), entity.jsonValue, entity.withdrawalDate?.toString(), null)
+        }
     }
 
     fun verifications(environment: DataFetchingEnvironment): CompletableFuture<List<ApplicationVerificationView>> =


### PR DESCRIPTION
### Short description

Currently a not authorized user such as applicant or verifier could add "note" into the graphl query and get private notes from the application.

### Proposed changes

<!-- Describe this PR in more detail. -->

- add a flag `includePrivateInformation` and only populates notes int the ApplicationView if its set to true


### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1391
