### PR TITLE
663: Protect pw reset mail

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/schema/ResetPasswordMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/schema/ResetPasswordMutationService.kt
@@ -65,7 +65,7 @@ class ResetPasswordMutationService {
             val passwordResetKeyHash = user?.passwordResetKeyHash
             // We don't send error messages for empty collection to the user to avoid scraping of mail addresses
             if (user === null || passwordResetKeyHash === null) {
-                logger.info("${context.remoteIp} $email failed to reset password unknown user")
+                logger.info("${context.remoteIp} $email failed to reset password (unknown user or no reset mail sent)")
                 return@transaction
             }
             if (user.passwordResetKeyExpiry!!.isBefore(Instant.now())) {

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/schema/ResetPasswordMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/schema/ResetPasswordMutationService.kt
@@ -72,7 +72,7 @@ class ResetPasswordMutationService {
                 logger.info("${context.remoteIp} $email failed to reset password (expired reset key)")
                 throw PasswordResetKeyExpiredException()
             } else if (!PasswordCrypto.verifyPasswordResetKey(passwordResetKey, passwordResetKeyHash)) {
-                logger.info("${context.remoteIp} $email failed to reset password invalid reset key")
+                logger.info("${context.remoteIp} $email failed to reset password (invalid reset key)")
                 throw InvalidLinkException()
             }
 

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/schema/ResetPasswordMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/auth/webservice/schema/ResetPasswordMutationService.kt
@@ -69,7 +69,7 @@ class ResetPasswordMutationService {
                 return@transaction
             }
             if (user.passwordResetKeyExpiry!!.isBefore(Instant.now())) {
-                logger.info("${context.remoteIp} $email failed to reset password expired reset key")
+                logger.info("${context.remoteIp} $email failed to reset password (expired reset key)")
                 throw PasswordResetKeyExpiredException()
             } else if (!PasswordCrypto.verifyPasswordResetKey(passwordResetKey, passwordResetKeyHash)) {
                 logger.info("${context.remoteIp} $email failed to reset password invalid reset key")


### PR DESCRIPTION
### Short description

Since password reset is not behind a login and can be triggered easily, this api interactions should be protected

### Proposed changes

<!-- Describe this PR in more detail. -->

- write to log if an unknown user(mail address) requests a password reset mail
- write to log if an reset password fails
- this log will be checked from fail2ban (check related pr)

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- no

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #663
related to : https://git.tuerantuer.org/DF/salt/pulls/187
