### PR TITLE
1468: Bulk csv card export fails

### DIFF
--- a/administration/src/bp-modules/cards/ImportCardsController.tsx
+++ b/administration/src/bp-modules/cards/ImportCardsController.tsx
@@ -92,8 +92,8 @@ const InnerImportCardsController = ({ region }: { region: Region }): ReactElemen
       <CreateCardsButtonBar
         cardBlueprints={cardBlueprints}
         goBack={goBack}
-        generateCardsPdf={generateCardsPdf}
-        generateCardsCsv={generateCardsCsv}
+        generateCardsPdf={() => generateCardsPdf()}
+        generateCardsCsv={() => generateCardsCsv()}
       />
     </>
   )

--- a/administration/src/bp-modules/cards/hooks/useCardGenerator.ts
+++ b/administration/src/bp-modules/cards/hooks/useCardGenerator.ts
@@ -144,7 +144,7 @@ const useCardGenerator = (region: Region) => {
         }
         setState(CardActivationState.finished)
       } catch (error) {
-        handleError(error, codes)
+        await handleError(error, codes)
       } finally {
         setCardBlueprints([])
       }
@@ -154,7 +154,7 @@ const useCardGenerator = (region: Region) => {
 
   const generateCardsPdf = useCallback(
     async (applicationIdToMarkAsProcessed?: number) => {
-      generateCards(
+      await generateCards(
         (codes: CreateCardsResult[], cardBlueprints: CardBlueprint[]) =>
           generatePdf(codes, cardBlueprints, region, projectConfig.pdf),
         'berechtigungskarten.pdf',
@@ -166,7 +166,7 @@ const useCardGenerator = (region: Region) => {
 
   const generateCardsCsv = useCallback(
     async (applicationIdToMarkAsProcessed?: number) => {
-      generateCards(
+      await generateCards(
         (codes: CreateCardsResult[], cardBlueprints: CardBlueprint[]) =>
           generateCsv(codes, cardBlueprints, projectConfig.csvExport),
         getCSVFilename(cardBlueprints),


### PR DESCRIPTION
### Short description

Execution of export csv cards and print cards with bulk data fails

### Proposed changes

<!-- Describe this PR in more detail. -->

- adjust function executions


### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none
-

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1468

### Testing
1. Go to "Mehrere Karten erstellen"
2. use csv import file from `administration/resources/cards/sample-nbg.csv`
3. click csv export
4. repeat step 1. and 2. and click QR-Codes drucken
