### PR TITLE
1509: Fix memory leaks

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -28,6 +28,11 @@ dependencies {
     implementation("com.github.ajalt.clikt:clikt:3.5.4")
     implementation("org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0")
     implementation("io.javalin:javalin:6.1.3")
+    // jetty version 11.0.20 causes memory leaks, should be removed with next javalin update using higher jetty version https://github.com/jetty/jetty.project/pull/11780
+    constraints {
+        implementation("org.eclipse.jetty:jetty-server:11.0.21")
+        implementation("org.eclipse.jetty.websocket:websocket-jetty-server:11.0.21")
+    }
     implementation("com.google.code.gson:gson:2.10.1")
     implementation("org.slf4j:slf4j-simple:2.0.7")
     implementation("org.apache.commons:commons-text:1.10.0")


### PR DESCRIPTION
### Short description

Update jetty version (required for javalin) to fix memory leaks
### Proposed changes

<!-- Describe this PR in more detail. -->

- update jetty version to 11.0.21
- adjust protobuf image for mac 


### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- didn't face any

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1509
