### PR TITLE
1628: Exclude fullName field from user hashing

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/cards/webservice/schema/CardMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/cards/webservice/schema/CardMutationService.kt
@@ -138,7 +138,6 @@ class CardMutationService {
 
         val cardInfo = parseEncodedCardInfo(encodedCardInfo)
         val user = KoblenzUser(
-            cardInfo.fullName,
             cardInfo.extensions.extensionBirthday.birthday,
             cardInfo.extensions.extensionKoblenzReferenceNumber.referenceNumber
         )

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/userdata/KoblenzUser.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/userdata/KoblenzUser.kt
@@ -4,4 +4,4 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 
 @JsonPropertyOrder(alphabetic = true)
-data class KoblenzUser(@get:JsonProperty("1") val fullname: String, @get:JsonProperty("2") val birthday: Int, @get:JsonProperty("3") val referenceNumber: String)
+data class KoblenzUser(@get:JsonProperty("1") val birthday: Int, @get:JsonProperty("2") val referenceNumber: String)

--- a/backend/src/test/kotlin/app/ehrenamtskarte/backend/cards/Argon2IdHasherTest.kt
+++ b/backend/src/test/kotlin/app/ehrenamtskarte/backend/cards/Argon2IdHasherTest.kt
@@ -17,8 +17,8 @@ internal class Argon2IdHasherTest {
 
         assertEquals(Environment.getVariable("KOBLENZ_PEPPER"), "123456789ABC")
 
-        val hash = Argon2IdHasher.hashKoblenzUserData(KoblenzUser("Karla Koblenz", 12213, "123K"))
-        val expectedHash = "\$argon2id\$v=19\$m=19456,t=2,p=1\$57YPIKvU/XE9h7/JA0tZFT2TzpwBQfYAW6K+ojXBh5w" // This expected output was created with https://argon2.online/
+        val hash = Argon2IdHasher.hashKoblenzUserData(KoblenzUser(12213, "123K"))
+        val expectedHash = "\$argon2id\$v=19\$m=19456,t=2,p=1\$cr3lP9IMUKNz4BLfPGlAOHq1z98G5/2tTbhDIko35tY" // This expected output was created with https://argon2.online/
         assertEquals(expectedHash, hash)
     }
 

--- a/backend/src/test/kotlin/app/ehrenamtskarte/backend/cards/CanonicalJsonTest.kt
+++ b/backend/src/test/kotlin/app/ehrenamtskarte/backend/cards/CanonicalJsonTest.kt
@@ -101,7 +101,7 @@ internal class CanonicalJsonTest {
     @Test
     fun mapUserInfoForKoblenzPass() {
         val expected = koblenzUserToString(koblenzTestUser)
-        assertEquals("{\"1\":\"Karla Koblenz\",\"2\":12213,\"3\":\"123K\"}", expected)
+        assertEquals("{\"1\":12213,\"2\":\"123K\"}", expected)
     }
 
     @Test

--- a/backend/src/test/kotlin/app/ehrenamtskarte/backend/cards/CreateCardFromSelfServiceTest.kt
+++ b/backend/src/test/kotlin/app/ehrenamtskarte/backend/cards/CreateCardFromSelfServiceTest.kt
@@ -99,7 +99,7 @@ internal class CreateCardFromSelfServiceTest : GraphqlApiTest() {
     fun `POST returns an error when user entitlements expired`() = JavalinTest.test(app) { _, client ->
         transaction {
             UserEntitlements.insert {
-                it[userHash] = "\$argon2id\$v=19\$m=19456,t=2,p=1\$57YPIKvU/XE9h7/JA0tZFT2TzpwBQfYAW6K+ojXBh5w".toByteArray()
+                it[userHash] = "\$argon2id\$v=19\$m=19456,t=2,p=1\$cr3lP9IMUKNz4BLfPGlAOHq1z98G5/2tTbhDIko35tY".toByteArray()
                 it[startDate] = LocalDate.now().minusYears(1L)
                 it[endDate] = LocalDate.now().minusDays(1L)
                 it[revoked] = false
@@ -129,7 +129,7 @@ internal class CreateCardFromSelfServiceTest : GraphqlApiTest() {
     fun `POST returns an error when user entitlements revoked`() = JavalinTest.test(app) { _, client ->
         transaction {
             UserEntitlements.insert {
-                it[userHash] = "\$argon2id\$v=19\$m=19456,t=2,p=1\$57YPIKvU/XE9h7/JA0tZFT2TzpwBQfYAW6K+ojXBh5w".toByteArray()
+                it[userHash] = "\$argon2id\$v=19\$m=19456,t=2,p=1\$cr3lP9IMUKNz4BLfPGlAOHq1z98G5/2tTbhDIko35tY".toByteArray()
                 it[startDate] = LocalDate.now().minusDays(1L)
                 it[endDate] = LocalDate.now().plusYears(1L)
                 it[revoked] = true
@@ -163,7 +163,7 @@ internal class CreateCardFromSelfServiceTest : GraphqlApiTest() {
 
         transaction {
             UserEntitlements.insert {
-                it[userHash] = "\$argon2id\$v=19\$m=19456,t=2,p=1\$57YPIKvU/XE9h7/JA0tZFT2TzpwBQfYAW6K+ojXBh5w".toByteArray()
+                it[userHash] = "\$argon2id\$v=19\$m=19456,t=2,p=1\$cr3lP9IMUKNz4BLfPGlAOHq1z98G5/2tTbhDIko35tY".toByteArray()
                 it[startDate] = cardStartDay
                 it[endDate] = cardExpirationDay
                 it[revoked] = false

--- a/backend/src/test/kotlin/app/ehrenamtskarte/backend/helper/ExampleUser.kt
+++ b/backend/src/test/kotlin/app/ehrenamtskarte/backend/helper/ExampleUser.kt
@@ -2,4 +2,4 @@ package app.ehrenamtskarte.backend.helper
 
 import app.ehrenamtskarte.backend.userdata.KoblenzUser
 
-val koblenzTestUser = KoblenzUser("Karla Koblenz", 12213, "123K")
+val koblenzTestUser = KoblenzUser(12213, "123K")

--- a/docs/CreateKoblenzHash.md
+++ b/docs/CreateKoblenzHash.md
@@ -6,7 +6,6 @@ The example data is
 
 | Parameter    | Value         |
 |--------------|---------------|
-| Name         | Karla Koblenz |
 | Geburtstag   | 10.06.2003    |
 | Aktenzeichen | 123K          |
 
@@ -15,14 +14,11 @@ The example data is
 ```agsl
 //Example:
 {
-    full_name: "Karla Koblenz"
     birthday: 12213
     referenceNumber: "123K"
 }
 ```
 
-- The full_name must be `FirstnameSpaceLastname`. Every char must exactly match the user input, as otherwise there is not possibility to match the data Koblenz transfers with the input the user makes.
-e.g. `Karla Koblenz` will match neither with `Karla Lisa Koblenz` nor with `Karlá Koblenz`.
 - The birthday is defined in our protobuf [card.proto](../frontend/card.proto) file: It counts the days since the birthday (calculated from 1970-01-01).
   All values of this field are valid, including the 0, which indicates that the birthday is on 1970-01-01. Birthdays before 1970-01-01 have negative values.
 - referenceNumber is set to the "Aktenzeichen"
@@ -31,7 +27,7 @@ e.g. `Karla Koblenz` will match neither with `Karla Lisa Koblenz` nor with `Karl
 ### 2. Convert this object to a Canonical Json
  Result should be:
  ```
- {"1":"Karla Koblenz","2":12213,"3":"123K"}
+ {"1":12213,"2":"123K"}
  ```
 
 ### 3. Hash it with Argon2id
@@ -51,11 +47,10 @@ Hash with Argon2id with the following parameters:
 ### 4. The result...
 ...for the example data and example salt must be (output in encoded form with salt removed):
 
-`$argon2id$v=19$m=19456,t=2,p=1$57YPIKvU/XE9h7/JA0tZFT2TzpwBQfYAW6K+ojXBh5w`
+`$argon2id$v=19$m=19456,t=2,p=1$cr3lP9IMUKNz4BLfPGlAOHq1z98G5/2tTbhDIko35tY`
 
 ## Additional Information
 
 - Online Argon2 hasher: https://argon2.online/
 - CanonicalJson creation is done in: [CanonicalJson.kt](../backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/CanonicalJson.kt)
 - Hashing is done in: [Argon2IdHasher.kt](../backend/src/main/kotlin/app/ehrenamtskarte/backend/verification/Argon2IdHasher.kt)
-


### PR DESCRIPTION
### Short description
Exclude fullName field from user hashing

> Koblenz-Pass News: "Aktenzeichen in der Kombination mit Geburtsdatum sind datenschutzrechtlich vereinbar. Die Übertragung des Aktenzeichen und des Geburtsdatums sind möglich."

### Proposed changes
- Adjust Argon2IdHasher, docs, tests

### Side effects
Card can be issued under any name

### Testing
1. Import user entitlements via POST http://localhost:8000/users/import
Include CSV file as a form-data:
```
regionKey,userHash,startDate,endDate,revoked
07111,"$argon2id$v=19$m=19456,t=2,p=1$cr3lP9IMUKNz4BLfPGlAOHq1z98G5/2tTbhDIko35tY",01.01.2024,01.01.2025,false
```
The above hash **does not contain** a name of the user

2. Send graphql request to create card:
```
mutation CreateCardFromSelfService {
    createCardFromSelfService(
        project: "koblenz.sozialpass.app"
        encodedCardInfo: "Cg1LYXJsYSBLb2JsZW56GhIKAghfEgQI6r4BMgYKBDEyM0s="
        generateStaticCode: true
    ) {
        dynamicActivationCode {
            cardInfoHashBase64
            codeBase64
        }
        staticVerificationCode {
            cardInfoHashBase64
            codeBase64
        }
    }
}
```
The encodedCardInfo above **contains** a name of the user

### Resolved issues
Fixes: #1628
