### PR TITLE
🥳 1312: Fix exception when PageController was used after being disposed

### DIFF
--- a/frontend/lib/search/results_loader.dart
+++ b/frontend/lib/search/results_loader.dart
@@ -90,12 +90,15 @@ class ResultsLoaderState extends State<ResultsLoader> {
       }
 
       final newItems = query.parse(newData).searchAcceptingStoresInProject;
-      final isLastPage = newItems.length < _pageSize;
-      if (isLastPage) {
-        _pagingController.appendLastPage(newItems);
-      } else {
-        final nextPageKey = pageKey + newItems.length;
-        _pagingController.appendPage(newItems, nextPageKey);
+
+      if (mounted) {
+        final isLastPage = newItems.length < _pageSize;
+        if (isLastPage) {
+          _pagingController.appendLastPage(newItems);
+        } else {
+          final nextPageKey = pageKey + newItems.length;
+          _pagingController.appendPage(newItems, nextPageKey);
+        }
       }
     } on Exception catch (error) {
       if (widget != oldWidget) {
@@ -105,7 +108,9 @@ class ResultsLoaderState extends State<ResultsLoader> {
           return await _fetchPage(pageKey);
         }
       }
-      _pagingController.error = error;
+      if (mounted) {
+        _pagingController.error = error;
+      }
     }
   }
 


### PR DESCRIPTION
### Short description
Sometimes the following exception can be seen in the log, most likely right after the application starts:
```
_Exception: Exception: A PagingController was used after being disposed.
Once you have called dispose() on a PagingController, it can no longer be used.
If you’re using a Future, it probably completed after the disposal of the owning widget.
Make sure dispose() has not been called yet before using the PagingController.
  File "paging_controller.dart", line 133, in PagingController._debugAssertNotDisposed.<fn>
  File "paging_controller.dart", line 142, in PagingController._debugAssertNotDisposed
  File "paging_controller.dart", line 168, in PagingController.notifyStatusListeners
  File "paging_controller.dart", line 94, in PagingController.value=
  File "paging_controller.dart", line 69, in PagingController.error=
```

And I also included a fix for a similar issue with Favorites.
It was reproduced in the following way:
1. wipe user data or re-install the app
2. after the first launch, try adding any store to favorites

**Result**: it caused the following exception in the log:
```
======== Exception caught by foundation library ====================================================
The following _Exception was thrown while dispatching notifications for FavoritesModel:
Exception: A PagingController was used after being disposed.
Once you have called dispose() on a PagingController, it can no longer be used.
If you’re using a Future, it probably completed after the disposal of the owning widget.
Make sure dispose() has not been called yet before using the PagingController.

When the exception was thrown, this was the stack: 

#0      PagingController._debugAssertNotDisposed.<anonymous closure> (package:infinite_scroll_pagination/src/core/paging_controller.dart:133:9)
#1      PagingController._debugAssertNotDisposed (package:infinite_scroll_pagination/src/core/paging_controller.dart:142:6)
#2      PagingController.notifyStatusListeners (package:infinite_scroll_pagination/src/core/paging_controller.dart:168:12)
#3      PagingController.value= (package:infinite_scroll_pagination/src/core/paging_controller.dart:94:7)
#4      PagingController.refresh (package:infinite_scroll_pagination/src/core/paging_controller.dart:123:5)
#5      FavoritesLoaderState.initState.<anonymous closure> (package:ehrenamtskarte/favorites/favorites_loader.dart:41:25)
#6      ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:433:24)
#7      FavoritesModel.saveFavorite (package:ehrenamtskarte/favorites/favorites_model.dart:53:5)
<asynchronous suspension>
#8      DetailAppBar._toggleFavorites (package:ehrenamtskarte/store_widgets/detail/detail_app_bar.dart:155:9)
<asynchronous suspension>
#9      DetailAppBar.build.<anonymous closure> (package:ehrenamtskarte/store_widgets/detail/detail_app_bar.dart:124:17)
<asynchronous suspension>
The FavoritesModel sending notification was: Instance of 'FavoritesModel'
```
When running the application a second or more times, the exception did not appear.

### Proposed changes
- check if widget is mounted, before calling PageController

### Side effects
- hopefully no

_No 100% guarantee that it helped because the problem was flaky, but as far as I tested I couldn't reproduce it after the fix anymore._

### Resolved issues
Fixes: #1312
