### PR TITLE
1543: Fix metadata promotion

### DIFF
--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -177,6 +177,7 @@ platform :ios do
 
     # https://docs.fastlane.tools/actions/deliver/#submit-build
     deliver(
+      metadata_path: "./#{build_config_name}/metadata"
       app_version: testflight_version,
       build_number: testflight_build_number.to_s,
       app_identifier: bundle_identifier,


### PR DESCRIPTION
### Short description

The ios promotion requires release notes.  With #1503 the metadata was restructured but the metadata path not added. So still the default path `./metadata` was used and an error occurred during promotion

### Proposed changes

<!-- Describe this PR in more detail. -->

- add a build config depended metadata path

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

no testing

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1543 
