### PR TITLE
1416: Rename the unique_userhash_regionid index to lowercase

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/V0014_CreateUserEntitlementsTable.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/V0014_CreateUserEntitlementsTable.kt
@@ -32,7 +32,7 @@ internal class V0014_CreateUserEntitlementsTable : Migration() {
             ALTER TABLE ONLY userentitlements
                 ADD CONSTRAINT fk_userentitlements_regionId__id FOREIGN KEY ("regionId") REFERENCES regions(id) ON UPDATE RESTRICT ON DELETE RESTRICT;
                 
-            ALTER TABLE userentitlements ADD CONSTRAINT unique_userHash_regionId UNIQUE ("userHash", "regionId");
+            ALTER TABLE userentitlements ADD CONSTRAINT unique_userhash_regionid UNIQUE ("userHash", "regionId");
             """.trimIndent()
         )
     }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/userdata/database/Schema.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/userdata/database/Schema.kt
@@ -18,7 +18,7 @@ object UserEntitlements : IntIdTable() {
     val lastUpdated = timestamp("lastUpdated").defaultExpression(CurrentTimestamp())
 
     init {
-        uniqueIndex("unique_userHash_regionId", userHash, regionId)
+        uniqueIndex("unique_userhash_regionid", userHash, regionId)
     }
 }
 


### PR DESCRIPTION
### Short description
Fix warning
`[main] INFO Exposed - Index on table 'UserEntitlements' differs only in name: in db unique_userhash_regionid -> in mapping unique_userHash_regionId`

### Proposed changes
- Rename the unique_userhash_regionid index to lowercase

I assume it's okay just to update the existing migration, as it hasn't been released yet
