### PR TITLE
Fix failing build_backend job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,6 +363,8 @@ jobs:
         steps:
             - checkout:
                 path: ~/project
+            - setup_remote_docker:
+                docker_layer_caching: true
             - run: git submodule sync
             - run: git submodule update --init
             - install_app_toolbelt

--- a/.circleci/src/jobs/build_backend.yml
+++ b/.circleci/src/jobs/build_backend.yml
@@ -7,6 +7,8 @@ working_directory: ~/project/backend
 steps:
   - checkout:
       path: ~/project
+  - setup_remote_docker:
+      docker_layer_caching: true
   - run: git submodule sync
   - run: git submodule update --init
   - install_app_toolbelt


### PR DESCRIPTION
### Short description
This should potentially fix failing build_backend job
Can only be verified once merged, since build_backend doesn't run on PR

### Resolved issues
Failing CI:
https://app.circleci.com/pipelines/github/digitalfabrik/entitlementcard/5968/workflows/cf3ad231-f60d-4bd4-966f-07013e4991d1/jobs/42825
