### PR TITLE
1485: Improve activation route

### DIFF
--- a/administration/src/Router.tsx
+++ b/administration/src/Router.tsx
@@ -90,7 +90,7 @@ const Router = () => {
       },
     ]
     return createBrowserRouter(routes.filter((element): element is RouteObject => element !== null))
-  }, [authData, projectConfig.applicationFeature, signIn, signOut])
+  }, [authData, projectConfig.applicationFeature, signIn, signOut, projectConfig.cardStatistics])
 
   return <RouterProvider router={router} />
 }

--- a/administration/src/bp-modules/cards/hooks/useCardGenerator.ts
+++ b/administration/src/bp-modules/cards/hooks/useCardGenerator.ts
@@ -149,7 +149,15 @@ const useCardGenerator = (region: Region) => {
         setCardBlueprints([])
       }
     },
-    [cardBlueprints, client, projectConfig, handleError, sendCardConfirmationMails, projectConfig.csvExport]
+    [
+      cardBlueprints,
+      client,
+      projectConfig,
+      handleError,
+      sendCardConfirmationMails,
+      projectConfig.csvExport,
+      region.activatedForCardConfirmationMail,
+    ]
   )
 
   const generateCardsPdf = useCallback(
@@ -173,7 +181,7 @@ const useCardGenerator = (region: Region) => {
         applicationIdToMarkAsProcessed
       )
     },
-    [cardBlueprints, generateCards]
+    [cardBlueprints, generateCards, projectConfig.csvExport]
   )
 
   return {

--- a/administration/src/mui-modules/activation/ActivationPage.tsx
+++ b/administration/src/mui-modules/activation/ActivationPage.tsx
@@ -1,6 +1,7 @@
-import { Card } from '@mui/material'
+import { Alert, Card } from '@mui/material'
 import { styled } from '@mui/system'
 import React, { ReactElement, useContext } from 'react'
+import { useLocation } from 'react-router-dom'
 
 import { ProjectConfigContext } from '../../project-configs/ProjectConfigContext'
 import ActivationPageContent from './components/ActivationPageContent'
@@ -20,13 +21,22 @@ const StandaloneHorizontalCenter = styled('div')`
   margin-top: 10%;
 `
 
+const CenteredMessage = styled(Alert)`
+  margin: auto;
+`
+
 const ActivationPage = (): ReactElement | null => {
   const config = useContext(ProjectConfigContext)
+  const { hash } = useLocation()
+
+  if (!hash) {
+    return <CenteredMessage severity='error'>Ihr Aktivierungslink ist ungültig</CenteredMessage>
+  }
 
   return (
     <StandaloneHorizontalCenter>
       <CardContainer>
-        <ActivationPageContent config={config} />
+        <ActivationPageContent config={config} activationCode={hash} />
       </CardContainer>
     </StandaloneHorizontalCenter>
   )

--- a/administration/src/mui-modules/activation/components/ActivationPageContent.tsx
+++ b/administration/src/mui-modules/activation/components/ActivationPageContent.tsx
@@ -2,14 +2,21 @@ import React, { ReactElement } from 'react'
 
 import ProjectSwitcher from '../../../bp-modules/util/ProjectSwitcher'
 import { ProjectConfig } from '../../../project-configs/getProjectConfig'
+import getCustomDeepLinkFromActivationCode from '../../../util/getCustomDeepLinkFromActivationCode'
 
-const ActivationPageContent = ({ config }: { config: ProjectConfig }): ReactElement => {
+const ActivationPageContent = ({
+  config,
+  activationCode,
+}: {
+  config: ProjectConfig
+  activationCode: string
+}): ReactElement => {
   if (!config.activation) {
     return <ProjectSwitcher />
   }
   const { activationText, downloadLink } = config.activation
 
-  return <>{activationText(config.name, downloadLink)}</>
+  return <>{activationText(config.name, downloadLink, getCustomDeepLinkFromActivationCode(activationCode))}</>
 }
 
 export default ActivationPageContent

--- a/administration/src/project-configs/bayern/activationText.tsx
+++ b/administration/src/project-configs/bayern/activationText.tsx
@@ -1,11 +1,27 @@
-import { Typography } from '@mui/material'
+import { Button, Typography, styled } from '@mui/material'
 import React from 'react'
 
-export const ActivationText = (applicationName: string, downloadLink: string) => (
+const ActivationButton = styled(Button)`
+  margin-top: 12px;
+  :hover {
+    color: white;
+  }
+`
+
+export const ActivationText = (applicationName: string, downloadLink: string, deepLink: string) => (
   <div>
     <Typography variant='h6' mb='8px'>
       Aktivierung nur in der App möglich
     </Typography>
+    <span>
+      Falls sie die App Ehrenamtskarte installiert haben und sich dennoch ihr Browser geöffnet hat, nutzen Sie bitte
+      diese Schaltfläche zur Aktivierung: <br />{' '}
+      <ActivationButton href={deepLink} variant='contained' size='small'>
+        Karte aktivieren
+      </ActivationButton>
+      <br /> <br />
+      <b>Andernfalls befolgen Sie diese Schritte:</b>
+    </span>
     <ol>
       <li>
         Laden Sie sich die App <b>{applicationName}</b> im App- oder PlayStore auf Ihrem Smartphone herunter.

--- a/administration/src/project-configs/bayern/activationText.tsx
+++ b/administration/src/project-configs/bayern/activationText.tsx
@@ -14,7 +14,7 @@ export const ActivationText = (applicationName: string, downloadLink: string, de
       Aktivierung nur in der App möglich
     </Typography>
     <span>
-      Falls sie die App Ehrenamtskarte installiert haben und sich dennoch ihr Browser geöffnet hat, nutzen Sie bitte
+      Falls Sie die App Ehrenamtskarte installiert haben und sich dennoch Ihr Browser geöffnet hat, nutzen Sie bitte
       diese Schaltfläche zur Aktivierung: <br />{' '}
       <ActivationButton href={deepLink} variant='contained' size='small'>
         Karte aktivieren

--- a/administration/src/project-configs/getProjectConfig.ts
+++ b/administration/src/project-configs/getProjectConfig.ts
@@ -88,7 +88,7 @@ export interface ProjectConfig {
   timezone: string
   activityLogConfig?: ActivityLogConfig
   activation?: {
-    activationText: (applicationName: string, downloadLink: string) => ReactElement
+    activationText: (applicationName: string, downloadLink: string, deepLink: string) => ReactElement
     downloadLink: string
   }
   csvExport: CsvExport

--- a/administration/src/util/__tests__/getCustomDeepLinkFromActivationCode.test.ts
+++ b/administration/src/util/__tests__/getCustomDeepLinkFromActivationCode.test.ts
@@ -1,0 +1,17 @@
+import { ACTIVATION_FRAGMENT, ACTIVATION_PATH, BAYERN_STAGING_ID, CUSTOM_SCHEME } from 'build-configs'
+
+import { LOCAL_STORAGE_PROJECT_KEY } from '../../project-configs/constants'
+import { getBuildConfig } from '../getBuildConfig'
+import getCustomDeepLinkFromActivationCode from '../getCustomDeepLinkFromActivationCode'
+
+describe('Custom scheme deepLink generation', () => {
+  const activationCodeFromUrl = '#ChsKGQoJVGhlYSBUZXN0ENOiARoICgIIACICCAA%3D'
+
+  it('should generate a correct link', () => {
+    localStorage.setItem(LOCAL_STORAGE_PROJECT_KEY, BAYERN_STAGING_ID)
+    const projectId = getBuildConfig(window.location.hostname).common.projectId.production
+    expect(getCustomDeepLinkFromActivationCode(activationCodeFromUrl)).toBe(
+      `${CUSTOM_SCHEME}://${projectId}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}${activationCodeFromUrl}`
+    )
+  })
+})

--- a/administration/src/util/getCustomDeepLinkFromActivationCode.ts
+++ b/administration/src/util/getCustomDeepLinkFromActivationCode.ts
@@ -1,0 +1,9 @@
+import { ACTIVATION_FRAGMENT, ACTIVATION_PATH, CUSTOM_SCHEME } from 'build-configs'
+
+import { getBuildConfig } from './getBuildConfig'
+
+const getCustomSchemeDeepLinkFromCode = (activationCode: string): string => {
+  const host = getBuildConfig(window.location.hostname).common.projectId.production
+  return `${CUSTOM_SCHEME}://${host}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}${activationCode}`
+}
+export default getCustomSchemeDeepLinkFromCode

--- a/administration/src/util/getDeepLinkFromQrCode.test.ts
+++ b/administration/src/util/getDeepLinkFromQrCode.test.ts
@@ -60,21 +60,21 @@ describe('DeepLink generation', () => {
     localStorage.setItem(LOCAL_STORAGE_PROJECT_KEY, BAYERN_STAGING_ID)
     const projectId = getBuildConfig(window.location.hostname).common.projectId.staging
     expect(getDeepLinkFromQrCode(dynamicPdfQrCode)).toBe(
-      `${HTTPS_SCHEME}://${projectId}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}${encodedActivationCodeBase64}/`
+      `${HTTPS_SCHEME}://${projectId}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodedActivationCodeBase64}/`
     )
   })
   it('should generate a correct link for staging', () => {
     overrideHostname(BAYERN_STAGING_ID)
     const projectId = getBuildConfig(window.location.hostname).common.projectId.staging
     expect(getDeepLinkFromQrCode(dynamicPdfQrCode)).toBe(
-      `${HTTPS_SCHEME}://${projectId}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}${encodedActivationCodeBase64}/`
+      `${HTTPS_SCHEME}://${projectId}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodedActivationCodeBase64}/`
     )
   })
   it('should generate a correct link for production', () => {
     overrideHostname(BAYERN_PRODUCTION_ID)
     const projectId = getBuildConfig(window.location.hostname).common.projectId.production
     expect(getDeepLinkFromQrCode(dynamicPdfQrCode)).toBe(
-      `${HTTPS_SCHEME}://${projectId}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}${encodedActivationCodeBase64}/`
+      `${HTTPS_SCHEME}://${projectId}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodedActivationCodeBase64}/`
     )
   })
 })

--- a/administration/src/util/getDeepLinkFromQrCode.ts
+++ b/administration/src/util/getDeepLinkFromQrCode.ts
@@ -13,7 +13,7 @@ const getDeepLinkFromQrCode = (qrCode: PdfQrCode): string => {
   const buildConfigProjectId = getBuildConfig(window.location.hostname).common.projectId
   // custom link schemes don't work in browsers or pdf thats why we use the staging link scheme also for development
   const host = isStagingMode() || isDevMode() ? buildConfigProjectId.staging : buildConfigProjectId.production
-  const deepLink = `${HTTPS_SCHEME}://${host}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}${encodeURIComponent(
+  const deepLink = `${HTTPS_SCHEME}://${host}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodeURIComponent(
     uint8ArrayToBase64(qrCodeContent)
   )}/`
   if (isDevMode() || isStagingMode()) {

--- a/frontend/build-configs/constants/index.ts
+++ b/frontend/build-configs/constants/index.ts
@@ -1,5 +1,5 @@
 export const ACTIVATION_PATH = "activation"
-export const ACTIVATION_FRAGMENT = 'code#'
+export const ACTIVATION_FRAGMENT = 'code'
 
 export const CUSTOM_SCHEME = 'berechtigungskarte'
 export const HTTPS_SCHEME = 'https'


### PR DESCRIPTION
### Short description

Since we have some issues with associated domains on some android device, it may be useful to also provide a custom scheme link to the user for card activation since it works without domain association

### Proposed changes

<!-- Describe this PR in more detail. -->

- add button for card activation with custom scheme deeplink
- fixed some linting issues

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none 

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1485 

### Testing is quite difficult on local dev
1. Create a card
2. copy the pdf on your device
3. click on the qr code on the pdf and open with a browser
4. replace the domain with your local network ip to be able to load the local state f.e.
```js
http://192.168.161.22:3000//activation/code#CkkKHwoPQW5kcmVhcyBGaXNjaGVyEO2jARoICgIICSICCAASEAkhZfDlmmOKpEMx5vIR3aoaFKFbplTzRz55MY6S4wA16chnLn5J/
```
5. Switch to "Ehrenamtskarte" (will only appear in dev environment)
6. Click on "Karte aktivieren"
