### PR TITLE
1482: Fix typo in the card activation text

### DIFF
--- a/administration/src/project-configs/bayern/activationText.tsx
+++ b/administration/src/project-configs/bayern/activationText.tsx
@@ -35,7 +35,7 @@ export const ActivationText = (applicationName: string, downloadLink: string, de
         </a>
       </li>
       <li>
-        Öffnen Sie nach erfolgreicher Installation die PDF mit dem Aktivierungscode und führen Sie die Aktivierung
+        Öffnen Sie nach erfolgreicher Installation das PDF mit dem Aktivierungscode und führen Sie die Aktivierung
         erneut durch. Gegebenenfalls müssen Sie dabei die heruntergeladene App auswählen, um den Vorgang in der App zu
         starten.
       </li>


### PR DESCRIPTION
### Short description
Typo in the card activation text

### Resolved issues
Fixes: #1482
