### PR TITLE
1286: Improve error message activation

### DIFF
--- a/frontend/assets/l10n/app_de.json
+++ b/frontend/assets/l10n/app_de.json
@@ -99,7 +99,7 @@
     "codeExpired": "Der eingescannte Code ist bereits am {{expirationDate}} abgelaufen.",
     "codeInvalid": "Der Inhalt des eingescannten Codes kann nicht verstanden werden. Vermutlich handelt es sich um einen QR-Code, der nicht für diese App generiert wurde.",
     "codeInvalidMissing": "Der Inhalt des eingescannten Codes ist unvollständig. (Fehlercode: {{missing}}Missing)",
-    "codeInvalidType": "Der eingescannte Code ist nicht für die Aktivierung in der App vorgesehen. (Eingescannt: {{qrCodeType}}). Bitte verwenden Sie den als Aktivierungscode ausgewiesenen QR-Code.",
+    "codeInvalidType": "Der eingescannte Code ist nicht für die Aktivierung in der App vorgesehen. Bitte verwenden Sie den als Aktivierungscode ausgewiesenen QR-Code.",
     "codeUnknownType": "Der eingescannte Code ist für diese Anwendung nicht gültig.",
     "codeVerificationFailed": "Der eingescannte Code konnte vom Server nicht verifiziert werden.",
     "codeActivationFailedConnection": "Der eingescannte Code konnte nicht aktiviert werden. Bitte stellen Sie sicher, dass eine Internetverbindung besteht und prüfen Sie erneut.",

--- a/frontend/assets/l10n/app_de.json
+++ b/frontend/assets/l10n/app_de.json
@@ -99,7 +99,7 @@
     "codeExpired": "Der eingescannte Code ist bereits am {{expirationDate}} abgelaufen.",
     "codeInvalid": "Der Inhalt des eingescannten Codes kann nicht verstanden werden. Vermutlich handelt es sich um einen QR-Code, der nicht für diese App generiert wurde.",
     "codeInvalidMissing": "Der Inhalt des eingescannten Codes ist unvollständig. (Fehlercode: {{missing}}Missing)",
-    "codeInvalidType": "Der eingescannte Code ist für die Aktivierung nicht gültig. (Eingescannt: {{qrCodeType}}). Bitte verwenden Sie den als Aktivierungscode ausgewiesenen QR-Code.",
+    "codeInvalidType": "Der eingescannte Code ist nicht für die Aktivierung in der App vorgesehen. (Eingescannt: {{qrCodeType}}). Bitte verwenden Sie den als Aktivierungscode ausgewiesenen QR-Code.",
     "codeUnknownType": "Der eingescannte Code ist für diese Anwendung nicht gültig.",
     "codeVerificationFailed": "Der eingescannte Code konnte vom Server nicht verifiziert werden.",
     "codeActivationFailedConnection": "Der eingescannte Code konnte nicht aktiviert werden. Bitte stellen Sie sicher, dass eine Internetverbindung besteht und prüfen Sie erneut.",

--- a/frontend/assets/l10n/app_de.json
+++ b/frontend/assets/l10n/app_de.json
@@ -99,7 +99,7 @@
     "codeExpired": "Der eingescannte Code ist bereits am {{expirationDate}} abgelaufen.",
     "codeInvalid": "Der Inhalt des eingescannten Codes kann nicht verstanden werden. Vermutlich handelt es sich um einen QR-Code, der nicht für diese App generiert wurde.",
     "codeInvalidMissing": "Der Inhalt des eingescannten Codes ist unvollständig. (Fehlercode: {{missing}}Missing)",
-    "codeInvalidType": "Der eingescannte Code ist für diesen Vorgang nicht gültig. (Eingescannt: {{qrCodeType}})",
+    "codeInvalidType": "Der eingescannte Code ist für die Aktivierung nicht gültig. (Eingescannt: {{qrCodeType}}). Bitte verwenden Sie den als Aktivierungscode ausgewiesenen QR-Code.",
     "codeUnknownType": "Der eingescannte Code ist für diese Anwendung nicht gültig.",
     "codeVerificationFailed": "Der eingescannte Code konnte vom Server nicht verifiziert werden.",
     "codeActivationFailedConnection": "Der eingescannte Code konnte nicht aktiviert werden. Bitte stellen Sie sicher, dass eine Internetverbindung besteht und prüfen Sie erneut.",

--- a/frontend/assets/l10n/app_en.json
+++ b/frontend/assets/l10n/app_en.json
@@ -99,7 +99,7 @@
     "codeExpired": "The scanned code has already expired on {{expirationDate}}.",
     "codeInvalid": "The content of the scanned code cannot be understood. It is probably a QR code that was not generated for this app.",
     "codeInvalidMissing": "The content of the scanned code is incomplete. (Error code: {{missing}}Missing)",
-    "codeInvalidType": "The scanned code is not valid for activation. (Scanned: {{qrCodeType}}). Please use the QR code shown as activation code.",
+    "codeInvalidType": "The scanned code is not intended for activation in the app. (Scanned: {{qrCodeType}}). Please use the QR code shown as activation code.",
     "codeUnknownType": "The scanned code is not valid for this application.",
     "codeVerificationFailed": "The scanned code could not be verified by the server.",
     "codeActivationFailedConnection": "The scanned code could not be activated. Please make sure you have an internet connection and try again.",

--- a/frontend/assets/l10n/app_en.json
+++ b/frontend/assets/l10n/app_en.json
@@ -99,7 +99,7 @@
     "codeExpired": "The scanned code has already expired on {{expirationDate}}.",
     "codeInvalid": "The content of the scanned code cannot be understood. It is probably a QR code that was not generated for this app.",
     "codeInvalidMissing": "The content of the scanned code is incomplete. (Error code: {{missing}}Missing)",
-    "codeInvalidType": "The scanned code is not valid for this operation. (Scanned: {{qrCodeType}})",
+    "codeInvalidType": "The scanned code is not valid for activation. (Scanned: {{qrCodeType}}). Please use the QR code shown as activation code.",
     "codeUnknownType": "The scanned code is not valid for this application.",
     "codeVerificationFailed": "The scanned code could not be verified by the server.",
     "codeActivationFailedConnection": "The scanned code could not be activated. Please make sure you have an internet connection and try again.",

--- a/frontend/assets/l10n/app_en.json
+++ b/frontend/assets/l10n/app_en.json
@@ -99,7 +99,7 @@
     "codeExpired": "The scanned code has already expired on {{expirationDate}}.",
     "codeInvalid": "The content of the scanned code cannot be understood. It is probably a QR code that was not generated for this app.",
     "codeInvalidMissing": "The content of the scanned code is incomplete. (Error code: {{missing}}Missing)",
-    "codeInvalidType": "The scanned code is not intended for activation in the app. (Scanned: {{qrCodeType}}). Please use the QR code shown as activation code.",
+    "codeInvalidType": "The scanned code is not intended for activation in the app. Please use the QR code shown as activation code.",
     "codeUnknownType": "The scanned code is not valid for this application.",
     "codeVerificationFailed": "The scanned code could not be verified by the server.",
     "codeActivationFailedConnection": "The scanned code could not be activated. Please make sure you have an internet connection and try again.",

--- a/frontend/lib/identification/activation_workflow/activation_code_scanner_page.dart
+++ b/frontend/lib/identification/activation_workflow/activation_code_scanner_page.dart
@@ -48,7 +48,7 @@ class ActivationCodeScannerPage extends StatelessWidget {
     } on QrCodeFieldMissingException catch (e) {
       await showError(t.identification.codeInvalidMissing(missing: e.missingFieldName), null);
     } on QrCodeWrongTypeException catch (e) {
-      await showError(t.identification.codeInvalidType(qrCodeType: e.qrCodeType), null);
+      await QrParsingErrorDialog.showErrorDialog(context, t.identification.codeInvalidType(qrCodeType: e.qrCodeType));
     } on CardExpiredException catch (e) {
       final expirationDate = DateFormat('dd.MM.yyyy').format(e.expiry);
       await showError(t.identification.codeExpired(expirationDate: expirationDate), null);

--- a/frontend/lib/identification/activation_workflow/activation_code_scanner_page.dart
+++ b/frontend/lib/identification/activation_workflow/activation_code_scanner_page.dart
@@ -47,8 +47,8 @@ class ActivationCodeScannerPage extends StatelessWidget {
       await showError(t.identification.cardAlreadyActivated, null);
     } on QrCodeFieldMissingException catch (e) {
       await showError(t.identification.codeInvalidMissing(missing: e.missingFieldName), null);
-    } on QrCodeWrongTypeException catch (e) {
-      await QrParsingErrorDialog.showErrorDialog(context, t.identification.codeInvalidType(qrCodeType: e.qrCodeType));
+    } on QrCodeWrongTypeException catch (_) {
+      await QrParsingErrorDialog.showErrorDialog(context, t.identification.codeInvalidType);
     } on CardExpiredException catch (e) {
       final expirationDate = DateFormat('dd.MM.yyyy').format(e.expiry);
       await showError(t.identification.codeExpired(expirationDate: expirationDate), null);


### PR DESCRIPTION
### Short description

Some users seem to scan the static verification code (physical pass) for activation instead of the activation code.
First there was an unknown error report.
To be able to get proper error information we send the information to Sentry. Since we identified the issue the error reporting to Sentry can be removed

### Proposed changes

<!-- Describe this PR in more detail. -->

- improve the error message to indicate the user what should be scanned
- remove sending error reports to sentry, since this is an intended error and displays error information to to the user

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. Create a card for nuernberg
2. add screenshot of the static qr code to the emulator/ or scan it with real device
3. try to activate the card and check error message

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1286
