### PR TITLE
1223: Log no applications

### DIFF
--- a/administration/src/graphql/applications/getApplication.graphql
+++ b/administration/src/graphql/applications/getApplication.graphql
@@ -7,7 +7,7 @@ query getApplicationByApplicationVerificationAccessKey($applicationVerificationA
     jsonValue
     withdrawalDate
   }
-  verification: getApplicationVerification(accessKey: $applicationVerificationAccessKey) {
+  verification: getApplicationVerification(applicationVerificationAccessKey: $applicationVerificationAccessKey) {
     contactName
     organizationName
     verifiedDate

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/database/repos/ApplicationRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/database/repos/ApplicationRepository.kt
@@ -7,7 +7,6 @@ import app.ehrenamtskarte.backend.application.database.Applications
 import app.ehrenamtskarte.backend.application.webservice.schema.view.ApplicationView
 import app.ehrenamtskarte.backend.application.webservice.schema.view.JsonField
 import app.ehrenamtskarte.backend.application.webservice.utils.ExtractedApplicationVerification
-import app.ehrenamtskarte.backend.auth.webservice.schema.ResetPasswordMutationService
 import app.ehrenamtskarte.backend.common.database.sortByKeys
 import app.ehrenamtskarte.backend.common.webservice.GraphQLContext
 import app.ehrenamtskarte.backend.exception.webservice.exceptions.InvalidLinkException

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/database/repos/ApplicationRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/database/repos/ApplicationRepository.kt
@@ -101,7 +101,7 @@ object ApplicationRepository {
     }
 
     fun getApplicationByApplicant(accessKey: String, dfe: DataFetchingEnvironment): ApplicationView {
-        val logger = LoggerFactory.getLogger(ResetPasswordMutationService::class.java)
+        val logger = LoggerFactory.getLogger(ApplicationRepository::class.java)
         val context = dfe.getContext<GraphQLContext>()
         return transaction {
             val application = ApplicationEntity.find { Applications.accessKey eq accessKey }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/database/repos/ApplicationRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/database/repos/ApplicationRepository.kt
@@ -116,7 +116,7 @@ object ApplicationRepository {
     }
 
     fun getApplicationByApplicationVerificationAccessKey(applicationVerificationAccessKey: String, dfe: DataFetchingEnvironment): ApplicationView {
-        val logger = LoggerFactory.getLogger(ResetPasswordMutationService::class.java)
+        val logger = LoggerFactory.getLogger(ApplicationRepository::class.java)
         val context = dfe.getContext<GraphQLContext>()
         return transaction {
             val application = (Applications innerJoin ApplicationVerifications)

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/EakApplicationMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/EakApplicationMutationService.kt
@@ -114,7 +114,7 @@ class EakApplicationMutationService {
         verified: Boolean,
         dfe: DataFetchingEnvironment
     ): Boolean {
-        val application = transaction { getApplicationByApplicationVerificationAccessKey(accessKey) }
+        val application = transaction { getApplicationByApplicationVerificationAccessKey(accessKey, dfe) }
         return transaction {
             if (verified) {
                 val context = dfe.getContext<GraphQLContext>()

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/EakApplicationQueryService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/EakApplicationQueryService.kt
@@ -35,28 +35,30 @@ class EakApplicationQueryService {
 
     @GraphQLDescription("Queries an application by application accessKey")
     fun getApplicationByApplicant(
-        accessKey: String
+        accessKey: String,
+        dfe: DataFetchingEnvironment
     ): ApplicationView {
         return transaction {
-            ApplicationRepository.getApplicationByApplicant(accessKey)
+            ApplicationRepository.getApplicationByApplicant(accessKey, dfe)
         }
     }
 
-    @GraphQLDescription("Queries an application by application accessKey")
+    @GraphQLDescription("Queries an application by application verification accessKey")
     fun getApplicationByApplicationVerificationAccessKey(
-        applicationVerificationAccessKey: String
+        applicationVerificationAccessKey: String,
+        dfe: DataFetchingEnvironment
     ): ApplicationView {
         return transaction {
-            ApplicationRepository.getApplicationByApplicationVerificationAccessKey(applicationVerificationAccessKey)
+            ApplicationRepository.getApplicationByApplicationVerificationAccessKey(applicationVerificationAccessKey, dfe)
         }
     }
 
-    @GraphQLDescription("Queries an application verification by application accessKey")
+    @GraphQLDescription("Queries an application verification by application verification accessKey")
     fun getApplicationVerification(
-        accessKey: String
+        applicationVerificationAccessKey: String
     ): ApplicationVerificationView {
         return transaction {
-            ApplicationRepository.getApplicationVerification(accessKey).let {
+            ApplicationRepository.getApplicationVerification(applicationVerificationAccessKey).let {
                 ApplicationVerificationView.fromDbEntity(it)
             }
         }

--- a/specs/backend-api.graphql
+++ b/specs/backend-api.graphql
@@ -179,10 +179,10 @@ type Query {
   checkPasswordResetLink(project: String!, resetKey: String!): Boolean!
   "Queries an application by application accessKey"
   getApplicationByApplicant(accessKey: String!): ApplicationView!
-  "Queries an application by application accessKey"
+  "Queries an application by application verification accessKey"
   getApplicationByApplicationVerificationAccessKey(applicationVerificationAccessKey: String!): ApplicationView!
-  "Queries an application verification by application accessKey"
-  getApplicationVerification(accessKey: String!): ApplicationVerificationView!
+  "Queries an application verification by application verification accessKey"
+  getApplicationVerification(applicationVerificationAccessKey: String!): ApplicationVerificationView!
   "Queries all applications for a specific region"
   getApplications(regionId: Int!): [ApplicationView!]!
   "Returns card statistics for project. Start and end dates are inclusive."


### PR DESCRIPTION
### Short description

We are facing some issues that we get a lot of server logs that no applications where found.
To be able to better investigate why this happens we log the `accessKeys` of the applicants and verifiers that cannot get applications.

### Proposed changes

<!-- Describe this PR in more detail. -->

- add logger if `application == null` that logs ip address and accessKey
- some small refactoring to clarify which accessKeys will be passed

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

relates: #1223 

### Testing (dev only)
1. Create an application that needs an organization to verify
2. Open the verification and the application link and check that everything is still working
3. Remove some characters of the `accessKey` in the links and check the backend log

