### PR TITLE
1489: Note icon application header

### DIFF
--- a/administration/src/bp-modules/applications/ApplicationCard.tsx
+++ b/administration/src/bp-modules/applications/ApplicationCard.tsx
@@ -10,7 +10,7 @@ import {
   SectionCard,
   Tooltip,
 } from '@blueprintjs/core'
-import { memo, useContext, useMemo, useState } from 'react'
+import { ReactElement, memo, useContext, useMemo, useState } from 'react'
 import styled, { css } from 'styled-components'
 
 import getMessageFromApolloError from '../../errors/getMessageFromApolloError'
@@ -94,6 +94,13 @@ const SectionCardHeader = styled.div`
   flex-direction: row-reverse;
 `
 
+const RightElementContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 32px;
+`
+
 type ApplicationCardProps = {
   application: Application
   onDelete: () => void
@@ -148,6 +155,19 @@ const ApplicationCard = ({
     return !!blueCardJuleicaEntitlement
   }
 
+  const RightElement = (): ReactElement => {
+    return (
+      <RightElementContainer>
+        {application.note && <Icon icon='annotation' intent='none' />}
+        {isJuleicaEntitlementType() ? (
+          <JuleicaVerificationQuickIndicator />
+        ) : (
+          <VerificationsQuickIndicator verifications={application.verifications} />
+        )}
+      </RightElementContainer>
+    )
+  }
+
   return (
     <ApplicationViewCard
       title={
@@ -160,13 +180,7 @@ const ApplicationCard = ({
           )}
         </div>
       }
-      rightElement={
-        isJuleicaEntitlementType() ? (
-          <JuleicaVerificationQuickIndicator />
-        ) : (
-          <VerificationsQuickIndicator verifications={application.verifications} />
-        )
-      }
+      rightElement={<RightElement />}
       elevation={1}
       icon={withdrawalDate ? <Icon icon='warning-sign' intent='warning' /> : undefined}
       collapseProps={{ isOpen: isExpanded, onToggle: () => setIsExpanded(!isExpanded), keepChildrenMounted: true }}

--- a/administration/src/bp-modules/applications/ApplicationCard.tsx
+++ b/administration/src/bp-modules/applications/ApplicationCard.tsx
@@ -158,7 +158,7 @@ const ApplicationCard = ({
   const RightElement = (): ReactElement => {
     return (
       <RightElementContainer>
-        {application.note && <Icon icon='annotation' intent='none' />}
+        {application.note && application.note.trim() && <Icon icon='annotation' intent='none' />}
         {isJuleicaEntitlementType() ? (
           <JuleicaVerificationQuickIndicator />
         ) : (


### PR DESCRIPTION
### Short description

As a user i want to get a quick indicator if a note was set

### Proposed changes

<!-- Describe this PR in more detail. -->

- add note icon to the application header if a note was set

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-none

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1489

### Testing
1. Go to applications and create a note. Icon should be displayed
