### PR TITLE
1453: Fix failing notify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,7 @@ commands:
 jobs:
     build_administration:
         docker:
-            - image: cimg/node:19.1.0
+            - image: cimg/node:20.13.1
         steps:
             - checkout:
                 path: ~/project
@@ -484,7 +484,7 @@ jobs:
         working_directory: ~/martin
     bump_version:
         docker:
-            - image: cimg/node:18.14.1
+            - image: cimg/node:20.13.1
         parameters:
             prepare_delivery:
                 default: false
@@ -523,7 +523,7 @@ jobs:
             - notify
     check:
         docker:
-            - image: cimg/node:19.1.0-browsers
+            - image: cimg/node:20.13.1-browsers
         environment:
             TOTAL_CPUS: 1
             TZ: Europe/Berlin
@@ -537,12 +537,13 @@ jobs:
             - notify
     check_administration:
         docker:
-            - image: cimg/node:19.1.0
+            - image: cimg/node:20.13.1
         steps:
             - checkout:
                 path: ~/project
             - install_dart_linux
             - install_protobuf_linux
+            - install_app_toolbelt
             - prepare_workspace
             - restore_npm_cache
             - run:
@@ -565,6 +566,7 @@ jobs:
                 command: npm run ts:check
                 name: Typescript
                 working_directory: ~/project/administration
+            - notify
         working_directory: ~/project
     check_backend:
         docker:
@@ -578,6 +580,7 @@ jobs:
             - run: git submodule sync
             - run: git submodule update --init
             - install_protobuf_linux
+            - install_app_toolbelt
             - prepare_workspace
             - restore_cache:
                 key: v3-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
@@ -603,10 +606,11 @@ jobs:
                 key: v3-gradle-cache-{{ checksum "build.gradle.kts" }}
                 paths:
                     - ~/.gradle/caches
+            - notify
         working_directory: ~/project/backend
     check_frontend:
         docker:
-            - image: cimg/node:19.1.0-browsers
+            - image: cimg/node:20.13.1-browsers
         resource_class: small
         steps:
             - checkout:
@@ -751,7 +755,7 @@ jobs:
             - notify
     install_packages_to_server:
         docker:
-            - image: cimg/base:2022.09
+            - image: cimg/node:20.13.1
         parameters:
             production:
                 description: Whether builds are delivered to production or beta.
@@ -759,11 +763,6 @@ jobs:
         steps:
             - checkout:
                 path: ~/project
-            - run:
-                command: |
-                    sudo apt update
-                    sudo apt install -y curl nodejs npm
-                name: Install Curl, node and npm
             - install_app_toolbelt
             - prepare_workspace
             - when:
@@ -783,7 +782,7 @@ jobs:
             - notify
     notify_release:
         docker:
-            - image: cimg/node:19.1.0
+            - image: cimg/node:20.13.1
         parameters:
             production_delivery:
                 description: Whether builds are delivered to the production or beta lane of the play store.
@@ -805,6 +804,10 @@ jobs:
             - run:
                 command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/debs/backend/*.deb)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
                 name: Upload backend debian packages to github release
+            - notify:
+                allow-all-branches: false
+                channel: releases
+                success_message: <<^ parameters.production_delivery >>[Beta] <</ parameters.production_delivery >>Ehrenamtskarte Bayern und Sozialpass Nürnberg ${NEW_VERSION_NAME} have been released successfully! https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/tag/${NEW_VERSION_NAME}-all
     pack_administration:
         docker:
             - image: debian:12
@@ -947,17 +950,13 @@ jobs:
                 command: bundle exec fastlane ios appstoreconnect_promote build_config_name:<< parameters.build_config_name >>
                 name: '[FL] Appstore Connect Store Promotion'
                 working_directory: frontend/ios
+            - notify
     promote_to_server:
         docker:
-            - image: cimg/base:2022.09
+            - image: cimg/node:20.13.1
         steps:
             - checkout:
                 path: ~/project
-            - run:
-                command: |
-                    sudo apt update
-                    sudo apt install -y curl nodejs npm
-                name: Install Curl, node and npm
             - install_app_toolbelt
             - prepare_workspace
             - add_ssh_keys:
@@ -977,7 +976,7 @@ jobs:
             - notify
     upload_packages_to_server:
         docker:
-            - image: cimg/base:2022.09
+            - image: cimg/node:20.13.1
         parameters:
             bundle:
                 description: Defines which bundle should be deployed to the server.
@@ -991,11 +990,6 @@ jobs:
         steps:
             - checkout:
                 path: ~/project
-            - run:
-                command: |
-                    sudo apt update
-                    sudo apt install -y nodejs npm
-                name: Install node and npm
             - install_app_toolbelt
             - prepare_workspace
             - add_ssh_keys:
@@ -1028,6 +1022,7 @@ jobs:
                             echo "Uploading: " /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb
                             sftp -b - ci@entitlementcard-test.tuerantuer.org:/srv/local-apt-repository/ \<<< "put -r /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb"
                         name: SFTP upload package
+            - notify
 orbs:
     browser-tools: circleci/browser-tools@1.4.1
     gradle: circleci/gradle@2.2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,9 +261,9 @@ jobs:
         steps:
             - checkout:
                 path: ~/project
+            - install_app_toolbelt
             - install_dart_linux
             - install_protobuf_linux
-            - install_app_toolbelt
             - prepare_workspace
             - restore_environment_variables
             - restore_npm_cache
@@ -314,10 +314,10 @@ jobs:
             - add_ssh_keys:
                 fingerprints:
                     - 24:1d:3b:b7:b3:49:69:d7:54:c3:93:a5:a2:d1:71:db
+            - install_app_toolbelt
             - prepare_workspace
             - install_dart_linux
             - install_fvm
-            - install_app_toolbelt
             - install_protobuf_linux:
                 dart_plugin: true
             - restore_environment_variables
@@ -410,9 +410,9 @@ jobs:
         steps:
             - checkout:
                 path: ~/project
+            - install_app_toolbelt
             - install_dart_mac
             - install_fvm
-            - install_app_toolbelt
             - install_protobuf_mac
             - prepare_workspace
             - restore_environment_variables
@@ -541,9 +541,9 @@ jobs:
         steps:
             - checkout:
                 path: ~/project
+            - install_app_toolbelt
             - install_dart_linux
             - install_protobuf_linux
-            - install_app_toolbelt
             - prepare_workspace
             - restore_npm_cache
             - run:
@@ -579,8 +579,8 @@ jobs:
                 path: ~/project
             - run: git submodule sync
             - run: git submodule update --init
-            - install_protobuf_linux
             - install_app_toolbelt
+            - install_protobuf_linux
             - prepare_workspace
             - restore_cache:
                 key: v3-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
@@ -615,10 +615,10 @@ jobs:
         steps:
             - checkout:
                 path: ~/project
+            - install_app_toolbelt
             - browser-tools/install-chrome
             - install_dart_linux
             - install_fvm
-            - install_app_toolbelt
             - install_protobuf_linux:
                 dart_plugin: true
             - run:
@@ -733,9 +733,9 @@ jobs:
         steps:
             - checkout:
                 path: ~/project
+            - install_app_toolbelt
             - prepare_workspace
             - restore_environment_variables
-            - install_app_toolbelt
             - restore_ruby_cache:
                 directory: ~/project/frontend/ios
             - when:
@@ -789,9 +789,9 @@ jobs:
                 type: boolean
         resource_class: small
         steps:
+            - install_app_toolbelt
             - prepare_workspace
             - restore_environment_variables
-            - install_app_toolbelt
             - run:
                 command: echo "export RELEASE_ID='$(app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} <<# parameters.production_delivery >>--production-release<</ parameters.production_delivery >>)'" >> ${BASH_ENV}
                 name: Create github release
@@ -835,10 +835,10 @@ jobs:
         steps:
             - checkout:
                 path: ~/project
-            - prepare_workspace
-            - restore_environment_variables
             - run: apt update -y && apt install -y nodejs npm
             - install_app_toolbelt
+            - prepare_workspace
+            - restore_environment_variables
             - run: ~/project/scripts/pack_deb.sh -v "${NEW_VERSION_NAME}" -t ~/attached_workspace/backend/build/distributions/*.tar -s ~/project/scripts/eak-backend.service -d "Backend server for the Ehrenamtskarte app" -n "eak-backend" -c "openjdk-17-jre-headless"
             - run: |
                 mkdir -p ~/attached_workspace/debs/backend
@@ -888,11 +888,11 @@ jobs:
         steps:
             - checkout:
                 path: ~/project
+            - run: apt update -y && apt install -y nodejs npm
+            - install_app_toolbelt
             - prepare_workspace
             - restore_environment_variables
             - run: ~/project/scripts/pack_deb.sh -v "${NEW_VERSION_NAME}" -d "Meta package for the Ehrenamtskarte app" -n "eak" -c "eak-backend, eak-administration, eak-martin"
-            - run: apt update -y && apt install -y nodejs npm
-            - install_app_toolbelt
             - run: |
                 mkdir -p ~/attached_workspace/debs/backend
                 cp *.deb ~/attached_workspace/debs/backend
@@ -920,9 +920,9 @@ jobs:
         steps:
             - checkout:
                 path: ~/project
+            - install_app_toolbelt
             - restore_ruby_cache:
                 directory: ~/project/frontend/android
-            - install_app_toolbelt
             - run:
                 command: bundle exec fastlane android playstore_promote build_config_name:<< parameters.build_config_name >>
                 name: '[FL] Play Store Promotion'
@@ -943,9 +943,9 @@ jobs:
         shell: /bin/bash --login -o pipefail
         steps:
             - checkout
+            - install_app_toolbelt
             - restore_ruby_cache:
                 directory: ~/project/frontend/ios
-            - install_app_toolbelt
             - run:
                 command: bundle exec fastlane ios appstoreconnect_promote build_config_name:<< parameters.build_config_name >>
                 name: '[FL] Appstore Connect Store Promotion'

--- a/.circleci/src/jobs/build_administration.yml
+++ b/.circleci/src/jobs/build_administration.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: cimg/node:19.1.0
+  - image: cimg/node:20.13.1
 working_directory: ~/project
 steps:
   - checkout:

--- a/.circleci/src/jobs/build_administration.yml
+++ b/.circleci/src/jobs/build_administration.yml
@@ -4,9 +4,9 @@ working_directory: ~/project
 steps:
   - checkout:
       path: ~/project
+  - install_app_toolbelt
   - install_dart_linux
   - install_protobuf_linux
-  - install_app_toolbelt
   - prepare_workspace
   - restore_environment_variables
   - restore_npm_cache

--- a/.circleci/src/jobs/build_android.yml
+++ b/.circleci/src/jobs/build_android.yml
@@ -18,10 +18,10 @@ steps:
   - add_ssh_keys: # Needed for credentials repo
       fingerprints:
         - 24:1d:3b:b7:b3:49:69:d7:54:c3:93:a5:a2:d1:71:db
+  - install_app_toolbelt
   - prepare_workspace
   - install_dart_linux
   - install_fvm
-  - install_app_toolbelt
   - install_protobuf_linux:
       dart_plugin: true
   - restore_environment_variables

--- a/.circleci/src/jobs/build_ios.yml
+++ b/.circleci/src/jobs/build_ios.yml
@@ -12,9 +12,9 @@ parameters:
 steps:
   - checkout:
       path: ~/project
+  - install_app_toolbelt
   - install_dart_mac
   - install_fvm
-  - install_app_toolbelt
   - install_protobuf_mac
   - prepare_workspace
   - restore_environment_variables

--- a/.circleci/src/jobs/bump_version.yml
+++ b/.circleci/src/jobs/bump_version.yml
@@ -5,7 +5,7 @@ parameters:
     type: boolean
     default: false
 docker:
-  - image: cimg/node:18.14.1
+  - image: cimg/node:20.13.1
 resource_class: small
 steps:
   - checkout:

--- a/.circleci/src/jobs/check.yml
+++ b/.circleci/src/jobs/check.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: cimg/node:19.1.0-browsers
+  - image: cimg/node:20.13.1-browsers
 resource_class: small
 environment:
   TOTAL_CPUS: 1 # For resource_class small

--- a/.circleci/src/jobs/check_administration.yml
+++ b/.circleci/src/jobs/check_administration.yml
@@ -4,9 +4,9 @@ working_directory: ~/project
 steps:
   - checkout:
       path: ~/project
+  - install_app_toolbelt
   - install_dart_linux
   - install_protobuf_linux
-  - install_app_toolbelt
   - prepare_workspace
   - restore_npm_cache
   - run:

--- a/.circleci/src/jobs/check_administration.yml
+++ b/.circleci/src/jobs/check_administration.yml
@@ -1,11 +1,12 @@
 docker:
-  - image: cimg/node:19.1.0
+  - image: cimg/node:20.13.1
 working_directory: ~/project
 steps:
   - checkout:
       path: ~/project
   - install_dart_linux
   - install_protobuf_linux
+  - install_app_toolbelt
   - prepare_workspace
   - restore_npm_cache
   - run:
@@ -28,3 +29,4 @@ steps:
       name: Typescript
       command: npm run ts:check
       working_directory: ~/project/administration
+  - notify

--- a/.circleci/src/jobs/check_backend.yml
+++ b/.circleci/src/jobs/check_backend.yml
@@ -9,8 +9,8 @@ steps:
       path: ~/project
   - run: git submodule sync
   - run: git submodule update --init
-  - install_protobuf_linux
   - install_app_toolbelt
+  - install_protobuf_linux
   - prepare_workspace
   - restore_cache:
       key: v3-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}

--- a/.circleci/src/jobs/check_backend.yml
+++ b/.circleci/src/jobs/check_backend.yml
@@ -10,6 +10,7 @@ steps:
   - run: git submodule sync
   - run: git submodule update --init
   - install_protobuf_linux
+  - install_app_toolbelt
   - prepare_workspace
   - restore_cache:
       key: v3-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
@@ -35,3 +36,4 @@ steps:
       paths:
         - ~/.gradle/caches
       key: v3-gradle-cache-{{ checksum "build.gradle.kts" }}
+  - notify

--- a/.circleci/src/jobs/check_frontend.yml
+++ b/.circleci/src/jobs/check_frontend.yml
@@ -4,10 +4,10 @@ resource_class: small
 steps:
   - checkout:
       path: ~/project
+  - install_app_toolbelt
   - browser-tools/install-chrome
   - install_dart_linux
   - install_fvm
-  - install_app_toolbelt
   - install_protobuf_linux:
       dart_plugin: true
   - run:

--- a/.circleci/src/jobs/check_frontend.yml
+++ b/.circleci/src/jobs/check_frontend.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: cimg/node:19.1.0-browsers
+  - image: cimg/node:20.13.1-browsers
 resource_class: small
 steps:
   - checkout:

--- a/.circleci/src/jobs/deliver_ios.yml
+++ b/.circleci/src/jobs/deliver_ios.yml
@@ -14,9 +14,9 @@ shell: /bin/bash --login -o pipefail
 steps:
   - checkout:
       path: ~/project
+  - install_app_toolbelt
   - prepare_workspace
   - restore_environment_variables
-  - install_app_toolbelt
   - restore_ruby_cache:
       directory:  ~/project/frontend/ios
   - when:

--- a/.circleci/src/jobs/install_packages_to_server.yml
+++ b/.circleci/src/jobs/install_packages_to_server.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: cimg/base:2022.09
+  - image: cimg/node:20.13.1
 parameters:
   production:
     description: Whether builds are delivered to production or beta.
@@ -7,11 +7,6 @@ parameters:
 steps:
   - checkout:
       path: ~/project
-  - run:
-      name: Install Curl, node and npm
-      command: |
-        sudo apt update
-        sudo apt install -y curl nodejs npm
   - install_app_toolbelt
   - prepare_workspace
   - when:

--- a/.circleci/src/jobs/notify_release.yml
+++ b/.circleci/src/jobs/notify_release.yml
@@ -7,9 +7,9 @@ docker:
   - image: cimg/node:20.13.1
 resource_class: small
 steps:
+  - install_app_toolbelt
   - prepare_workspace
   - restore_environment_variables
-  - install_app_toolbelt
   - run:
       name: Create github release
       command: echo "export RELEASE_ID='$(app-toolbelt v0 release create all ${NEW_VERSION_NAME} ${NEW_VERSION_CODE} --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME} <<# parameters.production_delivery >>--production-release<</ parameters.production_delivery >>)'" >> ${BASH_ENV}

--- a/.circleci/src/jobs/notify_release.yml
+++ b/.circleci/src/jobs/notify_release.yml
@@ -4,7 +4,7 @@ parameters:
     description: Whether builds are delivered to the production or beta lane of the play store.
     type: boolean
 docker:
-  - image: cimg/node:19.1.0
+  - image: cimg/node:20.13.1
 resource_class: small
 steps:
   - prepare_workspace
@@ -22,8 +22,7 @@ steps:
   - run:
       name: Upload backend debian packages to github release
       command: app-toolbelt v0 release upload --releaseId ${RELEASE_ID} --files "$(ls ~/attached_workspace/debs/backend/*.deb)" --deliverino-private-key ${DELIVERINO_PRIVATE_KEY} --owner ${CIRCLE_PROJECT_USERNAME} --repo ${CIRCLE_PROJECT_REPONAME}
-# https://github.com/digitalfabrik/entitlementcard/issues/1453
-#  - notify:
-#      success_message: <<^ parameters.production_delivery >>[Beta] <</ parameters.production_delivery >>Ehrenamtskarte Bayern und Sozialpass Nürnberg ${NEW_VERSION_NAME} have been released successfully! https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/tag/${NEW_VERSION_NAME}-all
-#      channel: releases
-#      allow-all-branches: false
+  - notify:
+      success_message: <<^ parameters.production_delivery >>[Beta] <</ parameters.production_delivery >>Ehrenamtskarte Bayern und Sozialpass Nürnberg ${NEW_VERSION_NAME} have been released successfully! https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/tag/${NEW_VERSION_NAME}-all
+      channel: releases
+      allow-all-branches: false

--- a/.circleci/src/jobs/pack_backend.yml
+++ b/.circleci/src/jobs/pack_backend.yml
@@ -4,10 +4,10 @@ working_directory: ~/project/backend
 steps:
   - checkout:
       path: ~/project
-  - prepare_workspace
-  - restore_environment_variables
   - run: apt update -y && apt install -y nodejs npm
   - install_app_toolbelt
+  - prepare_workspace
+  - restore_environment_variables
   - run: ~/project/scripts/pack_deb.sh -v "${NEW_VERSION_NAME}" -t ~/attached_workspace/backend/build/distributions/*.tar -s ~/project/scripts/eak-backend.service -d "Backend server for the Ehrenamtskarte app" -n "eak-backend" -c "openjdk-17-jre-headless"
   - run: |
       mkdir -p ~/attached_workspace/debs/backend

--- a/.circleci/src/jobs/pack_meta.yml
+++ b/.circleci/src/jobs/pack_meta.yml
@@ -3,11 +3,11 @@ docker:
 steps:
   - checkout:
       path: ~/project
+  - run: apt update -y && apt install -y nodejs npm
+  - install_app_toolbelt
   - prepare_workspace
   - restore_environment_variables
   - run: ~/project/scripts/pack_deb.sh -v "${NEW_VERSION_NAME}" -d "Meta package for the Ehrenamtskarte app" -n "eak" -c "eak-backend, eak-administration, eak-martin"
-  - run: apt update -y && apt install -y nodejs npm
-  - install_app_toolbelt
   - run: |
       mkdir -p ~/attached_workspace/debs/backend
       cp *.deb ~/attached_workspace/debs/backend

--- a/.circleci/src/jobs/promote_android.yml
+++ b/.circleci/src/jobs/promote_android.yml
@@ -13,9 +13,9 @@ environment:
 steps:
   - checkout:
       path: ~/project
+  - install_app_toolbelt
   - restore_ruby_cache:
       directory: ~/project/frontend/android
-  - install_app_toolbelt
   - run:
       name: '[FL] Play Store Promotion'
       command: bundle exec fastlane android playstore_promote build_config_name:<< parameters.build_config_name >>

--- a/.circleci/src/jobs/promote_ios.yml
+++ b/.circleci/src/jobs/promote_ios.yml
@@ -11,9 +11,9 @@ environment:
 shell: /bin/bash --login -o pipefail
 steps:
   - checkout
+  - install_app_toolbelt
   - restore_ruby_cache:
       directory: ~/project/frontend/ios
-  - install_app_toolbelt
   - run:
       name: '[FL] Appstore Connect Store Promotion'
       command: bundle exec fastlane ios appstoreconnect_promote build_config_name:<< parameters.build_config_name >>

--- a/.circleci/src/jobs/promote_ios.yml
+++ b/.circleci/src/jobs/promote_ios.yml
@@ -18,3 +18,4 @@ steps:
       name: '[FL] Appstore Connect Store Promotion'
       command: bundle exec fastlane ios appstoreconnect_promote build_config_name:<< parameters.build_config_name >>
       working_directory: frontend/ios
+  - notify

--- a/.circleci/src/jobs/promote_to_server.yml
+++ b/.circleci/src/jobs/promote_to_server.yml
@@ -1,13 +1,8 @@
 docker:
-  - image: cimg/base:2022.09
+  - image: cimg/node:20.13.1
 steps:
   - checkout:
       path: ~/project
-  - run:
-      name: Install Curl, node and npm
-      command: |
-        sudo apt update
-        sudo apt install -y curl nodejs npm
   - install_app_toolbelt
   - prepare_workspace
   - add_ssh_keys:

--- a/.circleci/src/jobs/upload_packages_to_server.yml
+++ b/.circleci/src/jobs/upload_packages_to_server.yml
@@ -1,5 +1,5 @@
 docker:
-  - image: cimg/base:2022.09
+  - image: cimg/node:20.13.1
 parameters:
   production:
     description: Whether builds are delivered to production or beta.
@@ -11,11 +11,6 @@ parameters:
 steps:
   - checkout:
       path: ~/project
-  - run:
-      name: Install node and npm
-      command: |
-        sudo apt update
-        sudo apt install -y nodejs npm
   - install_app_toolbelt
   - prepare_workspace
   - add_ssh_keys:
@@ -48,5 +43,4 @@ steps:
               echo ${APT_FINGERPRINT_STAGING} >> /home/circleci/.ssh/known_hosts
               echo "Uploading: " /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb
               sftp -b - ci@entitlementcard-test.tuerantuer.org:/srv/local-apt-repository/ \<<< "put -r /home/circleci/attached_workspace/debs/<< parameters.bundle >>/*.deb"
-# https://github.com/digitalfabrik/entitlementcard/issues/1453
-#  - notify
+  - notify


### PR DESCRIPTION
### Short description

Notification fails due to node versions that have issues

### Proposed changes

<!-- Describe this PR in more detail. -->

- adjust node versions to lts
- use node img instead of base, since the nodejs version were not working
- add missing notifications to jobs

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- the images of node may be little bit larger than base but don't require installation of additional packages and are fixed to a particular version

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1453
