### PR TITLE
Fix thread exhaustion/leak

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     implementation("org.slf4j:slf4j-simple:2.0.7")
     implementation("org.apache.commons:commons-text:1.10.0")
     implementation("org.simplejavamail:simple-java-mail:8.1.3")
-    implementation("org.piwik.java.tracking:matomo-java-tracker:3.2.0")
+    implementation("org.piwik.java.tracking:matomo-java-tracker:3.4.0")
 
     implementation("com.expediagroup:graphql-kotlin-schema-generator:6.5.3")
     implementation("com.graphql-java:graphql-java-extended-scalars:20.2")

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/cards/webservice/schema/CardMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/cards/webservice/schema/CardMutationService.kt
@@ -148,6 +148,7 @@ class CardMutationService {
         val regionId = user.regionId?.value
         if (regionId != null) {
             Matomo.trackCreateCards(
+                context.backendConfiguration,
                 projectConfig,
                 context.request,
                 dfe.field.name,
@@ -212,6 +213,7 @@ class CardMutationService {
             return@t CardActivationResultModel(ActivationState.success, encodedTotpSecret)
         }
         Matomo.trackActivation(
+            context.backendConfiguration,
             projectConfig,
             context.request,
             dfe.field.name,

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/cards/webservice/schema/CardQueryService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/cards/webservice/schema/CardQueryService.kt
@@ -26,7 +26,7 @@ class CardQueryService {
         } else if (card.codeType == CodeType.DYNAMIC) {
             verificationResult = card.totp != null && CardVerifier.verifyDynamicCard(project, cardHash, card.totp, projectConfig.timezone)
         }
-        Matomo.trackVerification(projectConfig, context.request, dfe.field.name, cardHash, card.codeType, verificationResult)
+        Matomo.trackVerification(context.backendConfiguration, projectConfig, context.request, dfe.field.name, cardHash, card.codeType, verificationResult)
         return false
     }
 
@@ -42,7 +42,7 @@ class CardQueryService {
         } else if (card.codeType == CodeType.DYNAMIC) {
             verificationResult = CardVerificationResultModel(card.totp != null && CardVerifier.verifyDynamicCard(project, cardHash, card.totp, projectConfig.timezone))
         }
-        Matomo.trackVerification(projectConfig, context.request, dfe.field.name, cardHash, card.codeType, verificationResult.valid)
+        Matomo.trackVerification(context.backendConfiguration, projectConfig, context.request, dfe.field.name, cardHash, card.codeType, verificationResult.valid)
         return verificationResult
     }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/config/BackendConfiguration.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/config/BackendConfiguration.kt
@@ -23,7 +23,7 @@ data class MapConfig(val baseUrl: String)
 data class GeocodingConfig(val enabled: Boolean, val host: String)
 data class CsvWriterConfig(val enabled: Boolean)
 data class SmtpConfig(val host: String, val port: Int, val username: String, val password: String)
-data class MatomoConfig(val siteId: Int, val url: String, val accessToken: String)
+data class MatomoConfig(val siteId: Int, val accessToken: String)
 data class ProjectConfig(
     val id: String,
     val importUrl: String,
@@ -44,13 +44,14 @@ data class BackendConfiguration(
     val postgres: PostgresConfig,
     val geocoding: GeocodingConfig,
     val projects: List<ProjectConfig>,
-    val csvWriter: CsvWriterConfig
+    val csvWriter: CsvWriterConfig,
+    val matomoUrl: String
 ) {
 
     fun sanityCheckMatomoConfig(): BackendConfiguration {
         val matomoConfig = projects.mapNotNull { it.matomo }
-        if (matomoConfig.size != matomoConfig.distinctBy { Pair(it.siteId, it.url) }.count()) {
-            throw Error("There are at least two matomo configs with the same siteId and url. This seems to be a copy/paste error.")
+        if (matomoConfig.size != matomoConfig.distinctBy { it.siteId }.count()) {
+            throw Error("There are at least two matomo configs with the same siteId. This seems to be a copy/paste error.")
         }
         return this
     }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/matomo/Matomo.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/matomo/Matomo.kt
@@ -22,8 +22,8 @@ import java.net.URI
 import java.util.concurrent.ExecutionException
 
 object Matomo {
-    val logger = LoggerFactory.getLogger(Matomo::class.java)
-    var tracker: MatomoTracker? = null
+    private val logger = LoggerFactory.getLogger(Matomo::class.java)
+    private var tracker: MatomoTracker? = null
 
     private fun getTracker(config: BackendConfiguration): MatomoTracker {
         val tracker = tracker

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/matomo/Matomo.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/matomo/Matomo.kt
@@ -23,11 +23,11 @@ import java.util.concurrent.ExecutionException
 
 object Matomo {
     val logger = LoggerFactory.getLogger(Matomo::class.java)
-    var tracker: MatomoTracker? = null;
+    var tracker: MatomoTracker? = null
 
     private fun getTracker(config: BackendConfiguration): MatomoTracker {
         val tracker = tracker
-            ?: return MatomoTracker(TrackerConfiguration.builder().apiEndpoint(URI.create(config.matomoUrl)).build());
+            ?: return MatomoTracker(TrackerConfiguration.builder().apiEndpoint(URI.create(config.matomoUrl)).build())
 
         return tracker
     }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/matomo/Matomo.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/matomo/Matomo.kt
@@ -2,6 +2,7 @@ package app.ehrenamtskarte.backend.matomo
 
 import app.ehrenamtskarte.backend.cards.database.CodeType
 import app.ehrenamtskarte.backend.cards.database.repos.CardRepository
+import app.ehrenamtskarte.backend.config.BackendConfiguration
 import app.ehrenamtskarte.backend.config.MatomoConfig
 import app.ehrenamtskarte.backend.config.ProjectConfig
 import app.ehrenamtskarte.backend.stores.webservice.schema.SearchParams
@@ -22,12 +23,19 @@ import java.util.concurrent.ExecutionException
 
 object Matomo {
     val logger = LoggerFactory.getLogger(Matomo::class.java)
+    var tracker: MatomoTracker? = null;
 
-    private fun sendTrackingRequest(matomoConfig: MatomoConfig, requestBuilder: MatomoRequestBuilder) {
+    private fun getTracker(config: BackendConfiguration): MatomoTracker {
+        val tracker = tracker
+            ?: return MatomoTracker(TrackerConfiguration.builder().apiEndpoint(URI.create(config.matomoUrl)).build());
+
+        return tracker
+    }
+
+    private fun sendTrackingRequest(config: BackendConfiguration, matomoConfig: MatomoConfig, requestBuilder: MatomoRequestBuilder) {
         CoroutineScope(Dispatchers.IO).launch {
             val siteId = matomoConfig.siteId
-            val url = matomoConfig.url
-            val tracker = MatomoTracker(TrackerConfiguration.builder().apiEndpoint(URI.create(url)).build())
+            val tracker = getTracker(config)
 
             val matomoRequest = requestBuilder
                 .siteId(siteId)
@@ -47,11 +55,10 @@ object Matomo {
         }
     }
 
-    private fun sendBulkTrackingRequest(matomoConfig: MatomoConfig, requestBuilder: Iterable<MatomoRequestBuilder>) {
+    private fun sendBulkTrackingRequest(config: BackendConfiguration, matomoConfig: MatomoConfig, requestBuilder: Iterable<MatomoRequestBuilder>) {
         CoroutineScope(Dispatchers.IO).launch {
             val siteId = matomoConfig.siteId
-            val url = matomoConfig.url
-            val tracker = MatomoTracker(TrackerConfiguration.builder().apiEndpoint(URI.create(url)).build())
+            val tracker = getTracker(config)
             val matomoRequests = requestBuilder.map {
                 it.siteId(siteId)
                 it.authToken(matomoConfig.accessToken)
@@ -88,11 +95,12 @@ object Matomo {
             .also { attachRequestInformation(it, request) }
     }
 
-    fun trackCreateCards(projectConfig: ProjectConfig, request: HttpServletRequest, query: String, regionId: Int, numberOfDynamicCards: Int, numberOfStaticCards: Int) {
+    fun trackCreateCards(config: BackendConfiguration, projectConfig: ProjectConfig, request: HttpServletRequest, query: String, regionId: Int, numberOfDynamicCards: Int, numberOfStaticCards: Int) {
         if (projectConfig.matomo == null) return
 
         if (numberOfDynamicCards > 0 && numberOfStaticCards > 0) {
             sendBulkTrackingRequest(
+                config,
                 projectConfig.matomo,
                 listOf(
                     buildCardsTrackingRequest(request, regionId, query, CodeType.STATIC, numberOfStaticCards),
@@ -101,6 +109,7 @@ object Matomo {
             )
         } else if (numberOfDynamicCards > 0) {
             sendTrackingRequest(
+                config,
                 projectConfig.matomo,
                 buildCardsTrackingRequest(
                     request,
@@ -113,10 +122,11 @@ object Matomo {
         }
     }
 
-    fun trackVerification(projectConfig: ProjectConfig, request: HttpServletRequest, query: String, cardHash: ByteArray, codeType: CodeType, successful: Boolean) {
+    fun trackVerification(config: BackendConfiguration, projectConfig: ProjectConfig, request: HttpServletRequest, query: String, cardHash: ByteArray, codeType: CodeType, successful: Boolean) {
         if (projectConfig.matomo === null) return
         val card = transaction { CardRepository.findByHash(projectConfig.id, cardHash) }
         sendTrackingRequest(
+            config,
             projectConfig.matomo,
             MatomoRequest.request()
                 .eventAction(query)
@@ -127,10 +137,11 @@ object Matomo {
         )
     }
 
-    fun trackActivation(projectConfig: ProjectConfig, request: HttpServletRequest, query: String, cardHash: ByteArray, successful: Boolean) {
+    fun trackActivation(config: BackendConfiguration, projectConfig: ProjectConfig, request: HttpServletRequest, query: String, cardHash: ByteArray, successful: Boolean) {
         if (projectConfig.matomo === null) return
         val card = transaction { CardRepository.findByHash(projectConfig.id, cardHash) }
         sendTrackingRequest(
+            config,
             projectConfig.matomo,
             MatomoRequest.request()
                 .eventAction(query)
@@ -140,10 +151,11 @@ object Matomo {
         )
     }
 
-    fun trackSearch(projectConfig: ProjectConfig, request: HttpServletRequest, query: String, params: SearchParams, numResults: Int) {
+    fun trackSearch(config: BackendConfiguration, projectConfig: ProjectConfig, request: HttpServletRequest, query: String, params: SearchParams, numResults: Int) {
         if (projectConfig.matomo === null) return
         if (params.searchText === null && params.categoryIds === null) return
         sendTrackingRequest(
+            config,
             projectConfig.matomo,
             MatomoRequest.request()
                 .actionName(query)

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/schema/AcceptingStoreQueryService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/schema/AcceptingStoreQueryService.kt
@@ -63,7 +63,7 @@ class AcceptingStoreQueryService {
                 AcceptingStore(it.id.value, it.name, it.description, it.contactId.value, it.categoryId.value)
             }
         }
-        Matomo.trackSearch(projectConfig, context.request, dfe.field.name, params, filteredStores.size)
+        Matomo.trackSearch(context.backendConfiguration, projectConfig, context.request, dfe.field.name, params, filteredStores.size)
         return filteredStores
     }
 

--- a/backend/src/main/resources/config/config.yml
+++ b/backend/src/main/resources/config/config.yml
@@ -15,6 +15,7 @@ server:
   host: 0.0.0.0
   port: 8000
   dataDirectory: ./data
+matomoUrl: http://localhost:5003/matomo.php
 projects:
   - id: bayern.ehrenamtskarte.app
     importUrl: https://www.ehrenamt.bayern.de/xml-json/app-daten.xml

--- a/backend/src/test/resources/config.test.yml
+++ b/backend/src/test/resources/config.test.yml
@@ -14,6 +14,7 @@ server:
   host: 0.0.0.0
   port: 8000
   dataDirectory: ./data
+matomoUrl: http://localhost:5003/matomo.php
 projects:
   - id: bayern.ehrenamtskarte.app
     importUrl: dummy


### PR DESCRIPTION


### Short description

We create many MatomoTrackers which require manual cleanup/closing. Since some version the tracker cleans up after itself automatically when created in a try-catch resource construct: https://github.com/matomo-org/matomo-java-tracker/issues/215#issuecomment-1986844774

### Proposed changes

- Upgrade matomo dependency
- make sure we only have a single tracker

### Resolved issues

Fixes #1544 
