### PR TITLE
Allow unknown config properties

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/config/BackendConfiguration.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/config/BackendConfiguration.kt
@@ -1,6 +1,7 @@
 package app.ehrenamtskarte.backend.config
 
 import app.ehrenamtskarte.backend.stores.importer.ImportConfig
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
@@ -65,6 +66,8 @@ data class BackendConfiguration(
             .registerModule(
                 KotlinModule.Builder().build()
             ).registerModule(JavaTimeModule())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
         private val logger = LoggerFactory.getLogger(BackendConfiguration::class.java)
 
         fun load(configFile: URL?): BackendConfiguration {

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/config/BackendConfiguration.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/config/BackendConfiguration.kt
@@ -66,6 +66,10 @@ data class BackendConfiguration(
             .registerModule(
                 KotlinModule.Builder().build()
             ).registerModule(JavaTimeModule())
+            // Allows unknown (potentially future) config options.
+            // Without this parsing a config fails if a property is defined that is missing
+            // from the BackendConfiguration class. We might want to be able to load configs that contain configuration
+            // for future features, therefore we want to allow unknown properties.
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
         private val logger = LoggerFactory.getLogger(BackendConfiguration::class.java)


### PR DESCRIPTION
### Short description

Allows to parse configs that include unkown (potentially future) properties. Previouisly starting the server failed if you parse an unknown value.

### Side effects

None

