### PR TITLE
1465: Replace requirements link

### DIFF
--- a/administration/src/mui-modules/application/forms/StepCardTypeForm.tsx
+++ b/administration/src/mui-modules/application/forms/StepCardTypeForm.tsx
@@ -98,7 +98,7 @@ const StepCardTypeForm: Form<State, Options, ValidatedInput, AdditionalProps> = 
           Die Erfüllung der Voraussetzungen wird im nächsten Schritt des Antrags abgefragt. Weitere Informationen können
           Sie{' '}
           <a
-            href='https://www.ehrenamt.bayern.de/vorteile-wettbewerbe/ehrenamtskarte/'
+            href='https://www.ehrenamt.bayern.de/vorteile-wettbewerbe/ehrenamtskarte/index.php#sec3'
             target='_blank'
             rel='noreferrer'>
             hier einsehen


### PR DESCRIPTION
### Short description

The link for the requirements of the EC changed

### Proposed changes

<!-- Describe this PR in more detail. -->

- replace the link


### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1465

### Testing
1. http://localhost:3000/beantragen
2. type in personal data and go next
3. Check the link above "Blaue Ehrenamtskarte" -> "hier einsehen" for the requirements
