### PR TITLE
Remove duplicate graphql provider

### DIFF
--- a/frontend/lib/graphql/configured_graphql_provider.dart
+++ b/frontend/lib/graphql/configured_graphql_provider.dart
@@ -73,12 +73,7 @@ class ConfiguredGraphQlProviderState extends State<ConfiguredGraphQlProvider> {
         ]),
       ),
     );
-    return GraphQLProvider(
-      client: client,
-      child: CacheProvider(
-        child: widget.child,
-      ),
-    );
+    return GraphQLProvider(client: client, child: widget.child);
   }
 
   void _printDebugMessage(BuildContext context, String message) {

--- a/frontend/lib/home/home_page.dart
+++ b/frontend/lib/home/home_page.dart
@@ -1,7 +1,6 @@
 import 'package:ehrenamtskarte/about/about_page.dart';
 import 'package:ehrenamtskarte/build_config/build_config.dart' show buildConfig;
 import 'package:ehrenamtskarte/configuration/settings_model.dart';
-import 'package:ehrenamtskarte/graphql/configured_graphql_provider.dart';
 import 'package:ehrenamtskarte/home/app_flow.dart';
 import 'package:ehrenamtskarte/home/app_flows_stack.dart';
 import 'package:ehrenamtskarte/identification/identification_page.dart';
@@ -76,14 +75,12 @@ class HomePageState extends State<HomePage> {
   Widget build(BuildContext context) {
     final settings = Provider.of<SettingsModel>(context);
 
-    return ConfiguredGraphQlProvider(
-      child: HomePageData(
-        navigateToMapTab: _navigateToMapTab,
-        child: settings.enableStaging
-            ? Banner(
-                message: 'Testing', location: BannerLocation.topEnd, color: Colors.red, child: _buildScaffold(context))
-            : _buildScaffold(context),
-      ),
+    return HomePageData(
+      navigateToMapTab: _navigateToMapTab,
+      child: settings.enableStaging
+          ? Banner(
+              message: 'Testing', location: BannerLocation.topEnd, color: Colors.red, child: _buildScaffold(context))
+          : _buildScaffold(context),
     );
   }
 


### PR DESCRIPTION
### Short description

The graphql provider was twice in the widget tree: The `App` and `HomePage` widgets both "rendered" the graphql provider.
I removed the one at `HomePage` as the one in `App` was further up the tree. 

### Side effects

Likely none. Maybe caching works better now.... Not sure what other consequences there are when there are two graphql providers in place.

### Testing

General smoke test ? :D
