### PR TITLE
release-2024.5.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1212,7 +1212,7 @@ workflows:
                 buildConfig: bayern
                 context:
                     - tuerantuer-apple
-                name: deliver_bayern_ios
+                name: deliver_ios_bayern
                 production_delivery: false
                 requires:
                     - build_ios_bayern
@@ -1230,7 +1230,7 @@ workflows:
                 buildConfig: nuernberg
                 context:
                     - tuerantuer-apple
-                name: deliver_nuernberg_ios
+                name: deliver_ios_nuernberg
                 production_delivery: false
                 requires:
                     - build_ios_nuernberg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -805,10 +805,6 @@ jobs:
             - run:
                 command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/debs/backend/*.deb)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
                 name: Upload backend debian packages to github release
-            - notify:
-                allow-all-branches: false
-                channel: releases
-                success_message: <<^ parameters.production_delivery >>[Beta] <</ parameters.production_delivery >>Ehrenamtskarte Bayern und Sozialpass Nürnberg ${NEW_VERSION_NAME} have been released successfully! https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/tag/${NEW_VERSION_NAME}-all
     pack_administration:
         docker:
             - image: debian:12
@@ -820,7 +816,6 @@ jobs:
             - prepare_workspace
             - restore_environment_variables
             - run: ~/project/scripts/pack_deb.sh -v "${NEW_VERSION_NAME}" -f ~/attached_workspace/administration/build -d "Administration backend for the Ehrenamtskarte app" -n "eak-administration"
-            - install_app_toolbelt
             - run: |
                 mkdir -p ~/attached_workspace/debs/administration
                 mv *.deb ~/attached_workspace/debs/administration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1033,7 +1033,6 @@ jobs:
                             echo "Uploading: " /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb
                             sftp -b - ci@entitlementcard-test.tuerantuer.org:/srv/local-apt-repository/ \<<< "put -r /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb"
                         name: SFTP upload package
-            - notify
 orbs:
     browser-tools: circleci/browser-tools@1.4.1
     gradle: circleci/gradle@2.2.0
@@ -1243,6 +1242,7 @@ workflows:
                     - deliver_android_nuernberg
                     - deliver_ios_bayern
                     - deliver_ios_nuernberg
+                    - install_packages_to_server_staging
             - check_administration
             - build_administration:
                 requires:

--- a/.circleci/src/jobs/notify_release.yml
+++ b/.circleci/src/jobs/notify_release.yml
@@ -22,7 +22,8 @@ steps:
   - run:
       name: Upload backend debian packages to github release
       command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/debs/backend/*.deb)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
-  - notify:
-      success_message: <<^ parameters.production_delivery >>[Beta] <</ parameters.production_delivery >>Ehrenamtskarte Bayern und Sozialpass Nürnberg ${NEW_VERSION_NAME} have been released successfully! https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/tag/${NEW_VERSION_NAME}-all
-      channel: releases
-      allow-all-branches: false
+# https://github.com/digitalfabrik/entitlementcard/issues/1453
+#  - notify:
+#      success_message: <<^ parameters.production_delivery >>[Beta] <</ parameters.production_delivery >>Ehrenamtskarte Bayern und Sozialpass Nürnberg ${NEW_VERSION_NAME} have been released successfully! https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/tag/${NEW_VERSION_NAME}-all
+#      channel: releases
+#      allow-all-branches: false

--- a/.circleci/src/jobs/pack_administration.yml
+++ b/.circleci/src/jobs/pack_administration.yml
@@ -8,7 +8,6 @@ steps:
   - prepare_workspace
   - restore_environment_variables
   - run: ~/project/scripts/pack_deb.sh -v "${NEW_VERSION_NAME}" -f ~/attached_workspace/administration/build -d "Administration backend for the Ehrenamtskarte app" -n "eak-administration"
-  - install_app_toolbelt
   - run: |
       mkdir -p ~/attached_workspace/debs/administration
       mv *.deb ~/attached_workspace/debs/administration

--- a/.circleci/src/jobs/upload_packages_to_server.yml
+++ b/.circleci/src/jobs/upload_packages_to_server.yml
@@ -48,4 +48,5 @@ steps:
               echo ${APT_FINGERPRINT_STAGING} >> /home/circleci/.ssh/known_hosts
               echo "Uploading: " /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb
               sftp -b - ci@entitlementcard-test.tuerantuer.org:/srv/local-apt-repository/ \<<< "put -r /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb"
-  - notify
+# https://github.com/digitalfabrik/entitlementcard/issues/1467
+#  - notify

--- a/.circleci/src/jobs/upload_packages_to_server.yml
+++ b/.circleci/src/jobs/upload_packages_to_server.yml
@@ -48,5 +48,5 @@ steps:
               echo ${APT_FINGERPRINT_STAGING} >> /home/circleci/.ssh/known_hosts
               echo "Uploading: " /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb
               sftp -b - ci@entitlementcard-test.tuerantuer.org:/srv/local-apt-repository/ \<<< "put -r /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb"
-# https://github.com/digitalfabrik/entitlementcard/issues/1467
+# https://github.com/digitalfabrik/entitlementcard/issues/1453
 #  - notify

--- a/.circleci/src/workflows/deliver_beta_all.yml
+++ b/.circleci/src/workflows/deliver_beta_all.yml
@@ -55,7 +55,7 @@ jobs:
         - tuerantuer-apple
         - fastlane-match
   - deliver_ios:
-      name: deliver_bayern_ios
+      name: deliver_ios_bayern
       buildConfig: bayern
       context:
         - tuerantuer-apple
@@ -73,7 +73,7 @@ jobs:
         - tuerantuer-apple
         - fastlane-match
   - deliver_ios:
-      name: deliver_nuernberg_ios
+      name: deliver_ios_nuernberg
       buildConfig: nuernberg
       context:
         - tuerantuer-apple

--- a/.circleci/src/workflows/deliver_beta_all.yml
+++ b/.circleci/src/workflows/deliver_beta_all.yml
@@ -89,6 +89,7 @@ jobs:
         - deliver_android_nuernberg
         - deliver_ios_bayern
         - deliver_ios_nuernberg
+        - install_packages_to_server_staging
   - check_administration
   - build_administration:
       requires:

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{"versionName":"2024.3.24","versionCode":163}
+{"versionName":"2024.5.3","versionCode":166}

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{"versionName":"2024.5.3","versionCode":166}
+{"versionName":"2024.5.6","versionCode":167}


### PR DESCRIPTION
### Short description

Latest release with missing bavaria administration artifacts.
Fixed some ci issues to get the delivery work

### Proposed changes

<!-- Describe this PR in more detail. -->

- renamed some steps because of wrong naming
- commented out non working notify step https://github.com/digitalfabrik/entitlementcard/issues/1453

Notes: We have different version numbers for native artifacts (2024.5.5) and backend (2024.5.6) since backend job failed at first run. Couldn't delete native store version versions to redeploy all, since they are in review. But it think its okay. But versions are based on the same tag
