### PR TITLE
1458: Remove endDate gold card

### DIFF
--- a/administration/src/bp-modules/cards/AddCardForm.tsx
+++ b/administration/src/bp-modules/cards/AddCardForm.tsx
@@ -57,7 +57,6 @@ const CreateCardForm = ({ cardBlueprint, onRemove, onUpdate }: CreateCardsFormPr
         <FormGroup label='Ablaufdatum'>
           <TextField
             fullWidth
-            disabled={cardBlueprint.hasInfiniteLifetime()}
             type='date'
             required
             size='small'

--- a/administration/src/bp-modules/cards/AddCardForm.tsx
+++ b/administration/src/bp-modules/cards/AddCardForm.tsx
@@ -53,33 +53,35 @@ const CreateCardForm = ({ cardBlueprint, onRemove, onUpdate }: CreateCardsFormPr
           }}
         />
       </FormGroup>
-      <FormGroup label='Ablaufdatum'>
-        <TextField
-          fullWidth
-          disabled={cardBlueprint.hasInfiniteLifetime()}
-          type='date'
-          required
-          size='small'
-          error={!cardBlueprint.isExpirationDateValid()}
-          value={cardBlueprint.expirationDate ? cardBlueprint.expirationDate.toString() : null}
-          sx={{ '& input[value=""]:not(:focus)': { color: 'transparent' }, '& fieldset': { borderRadius: 0 } }}
-          inputProps={{
-            style: { fontSize: 14, padding: '6px 10px' },
-            min: today.toString(),
-            max: today.add(maxCardValidity).toString(),
-          }}
-          onChange={e => {
-            if (e.target.value !== null) {
-              try {
-                cardBlueprint.expirationDate = PlainDate.from(e.target.value)
-                onUpdate()
-              } catch (error) {
-                console.error(`Could not parse date from string '${e.target.value}'.`, error)
+      {!cardBlueprint.hasInfiniteLifetime() && (
+        <FormGroup label='Ablaufdatum'>
+          <TextField
+            fullWidth
+            disabled={cardBlueprint.hasInfiniteLifetime()}
+            type='date'
+            required
+            size='small'
+            error={!cardBlueprint.isExpirationDateValid()}
+            value={cardBlueprint.expirationDate ? cardBlueprint.expirationDate.toString() : null}
+            sx={{ '& input[value=""]:not(:focus)': { color: 'transparent' }, '& fieldset': { borderRadius: 0 } }}
+            inputProps={{
+              style: { fontSize: 14, padding: '6px 10px' },
+              min: today.toString(),
+              max: today.add(maxCardValidity).toString(),
+            }}
+            onChange={e => {
+              if (e.target.value !== null) {
+                try {
+                  cardBlueprint.expirationDate = PlainDate.from(e.target.value)
+                  onUpdate()
+                } catch (error) {
+                  console.error(`Could not parse date from string '${e.target.value}'.`, error)
+                }
               }
-            }
-          }}
-        />
-      </FormGroup>
+            }}
+          />
+        </FormGroup>
+      )}
       {cardBlueprint.extensions.map((ext, i) => (
         <ExtensionForm key={i} extension={ext} onUpdate={onUpdate} />
       ))}


### PR DESCRIPTION
### Short description

As a service user it might be confusing if the field "Ablaufdatum" shows a particular date if gold card is selected, since gold card has an infinite lifetime

### Proposed changes

<!-- Describe this PR in more detail. -->

- only render "Ablaufdatum" field if "Standard" is the selected for card type

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1458

### Testing
- Create a card and select "Goldkarte"
- Field Ablaufdatum should disappear
- Choose Standard and the field should appear again
