### PR TITLE
1508: Add region header to the CSV export of cards statistics

### DIFF
--- a/administration/src/bp-modules/statistics/constants/index.ts
+++ b/administration/src/bp-modules/statistics/constants/index.ts
@@ -7,6 +7,7 @@ export const defaultStartDate = PlainDate.fromLocalDate(addDays(subYears(new Dat
 export const defaultEndDate = PlainDate.fromLocalDate(new Date()).toString()
 
 export const statisticKeyLabels = new Map<string, string>([
+  ['region', 'Region'],
   ['cardsCreated', 'Erstellte Karten'],
   ['cardsActivated', 'Davon aktiviert'],
 ])


### PR DESCRIPTION
### Short description
Region header is missing in the CSV export of cards statictics

### Proposed changes
Add 'region' to the mapping of statistics keys

### Side effects
no?

### Resolved issues
Fixes: #1508
