### PR TITLE
release-2024.5.3-hotfix

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/service/CardVerifier.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/service/CardVerifier.kt
@@ -29,6 +29,7 @@ object CardVerifier {
     }
 
     public fun isExpired(expirationDay: Long?, timezone: ZoneId): Boolean {
+        if (expirationDay == 0L) return false
         return expirationDay != null && !isOnOrBeforeToday(daysSinceEpochToDate(expirationDay), timezone)
     }
 


### PR DESCRIPTION
### Short description

Gold cards can not be activated since `expirationDate = 0` isBefore today

### Proposed changes

<!-- Describe this PR in more detail. -->

- return false if `expirationDate = 0` for `isExpired()`

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1517

### Testing
- Create a gold card
- Try to activate the gold card
- card should not be expired anymore and can be activated
