### PR TITLE
1470: Misleading wording empty list

### DIFF
--- a/administration/src/bp-modules/applications/ApplicationsOverview.tsx
+++ b/administration/src/bp-modules/applications/ApplicationsOverview.tsx
@@ -52,7 +52,7 @@ const sortApplications = (applications: Application[]): Application[] =>
     .sort((a, b) => sortByStatus(a.status, b.status) || sortByDateAsc(new Date(a.createdDate), new Date(b.createdDate)))
 
 const getEmptyApplicationsListStatusDescription = (activeBarItem: ApplicationStatusBarItemType): string => {
-  return activeBarItem.status ? `${activeBarItem.title.toLowerCase()}en` : ''
+  return activeBarItem.status !== undefined ? `${activeBarItem.title.toLowerCase()}en` : ''
 }
 
 const ApplicationsOverview = (props: { applications: Application[] }) => {

--- a/administration/src/bp-modules/applications/ApplicationsOverview.tsx
+++ b/administration/src/bp-modules/applications/ApplicationsOverview.tsx
@@ -51,6 +51,10 @@ const sortApplications = (applications: Application[]): Application[] =>
     }))
     .sort((a, b) => sortByStatus(a.status, b.status) || sortByDateAsc(new Date(a.createdDate), new Date(b.createdDate)))
 
+const getEmptyApplicationsListStatusDescription = (activeBarItem: ApplicationStatusBarItemType): string => {
+  return activeBarItem.status ? `${activeBarItem.title.toLowerCase()}en` : ''
+}
+
 const ApplicationsOverview = (props: { applications: Application[] }) => {
   const [updatedApplications, setUpdatedApplications] = useState(props.applications)
   const { applicationIdForPrint, printApplicationById } = usePrintApplication()
@@ -96,9 +100,11 @@ const ApplicationsOverview = (props: { applications: Application[] }) => {
       ) : (
         <StandaloneCenter>
           <NonIdealState
-            title='Keine Anträge vorhanden'
+            title={`Keine ${getEmptyApplicationsListStatusDescription(activeBarItem)} Anträge vorhanden`}
             icon='clean'
-            description='Aktuell liegen keine eingehenden Anträge vor. Schauen Sie später wieder vorbei.'
+            description={`Aktuell liegen keine ${getEmptyApplicationsListStatusDescription(
+              activeBarItem
+            )} Anträge vor. Schauen Sie später wieder vorbei.`}
           />
         </StandaloneCenter>
       )}


### PR DESCRIPTION
### Short description

For a service user the description of an empty list per status is not clear because the description is general

### Proposed changes

<!-- Describe this PR in more detail. -->

- add the particular status to the description and title for empty list message

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1470 

### Testing
- Go to applications
- Click on a status that is empty
- check description and title of the message
