### PR TITLE
1479: Missing withdrawed message

### DIFF
--- a/administration/src/mui-modules/application-verification/ApplicationVerificationController.tsx
+++ b/administration/src/mui-modules/application-verification/ApplicationVerificationController.tsx
@@ -41,7 +41,7 @@ type ApplicationVerificationProps = {
 }
 
 const ApplicationVerification = ({ applicationVerificationAccessKey }: ApplicationVerificationProps) => {
-  const [verificationFinised, setVerificationFinished] = useState(false)
+  const [verificationFinished, setVerificationFinished] = useState(false)
   const config = useContext(ProjectConfigContext)
   const { enqueueSnackbar } = useSnackbar()
   const [verifyOrRejectApplicationVerification] = useVerifyOrRejectApplicationVerificationMutation({
@@ -82,14 +82,14 @@ const ApplicationVerification = ({ applicationVerificationAccessKey }: Applicati
     return <CenteredMessage>Sie haben diesen Antrag bereits bearbeitet.</CenteredMessage>
   if (application.withdrawalDate)
     return (
-      <CenteredMessage
-        title={`Der Antrag wurde vom Antragsteller am ${formatDateWithTimezone(
+      <CenteredMessage>
+        {`Der Antrag wurde vom Antragsteller am ${formatDateWithTimezone(
           application.withdrawalDate,
           config.timezone
         )} zurückgezogen.`}
-      />
+      </CenteredMessage>
     )
-  if (verificationFinised)
+  if (verificationFinished)
     return (
       <CenteredMessage>
         <AlertTitle>Ihre Eingaben wurden erfolgreich gespeichert.</AlertTitle>


### PR DESCRIPTION
### Short description

If an application gets withdrawed by the applicant, the verifier doesn't get a proper message

### Proposed changes

<!-- Describe this PR in more detail. -->

- show a proper message to the verifier

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1479

### Testing
1. Create an application and set your mail address also for verification
2. Withdraw the application
3. Open the link in the verification mail
4. Check proper message
