### PR TITLE
1507: Mobile scanner does not recognize barcodes

### DIFF
--- a/frontend/lib/identification/qr_code_scanner/qr_code_scanner.dart
+++ b/frontend/lib/identification/qr_code_scanner/qr_code_scanner.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:ehrenamtskarte/identification/qr_code_scanner/qr_code_scanner_controls.dart';
 import 'package:ehrenamtskarte/identification/qr_code_scanner/qr_overlay_shape.dart';
+import 'package:ehrenamtskarte/widgets/error_message.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
@@ -22,7 +23,7 @@ class QrCodeScanner extends StatefulWidget {
 }
 
 class _QRViewState extends State<QrCodeScanner> {
-  bool _hasCameraIssues = false;
+  late Future<bool> _hasCameraIssues;
 
   @override
   void initState() {
@@ -30,11 +31,7 @@ class _QRViewState extends State<QrCodeScanner> {
     // Workaround for https://github.com/juliansteenbakker/mobile_scanner/issues/698
     // Check once the qr code scanner was initialized if the device has camera issues
     // Depending on that set a controller with predefined camera solution to fix that qr code reading issues
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      setState(() async {
-        _hasCameraIssues = await isDeviceWithCameraIssues();
-      });
-    });
+    _hasCameraIssues = isDeviceWithCameraIssues();
   }
 
   final MobileScannerController _controller = MobileScannerController(
@@ -55,66 +52,76 @@ class _QRViewState extends State<QrCodeScanner> {
 
   @override
   Widget build(BuildContext context) {
-    final t = context.t;
-    final controller = _hasCameraIssues ? _controllerPredefinedCameraResolution : _controller;
-    return Stack(
-      children: [
-        Column(
-          children: <Widget>[
-            Expanded(
-              flex: 4,
-              child: Stack(
-                fit: StackFit.expand,
-                children: [
-                  MobileScanner(
-                    key: qrKey,
-                    placeholderBuilder: (context, _) => Align(
-                      alignment: Alignment.center,
-                      child: Icon(Icons.camera_alt_outlined, size: 128, color: Colors.grey),
+    return FutureBuilder<bool>(
+        future: _hasCameraIssues,
+        builder: (context, AsyncSnapshot<bool> snapshot) {
+          final hasCameraIssues = snapshot.data;
+          if (snapshot.hasError && snapshot.error != null) {
+            return ErrorMessage(snapshot.error.toString());
+          } else if (hasCameraIssues == null) {
+            return const Center();
+          }
+          final controller = hasCameraIssues ? _controllerPredefinedCameraResolution : _controller;
+          final t = context.t;
+          return Stack(
+            children: [
+              Column(
+                children: <Widget>[
+                  Expanded(
+                    flex: 4,
+                    child: Stack(
+                      fit: StackFit.expand,
+                      children: [
+                        MobileScanner(
+                          key: qrKey,
+                          placeholderBuilder: (context, _) => Align(
+                            alignment: Alignment.center,
+                            child: Icon(Icons.camera_alt_outlined, size: 128, color: Colors.grey),
+                          ),
+                          onDetect: (barcodes) => _onCodeScanned(barcodes),
+                          controller: controller,
+                        ),
+                        DecoratedBox(
+                          decoration: ShapeDecoration(
+                            shape: QrScannerOverlayShape(
+                              borderRadius: 10,
+                              borderColor: Theme.of(context).colorScheme.secondary,
+                              borderLength: 30,
+                              borderWidth: 10,
+                              cutOutSize: _calculateScanArea(context),
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
-                    onDetect: (barcodes) => _onCodeScanned(barcodes),
-                    controller: controller,
                   ),
-                  DecoratedBox(
-                    decoration: ShapeDecoration(
-                      shape: QrScannerOverlayShape(
-                        borderRadius: 10,
-                        borderColor: Theme.of(context).colorScheme.secondary,
-                        borderLength: 30,
-                        borderWidth: 10,
-                        cutOutSize: _calculateScanArea(context),
+                  Expanded(
+                    flex: 1,
+                    child: FittedBox(
+                      fit: BoxFit.contain,
+                      child: Column(
+                        children: [
+                          Container(
+                            margin: const EdgeInsets.all(8),
+                            child: Text(t.identification.scanQRCode),
+                          ),
+                          QrCodeScannerControls(controller: controller)
+                        ],
                       ),
                     ),
-                  ),
+                  )
                 ],
               ),
-            ),
-            Expanded(
-              flex: 1,
-              child: FittedBox(
-                fit: BoxFit.contain,
-                child: Column(
-                  children: [
-                    Container(
-                      margin: const EdgeInsets.all(8),
-                      child: Text(t.identification.scanQRCode),
-                    ),
-                    QrCodeScannerControls(controller: controller)
-                  ],
-                ),
-              ),
-            )
-          ],
-        ),
-        if (showWaiting)
-          Center(
-              child: Card(
-                  child: Padding(
-            padding: const EdgeInsets.all(32),
-            child: CircularProgressIndicator(),
-          ))),
-      ],
-    );
+              if (showWaiting)
+                Center(
+                    child: Card(
+                        child: Padding(
+                  padding: const EdgeInsets.all(32),
+                  child: CircularProgressIndicator(),
+                ))),
+            ],
+          );
+        });
   }
 
   double _calculateScanArea(BuildContext context) {

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:ehrenamtskarte/configuration/definitions.dart';
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
 import 'package:ehrenamtskarte/sentry.dart';
 import 'package:ehrenamtskarte/settings_provider.dart';
-import 'package:ehrenamtskarte/util/android_certificate.dart';
+import 'package:ehrenamtskarte/util/android_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:slang/builder/model/enums.dart';

--- a/frontend/lib/util/android_utils.dart
+++ b/frontend/lib/util/android_utils.dart
@@ -12,3 +12,13 @@ Future<bool> certificateIsRequired() async {
   AndroidDeviceInfo androidInfo = await deviceInfo.androidInfo;
   return androidInfo.version.sdkInt < 25;
 }
+
+Future<bool> isDeviceWithCameraIssues() async {
+  if (!Platform.isAndroid) {
+    return false;
+  }
+  List<String> devicesWithoutQRCodeDetection = ['SM-A236B'];
+  DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
+  AndroidDeviceInfo androidInfo = await deviceInfo.androidInfo;
+  return devicesWithoutQRCodeDetection.contains(androidInfo.model);
+}

--- a/frontend/lib/util/android_utils.dart
+++ b/frontend/lib/util/android_utils.dart
@@ -17,7 +17,22 @@ Future<bool> isDeviceWithCameraIssues() async {
   if (!Platform.isAndroid) {
     return false;
   }
-  List<String> devicesWithoutQRCodeDetection = ['SM-A236B'];
+  // All models of Galaxy A23
+  List<String> devicesWithoutQRCodeDetection = [
+    'SM-A235F',
+    'SM-A235M',
+    'SM-A235N',
+    'SM-A233C',
+    'SM-A2360',
+    'SM-A236B',
+    'SM-A236E',
+    'SM-A236M',
+    'SM-A236U',
+    'SM-A236U1',
+    'SM-S236DL',
+    'SM-S237VL',
+    'SM-A236V'
+  ];
   DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
   AndroidDeviceInfo androidInfo = await deviceInfo.androidInfo;
   return devicesWithoutQRCodeDetection.contains(androidInfo.model);


### PR DESCRIPTION
### Short description

Some android cameras don't recognize barcodes due to some upstream android camera issues.
This seem to be related to the defaultCamera resolution each device uses
https://github.com/juliansteenbakker/mobile_scanner/issues/698
Its not that easy to detect which cameras may be issued to not apply this on all android devices.

### Proposed changes

<!-- Describe this PR in more detail. -->

- provide a fixed camera resolution for specific android models

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- aspect ratio is not correct. so we can discuss if this is good enough, because it looks ugly
- i played around with the values but didn't find a working solution with correct aspect ratio so far 

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Related: #1507 


### Note
I'm not sure if we should set the cameraResolution to all android devices because it looks ugly. But its also difficult to maintain particular models, so let me know what you think. We could keep the issue open if new devices will be reported.

### Testing (dev only)
This bugfix is only testable with the particular device, but you can just check if the controller applies, if you add your model to `devicesWithoutQRCodeDetection` list and check if the resolution of the camera changes

