### PR TITLE
1455: Improve debian package installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -749,16 +749,10 @@ jobs:
                         name: '[FL] TestFlight Upload'
                         working_directory: frontend/ios
             - notify
-    deliver_to_server:
+    install_packages_to_server:
         docker:
             - image: cimg/base:2022.09
         parameters:
-            bundle:
-                description: Defines which bundle should be deployed to the server.
-                enum:
-                    - administration
-                    - backend
-                type: enum
             production:
                 description: Whether builds are delivered to production or beta.
                 type: boolean
@@ -772,37 +766,20 @@ jobs:
                 name: Install Curl, node and npm
             - install_app_toolbelt
             - prepare_workspace
-            - add_ssh_keys:
-                fingerprints:
-                    - a1:3f:a7:c3:ff:12:40:1d:85:de:a7:ab:12:3f:cc:05
             - when:
                 condition: << parameters.production >>
                 steps:
                     - run:
                         command: |
-                            mkdir -p /home/circleci/.ssh
-                            echo ${APT_FINGERPRINT_PRODUCTION} >> /home/circleci/.ssh/known_hosts
-                            echo "Uploading: " ~/attached_workspace/debs/<< parameters.bundle >>/*.deb
-                            sftp -b - ci@entitlementcard.tuerantuer.org:/srv/local-apt-repository/ \<<< "put -r /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb"
-                        name: SFTP upload package
-                    - run:
-                        command: |
-                            curl https://webhook.entitlementcard.tuerantuer.org/hooks/install-<< parameters.bundle >>-$EAK_WEBHOOK
-                        name: Install package via webhook
+                            curl https://webhook.entitlementcard.tuerantuer.org/hooks/install-backend-admin-$EAK_WEBHOOK
+                        name: Install packages via webhook
             - unless:
                 condition: << parameters.production >>
                 steps:
                     - run:
                         command: |
-                            mkdir -p /home/circleci/.ssh
-                            echo ${APT_FINGERPRINT_STAGING} >> /home/circleci/.ssh/known_hosts
-                            echo "Uploading: " /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb
-                            sftp -b - ci@entitlementcard-test.tuerantuer.org:/srv/local-apt-repository/ \<<< "put -r /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb"
-                        name: SFTP upload package
-                    - run:
-                        command: |
-                            curl https://webhook.entitlementcard-test.tuerantuer.org/hooks/install-<< parameters.bundle >>-$EAK_WEBHOOK
-                        name: Install package via webhook
+                            curl https://webhook.entitlementcard-test.tuerantuer.org/hooks/install-backend-admin-$EAK_WEBHOOK
+                        name: Install packages via webhook
             - notify
     notify_release:
         docker:
@@ -981,13 +958,12 @@ jobs:
         steps:
             - checkout:
                 path: ~/project
-            - run: sudo apt update -y && sudo apt install -y nodejs npm
-            - install_app_toolbelt
             - run:
                 command: |
                     sudo apt update
-                    sudo apt install curl -y
-                name: Install Curl
+                    sudo apt install -y curl nodejs npm
+                name: Install Curl, node and npm
+            - install_app_toolbelt
             - prepare_workspace
             - add_ssh_keys:
                 fingerprints:
@@ -1001,12 +977,62 @@ jobs:
                 name: Transfer artifacts to production
             - run:
                 command: |
-                    curl https://webhook.entitlementcard.tuerantuer.org/hooks/install-administration-$EAK_WEBHOOK
-                name: Install administration package via webhook
+                    curl https://webhook.entitlementcard.tuerantuer.org/hooks/install-backend-admin-$EAK_WEBHOOK
+                name: Install administration & backend packages via webhook
+            - notify
+    upload_packages_to_server:
+        docker:
+            - image: cimg/base:2022.09
+        parameters:
+            bundle:
+                description: Defines which bundle should be deployed to the server.
+                enum:
+                    - administration
+                    - backend
+                type: enum
+            production:
+                description: Whether builds are delivered to production or beta.
+                type: boolean
+        steps:
+            - checkout:
+                path: ~/project
             - run:
                 command: |
-                    curl https://webhook.entitlementcard.tuerantuer.org/hooks/install-backend-$EAK_WEBHOOK
-                name: Install backend packages via webhook
+                    sudo apt update
+                    sudo apt install -y nodejs npm
+                name: Install node and npm
+            - install_app_toolbelt
+            - prepare_workspace
+            - add_ssh_keys:
+                fingerprints:
+                    - a1:3f:a7:c3:ff:12:40:1d:85:de:a7:ab:12:3f:cc:05
+            - when:
+                condition: << parameters.production >>
+                steps:
+                    - run:
+                        command: |
+                            mkdir -p /home/circleci/.ssh
+                            echo ${APT_FINGERPRINT_PRODUCTION} >> /home/circleci/.ssh/known_hosts
+                            echo "Uploading: " ~/attached_workspace/debs/<< parameters.bundle >>/*.deb
+                            sftp -b - ci@entitlementcard.tuerantuer.org:/srv/local-apt-repository/ \<<< "put -r /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb"
+                        name: SFTP upload package
+                    - run:
+                        command: |
+                            mkdir -p /home/circleci/.ssh
+                            echo ${APT_FINGERPRINT_PRODUCTION} >> /home/circleci/.ssh/known_hosts
+                            echo "Uploading: " ~/attached_workspace/debs/<< parameters.bundle >>/*.deb
+                            sftp -b - ci@entitlementcard.tuerantuer.org:/srv/local-apt-repository/ \<<< "put -r /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb"
+                        name: SFTP upload package
+            - unless:
+                condition: << parameters.production >>
+                steps:
+                    - run:
+                        command: |
+                            mkdir -p /home/circleci/.ssh
+                            echo ${APT_FINGERPRINT_STAGING} >> /home/circleci/.ssh/known_hosts
+                            echo "Uploading: " /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb
+                            sftp -b - ci@entitlementcard-test.tuerantuer.org:/srv/local-apt-repository/ \<<< "put -r /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb"
+                        name: SFTP upload package
             - notify
 orbs:
     browser-tools: circleci/browser-tools@1.4.1
@@ -1244,28 +1270,36 @@ workflows:
             - pack_meta:
                 requires:
                     - bump_version
-            - deliver_to_server:
+            - upload_packages_to_server:
                 bundle: administration
                 context:
                     - credentials-ehrenamtskarte
-                name: deliver_administration_staging
+                name: upload_administration_packages_to_server_staging
                 production: false
                 requires:
                     - pack_administration
                     - check_health_backend
                     - pack_martin
                     - pack_meta
-            - deliver_to_server:
+            - upload_packages_to_server:
                 bundle: backend
                 context:
                     - credentials-ehrenamtskarte
-                name: deliver_backend_staging
+                name: upload_backend_packages_to_server_staging
                 production: false
                 requires:
                     - pack_administration
                     - check_health_backend
                     - pack_martin
                     - pack_meta
+            - install_packages_to_server:
+                context:
+                    - credentials-ehrenamtskarte
+                name: install_packages_to_server_staging
+                production: false
+                requires:
+                    - upload_administration_packages_to_server_staging
+                    - upload_backend_packages_to_server_staging
         when: << pipeline.parameters.run_delivery_beta_all >>
     deliver_beta_backend_administration:
         jobs:
@@ -1300,28 +1334,36 @@ workflows:
             - pack_meta:
                 requires:
                     - bump_version
-            - deliver_to_server:
+            - upload_packages_to_server:
                 bundle: administration
                 context:
                     - credentials-ehrenamtskarte
-                name: deliver_administration_staging
+                name: upload_administration_packages_to_server_staging
                 production: false
                 requires:
                     - pack_administration
                     - check_health_backend
                     - pack_martin
                     - pack_meta
-            - deliver_to_server:
+            - upload_packages_to_server:
                 bundle: backend
                 context:
                     - credentials-ehrenamtskarte
-                name: deliver_backend_staging
+                name: upload_backend_packages_to_server_staging
                 production: false
                 requires:
                     - pack_administration
                     - check_health_backend
                     - pack_martin
                     - pack_meta
+            - install_packages_to_server:
+                context:
+                    - credentials-ehrenamtskarte
+                name: install_packages_to_server_staging
+                production: false
+                requires:
+                    - upload_administration_packages_to_server_staging
+                    - upload_backend_packages_to_server_staging
         when: << pipeline.parameters.run_deliver_beta_backend_administration >>
     deliver_production_backend_administration:
         jobs:
@@ -1356,28 +1398,36 @@ workflows:
             - pack_meta:
                 requires:
                     - bump_version
-            - deliver_to_server:
+            - upload_packages_to_server:
                 bundle: administration
                 context:
                     - credentials-ehrenamtskarte
-                name: deliver_administration_production
+                name: upload_administration_packages_to_server_production
                 production: true
                 requires:
                     - pack_administration
                     - check_health_backend
                     - pack_martin
                     - pack_meta
-            - deliver_to_server:
+            - upload_packages_to_server:
                 bundle: backend
                 context:
                     - credentials-ehrenamtskarte
-                name: deliver_backend_production
+                name: upload_backend_packages_to_server_production
                 production: true
                 requires:
                     - pack_administration
                     - check_health_backend
                     - pack_martin
                     - pack_meta
+            - install_packages_to_server:
+                context:
+                    - credentials-ehrenamtskarte
+                name: install_packages_to_server_production
+                production: true
+                requires:
+                    - upload_administration_packages_to_server_staging
+                    - upload_backend_packages_to_server_staging
         when: << pipeline.parameters.run_deliver_production_backend_administration >>
     delivery_beta_native:
         jobs:

--- a/.circleci/src/jobs/install_packages_to_server.yml
+++ b/.circleci/src/jobs/install_packages_to_server.yml
@@ -1,0 +1,31 @@
+docker:
+  - image: cimg/base:2022.09
+parameters:
+  production:
+    description: Whether builds are delivered to production or beta.
+    type: boolean
+steps:
+  - checkout:
+      path: ~/project
+  - run:
+      name: Install Curl, node and npm
+      command: |
+        sudo apt update
+        sudo apt install -y curl nodejs npm
+  - install_app_toolbelt
+  - prepare_workspace
+  - when:
+      condition: << parameters.production >>
+      steps:
+        - run:
+            name: Install packages via webhook
+            command: |
+              curl https://webhook.entitlementcard.tuerantuer.org/hooks/install-backend-admin-$EAK_WEBHOOK
+  - unless:
+      condition: << parameters.production >>
+      steps:
+        - run:
+            name: Install packages via webhook
+            command: |
+              curl https://webhook.entitlementcard-test.tuerantuer.org/hooks/install-backend-admin-$EAK_WEBHOOK
+  - notify

--- a/.circleci/src/jobs/promote_to_server.yml
+++ b/.circleci/src/jobs/promote_to_server.yml
@@ -3,13 +3,12 @@ docker:
 steps:
   - checkout:
       path: ~/project
-  - run: sudo apt update -y && sudo apt install -y nodejs npm
-  - install_app_toolbelt
   - run:
-      name: Install Curl
+      name: Install Curl, node and npm
       command: |
         sudo apt update
-        sudo apt install curl -y
+        sudo apt install -y curl nodejs npm
+  - install_app_toolbelt
   - prepare_workspace
   - add_ssh_keys:
       fingerprints:
@@ -22,11 +21,7 @@ steps:
               echo ${APT_FINGERPRINT_PRODUCTION} >> /home/circleci/.ssh/known_hosts
               scp ci@entitlementcard-test.tuerantuer.org:/srv/local-apt-repository/eak*.deb ci@entitlementcard.tuerantuer.org:/srv/local-apt-repository/
   - run:
-      name: Install administration package via webhook
+      name: Install administration & backend packages via webhook
       command: |
-              curl https://webhook.entitlementcard.tuerantuer.org/hooks/install-administration-$EAK_WEBHOOK
-  - run:
-      name: Install backend packages via webhook
-      command: |
-              curl https://webhook.entitlementcard.tuerantuer.org/hooks/install-backend-$EAK_WEBHOOK
+              curl https://webhook.entitlementcard.tuerantuer.org/hooks/install-backend-admin-$EAK_WEBHOOK
   - notify

--- a/.circleci/src/jobs/upload_packages_to_server.yml
+++ b/.circleci/src/jobs/upload_packages_to_server.yml
@@ -12,10 +12,10 @@ steps:
   - checkout:
       path: ~/project
   - run:
-      name: Install Curl, node and npm
+      name: Install node and npm
       command: |
         sudo apt update
-        sudo apt install -y curl nodejs npm
+        sudo apt install -y nodejs npm
   - install_app_toolbelt
   - prepare_workspace
   - add_ssh_keys:
@@ -32,9 +32,12 @@ steps:
               echo "Uploading: " ~/attached_workspace/debs/<< parameters.bundle >>/*.deb
               sftp -b - ci@entitlementcard.tuerantuer.org:/srv/local-apt-repository/ \<<< "put -r /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb"
         - run:
-            name: Install package via webhook
+            name: SFTP upload package
             command: |
-              curl https://webhook.entitlementcard.tuerantuer.org/hooks/install-<< parameters.bundle >>-$EAK_WEBHOOK
+              mkdir -p /home/circleci/.ssh
+              echo ${APT_FINGERPRINT_PRODUCTION} >> /home/circleci/.ssh/known_hosts
+              echo "Uploading: " ~/attached_workspace/debs/<< parameters.bundle >>/*.deb
+              sftp -b - ci@entitlementcard.tuerantuer.org:/srv/local-apt-repository/ \<<< "put -r /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb"
   - unless:
       condition: << parameters.production >>
       steps:
@@ -45,8 +48,4 @@ steps:
               echo ${APT_FINGERPRINT_STAGING} >> /home/circleci/.ssh/known_hosts
               echo "Uploading: " /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb
               sftp -b - ci@entitlementcard-test.tuerantuer.org:/srv/local-apt-repository/ \<<< "put -r /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb"
-        - run:
-            name: Install package via webhook
-            command: |
-              curl https://webhook.entitlementcard-test.tuerantuer.org/hooks/install-<< parameters.bundle >>-$EAK_WEBHOOK
   - notify

--- a/.circleci/src/workflows/deliver_beta_all.yml
+++ b/.circleci/src/workflows/deliver_beta_all.yml
@@ -116,8 +116,8 @@ jobs:
   - pack_meta:
       requires:
         - bump_version
-  - deliver_to_server:
-      name: deliver_administration_staging
+  - upload_packages_to_server:
+      name: upload_administration_packages_to_server_staging
       production: false
       bundle: administration
       context:
@@ -127,8 +127,8 @@ jobs:
         - check_health_backend
         - pack_martin
         - pack_meta
-  - deliver_to_server:
-      name: deliver_backend_staging
+  - upload_packages_to_server:
+      name: upload_backend_packages_to_server_staging
       production: false
       bundle: backend
       context:
@@ -138,3 +138,11 @@ jobs:
         - check_health_backend
         - pack_martin
         - pack_meta
+  - install_packages_to_server:
+      name: install_packages_to_server_staging
+      production: false
+      context:
+        - credentials-ehrenamtskarte
+      requires:
+        - upload_administration_packages_to_server_staging
+        - upload_backend_packages_to_server_staging

--- a/.circleci/src/workflows/deliver_beta_backend_administration.yml
+++ b/.circleci/src/workflows/deliver_beta_backend_administration.yml
@@ -31,8 +31,8 @@ jobs:
   - pack_meta:
       requires:
         - bump_version
-  - deliver_to_server:
-      name: deliver_administration_staging
+  - upload_packages_to_server:
+      name: upload_administration_packages_to_server_staging
       production: false
       bundle: administration
       context:
@@ -42,8 +42,8 @@ jobs:
         - check_health_backend
         - pack_martin
         - pack_meta
-  - deliver_to_server:
-      name: deliver_backend_staging
+  - upload_packages_to_server:
+      name: upload_backend_packages_to_server_staging
       production: false
       bundle: backend
       context:
@@ -53,4 +53,13 @@ jobs:
         - check_health_backend
         - pack_martin
         - pack_meta
+  - install_packages_to_server:
+      name: install_packages_to_server_staging
+      production: false
+      context:
+        - credentials-ehrenamtskarte
+      requires:
+        - upload_administration_packages_to_server_staging
+        - upload_backend_packages_to_server_staging
+
 

--- a/.circleci/src/workflows/deliver_production_backend_administration.yml
+++ b/.circleci/src/workflows/deliver_production_backend_administration.yml
@@ -32,8 +32,8 @@ jobs:
   - pack_meta:
       requires:
         - bump_version
-  - deliver_to_server:
-      name: deliver_administration_production
+  - upload_packages_to_server:
+      name: upload_administration_packages_to_server_production
       production: true
       bundle: administration
       context:
@@ -43,8 +43,8 @@ jobs:
         - check_health_backend
         - pack_martin
         - pack_meta
-  - deliver_to_server:
-      name: deliver_backend_production
+  - upload_packages_to_server:
+      name: upload_backend_packages_to_server_production
       production: true
       bundle: backend
       context:
@@ -54,4 +54,12 @@ jobs:
         - check_health_backend
         - pack_martin
         - pack_meta
+  - install_packages_to_server:
+      name: install_packages_to_server_production
+      production: true
+      context:
+        - credentials-ehrenamtskarte
+      requires:
+        - upload_administration_packages_to_server_staging
+        - upload_backend_packages_to_server_staging
 


### PR DESCRIPTION
### Short description

The installation of the backend and administration fails quite often even if the debian packages are existing on the server. This may have different reasons like racing conditions or one webhook(administration) and second webhook(backend) blocks each other because they were triggered simultaneously

### Proposed changes

<!-- Describe this PR in more detail. -->

- merge package installation and trigger one webhook to avoid blocking installations
- separate package upload and package installation jobs

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1455

Relate to several salt prs: 
- https://git.tuerantuer.org/DF/salt/pulls/157 (added a apt repo rebuild to ensure that packages will be recognized directly after uploading before installation was started
- https://git.tuerantuer.org/DF/salt/pulls/158 merge the webhook
