### PR TITLE
Add store_test_results step to check_backend job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -609,6 +609,8 @@ jobs:
                 command: |
                     ./gradlew test
                 name: Test
+            - store_test_results:
+                path: ./build/test-results
             - save_cache:
                 key: v3-gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
                 paths:

--- a/.circleci/src/jobs/check_backend.yml
+++ b/.circleci/src/jobs/check_backend.yml
@@ -30,6 +30,8 @@ steps:
       name: Test
       command: |
         ./gradlew test
+  - store_test_results:
+      path: ./build/test-results
   - save_cache:
       paths:
         - ~/.gradle/wrapper


### PR DESCRIPTION
### Short description
Add store_test_results step to check_backend job for debug purposes.
It allows to see how many tests have been run and if there were failed tests, a summary of them will also be shown here.

![image](https://github.com/user-attachments/assets/c63cfbee-1d31-4b15-848c-7649eaa65e23)

### Side effects
no

### Testing
n/a

### Resolved issues
n/a
