### PR TITLE
1688: Fix custom scheme deeplinks

### DIFF
--- a/administration/src/project-configs/showcase/config.ts
+++ b/administration/src/project-configs/showcase/config.ts
@@ -1,7 +1,8 @@
 import BavariaCardTypeExtension from '../../cards/extensions/BavariaCardTypeExtension'
 import RegionExtension from '../../cards/extensions/RegionExtension'
-import bayern, { applicationJsonToCardQuery, applicationJsonToPersonalData } from '../bayern/config'
+import { applicationJsonToCardQuery, applicationJsonToPersonalData } from '../bayern/config'
 import { DataPrivacyBaseText, dataPrivacyBaseHeadline } from '../bayern/dataPrivacyBase'
+import pdfConfiguration from '../bayern/pdf'
 import { ProjectConfig } from '../getProjectConfig'
 
 const config: ProjectConfig = {
@@ -22,12 +23,7 @@ const config: ProjectConfig = {
   dataPrivacyHeadline: dataPrivacyBaseHeadline,
   dataPrivacyContent: DataPrivacyBaseText,
   timezone: 'Europe/Berlin',
-  pdf: {
-    title: 'Karten',
-    templatePath: null,
-    issuer: 'Tür an Tür Digitalfabrik gGmbH',
-    elements: bayern.pdf.elements,
-  },
+  pdf: pdfConfiguration,
   csvExport: {
     enabled: false,
   },

--- a/administration/src/util/__tests__/getCustomDeepLinkFromActivationCode.test.ts
+++ b/administration/src/util/__tests__/getCustomDeepLinkFromActivationCode.test.ts
@@ -1,17 +1,24 @@
-import { ACTIVATION_FRAGMENT, ACTIVATION_PATH, BAYERN_STAGING_ID, CUSTOM_SCHEME } from 'build-configs'
+import { ACTIVATION_FRAGMENT, ACTIVATION_PATH } from 'build-configs'
 
+import bayernConfig from '../../project-configs/bayern/config'
 import { LOCAL_STORAGE_PROJECT_KEY } from '../../project-configs/constants'
+import koblenzConfig from '../../project-configs/koblenz/config'
 import { getBuildConfig } from '../getBuildConfig'
 import getCustomDeepLinkFromActivationCode from '../getCustomDeepLinkFromActivationCode'
 
 describe('Custom scheme deepLink generation', () => {
   const activationCodeFromUrl = '#ChsKGQoJVGhlYSBUZXN0ENOiARoICgIIACICCAA%3D'
-
-  it('should generate a correct link', () => {
-    localStorage.setItem(LOCAL_STORAGE_PROJECT_KEY, BAYERN_STAGING_ID)
-    const projectId = getBuildConfig(window.location.hostname).common.projectId.production
-    expect(getCustomDeepLinkFromActivationCode(activationCodeFromUrl)).toBe(
-      `${CUSTOM_SCHEME}://${projectId}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}${activationCodeFromUrl}`
-    )
-  })
+  const projectConfigsWithCustomSchemes = [{ projectConfig: bayernConfig }, { projectConfig: koblenzConfig }]
+  it.each(projectConfigsWithCustomSchemes)(
+    'should generate a correct link for $projectConfig.name',
+    ({ projectConfig }) => {
+      localStorage.setItem(LOCAL_STORAGE_PROJECT_KEY, projectConfig.projectId)
+      const { projectId, deepLinking } = getBuildConfig(window.location.hostname).common
+      const { production: host } = projectId
+      const { customScheme } = deepLinking
+      expect(getCustomDeepLinkFromActivationCode(activationCodeFromUrl)).toBe(
+        `${customScheme}://${host}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}${activationCodeFromUrl}`
+      )
+    }
+  )
 })

--- a/administration/src/util/getCustomDeepLinkFromActivationCode.ts
+++ b/administration/src/util/getCustomDeepLinkFromActivationCode.ts
@@ -1,9 +1,11 @@
-import { ACTIVATION_FRAGMENT, ACTIVATION_PATH, CUSTOM_SCHEME } from 'build-configs'
+import { ACTIVATION_FRAGMENT, ACTIVATION_PATH } from 'build-configs'
 
 import { getBuildConfig } from './getBuildConfig'
 
 const getCustomSchemeDeepLinkFromCode = (activationCode: string): string => {
-  const host = getBuildConfig(window.location.hostname).common.projectId.production
-  return `${CUSTOM_SCHEME}://${host}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}${activationCode}`
+  const { deepLinking, projectId } = getBuildConfig(window.location.hostname).common
+  const { production: host } = projectId
+  const { customScheme } = deepLinking
+  return `${customScheme}://${host}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}${activationCode}`
 }
 export default getCustomSchemeDeepLinkFromCode

--- a/administration/src/util/getCustomDeepLinkFromQrCode.ts
+++ b/administration/src/util/getCustomDeepLinkFromQrCode.ts
@@ -1,4 +1,4 @@
-import { ACTIVATION_FRAGMENT, ACTIVATION_PATH, CUSTOM_SCHEME } from 'build-configs/constants'
+import { ACTIVATION_FRAGMENT, ACTIVATION_PATH } from 'build-configs/constants'
 
 import { PdfQrCode } from '../cards/pdf/PdfQrCodeElement'
 import { QrCode } from '../generated/card_pb'
@@ -7,8 +7,10 @@ import { getBuildConfig } from './getBuildConfig'
 
 const getCustomDeepLinkFromQrCode = (qrCode: PdfQrCode): string => {
   const qrCodeContent = new QrCode({ qrCode }).toBinary()
-  const host = getBuildConfig(window.location.hostname).common.projectId.production
-  return `${CUSTOM_SCHEME}://${host}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodeURIComponent(
+  const { deepLinking, projectId } = getBuildConfig(window.location.hostname).common
+  const { production: host } = projectId
+  const { customScheme } = deepLinking
+  return `${customScheme}://${host}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodeURIComponent(
     uint8ArrayToBase64(qrCodeContent)
   )}/`
 }

--- a/docs/deep-linking.md
+++ b/docs/deep-linking.md
@@ -7,7 +7,7 @@ We use deep linking to simplify the card activation for the user.
 ### 1. Https
 
 This scheme has a trust association to our server and only works if `assetlinks.json` and `apple-app-site-association` files are properly deployed on our webserver.
-We need this scheme because some mail clients can not resolve a custom scheme if we send activation links via mail.
+We need this scheme because some mail clients and pdf readers can not resolve a custom scheme.
 Please note that we only have one web application for all projects and the `ProjectConfig` is depending on the url. 
 So in nginx redirects are configured for each project to reach the particular association file:
 
@@ -17,22 +17,24 @@ So in nginx redirects are configured for each project to reach the particular as
 
 ### 2. Custom scheme
 
-The custom scheme `berechtigungskarte` is basically used for local testing and can also be used as a fallback if `https` scheme is not working.
+The custom scheme is project dependent. It is used for local testing and deep links that have to be opened in the browser if `https` scheme is not working.
+Custom scheme deep links have a better browser compatibility than https deep links.
 
 ## ActivationLink
 
-The card activation links will be printed on the pdf or send via mail. It's important that the `activationCode` is uriEncoded.
+The card activation links will be printed on the pdf,send via mail or accessible via self service portal. It's important that the `activationCode` is uriEncoded.
 
 ### Examples:
 
 ```
 https://staging.bayern.ehrenamtskarte.app/activation/code#ClcKLQoNRGVlcGxpbmsgVGVzdBCWnQEaGAoCCF0SAwiIORoHCLPPvgEQASoECKiaARIQBuTHyi60o6UC2U439XGLMRoUBzxIAa%2BPG%2Bj%2FIrBzJVTJACh21KA%3D/
 
-berechtigungskarte://bayern.ehrenamtskarte.app/activation/code#ClcKLQoNRGVlcGxpbmsgVGVzdBCWnQEaGAoCCF0SAwiIORoHCLPPvgEQASoECKiaARIQBuTHyi60o6UC2U439XGLMRoUBzxIAa%2BPG%2Bj%2FIrBzJVTJACh21KA%3D/
+ehrenamtbayern://bayern.ehrenamtskarte.app/activation/code#ClcKLQoNRGVlcGxpbmsgVGVzdBCWnQEaGAoCCF0SAwiIORoHCLPPvgEQASoECKiaARIQBuTHyi60o6UC2U439XGLMRoUBzxIAa%2BPG%2Bj%2FIrBzJVTJACh21KA%3D/
+koblenzpass://koblenz.sozialpass.app/activation/code#ClcKLQoNRGVlcGxpbmsgVGVzdBCWnQEaGAoCCF0SAwiIORoHCLPPvgEQASoECKiaARIQBuTHyi60o6UC2U439XGLMRoUBzxIAa%2BPG%2Bj%2FIrBzJVTJACh21KA%3D/
 ```
 
 #### Note
-These are local activation codes are local and won't work on real devices.
+These activation codes are local and won't work on real devices.
 We use a `fragment (code#)` for the activation code to avoid sending user data to the server 
 
 ## Testing
@@ -43,15 +45,15 @@ Install: `npm i -g uri-scheme` if you want to use the simplified command
 
 #### Note
 For android trusted associations, which are required for https schemes, only work with signed apks out of the box.
-For local development you have to install the app and add these domains manually.
+For local testing you have to install the app and add these domains manually.
 - AppSettings -> OpenByDefault -> AddLinks -> enable supported links
 
 ```
- npx uri-scheme open https://staging.nuernberg.sozialpass.app/activation/code#<activationCode>/ --android
+npx uri-scheme open https://staging.nuernberg.sozialpass.app/activation/code#<activationCode>/ --android
 ```
 
 
-### a) iOS
+### b) iOS
 ```
 npx uri-scheme open https://staging.nuernberg.sozialpass.app/activation/code#<activationCode>/ --ios
 ```

--- a/frontend/build-configs/bayern/index.ts
+++ b/frontend/build-configs/bayern/index.ts
@@ -1,4 +1,4 @@
-import { ACTIVATION_PATH, BAYERN_PRODUCTION_ID, BAYERN_STAGING_ID, CUSTOM_SCHEME } from "../constants"
+import { ACTIVATION_PATH, BAYERN_PRODUCTION_ID, BAYERN_STAGING_ID } from "../constants"
 import BuildConfigType, { CommonBuildConfigType } from "../types"
 import disclaimerText from "./disclaimerText"
 import publisherText from "./publisherText"
@@ -80,7 +80,7 @@ export const bayernCommon: CommonBuildConfigType = {
     activationPath: ACTIVATION_PATH,
     deepLinking: {
         projectName: "bayern",
-        customScheme: CUSTOM_SCHEME,
+        customScheme: "ehrenamtbayern",
         android: {
             applicationId: ANDROID_APPLICATION_ID,
             path: `/${ACTIVATION_PATH}/.*`,

--- a/frontend/build-configs/constants/index.ts
+++ b/frontend/build-configs/constants/index.ts
@@ -1,7 +1,6 @@
 export const ACTIVATION_PATH = "activation"
 export const ACTIVATION_FRAGMENT = 'code'
 
-export const CUSTOM_SCHEME = 'berechtigungskarte'
 export const HTTPS_SCHEME = 'https'
 export const BAYERN_PRODUCTION_ID = 'bayern.ehrenamtskarte.app'
 export const BAYERN_STAGING_ID = 'staging.bayern.ehrenamtskarte.app'

--- a/frontend/build-configs/koblenz/index.ts
+++ b/frontend/build-configs/koblenz/index.ts
@@ -1,4 +1,4 @@
-import { ACTIVATION_PATH, KOBLENZ_PRODUCTION_ID, KOBLENZ_STAGING_ID, CUSTOM_SCHEME } from "../constants"
+import { ACTIVATION_PATH, KOBLENZ_PRODUCTION_ID, KOBLENZ_STAGING_ID } from "../constants"
 import BuildConfigType, { CommonBuildConfigType } from "../types"
 import disclaimerText from "./disclaimerText"
 import publisherText from "./publisherText"
@@ -80,7 +80,7 @@ export const koblenzCommon: CommonBuildConfigType = {
     activationPath: ACTIVATION_PATH,
     deepLinking: {
         projectName: "koblenz",
-        customScheme: CUSTOM_SCHEME,
+        customScheme: "koblenzpass",
         android: {
             applicationId: ANDROID_APPLICATION_ID,
             path: `/${ACTIVATION_PATH}/.*`,

--- a/frontend/build-configs/nuernberg/index.ts
+++ b/frontend/build-configs/nuernberg/index.ts
@@ -1,4 +1,4 @@
-import { ACTIVATION_PATH, CUSTOM_SCHEME, NUERNBERG_PRODUCTION_ID, NUERNBERG_STAGING_ID } from "../constants"
+import { ACTIVATION_PATH, NUERNBERG_PRODUCTION_ID, NUERNBERG_STAGING_ID } from "../constants"
 import BuildConfigType, { CommonBuildConfigType } from "../types"
 import disclaimerText from "./disclaimerText"
 import publisherText from "./publisherText"
@@ -80,7 +80,7 @@ export const nuernbergCommon: CommonBuildConfigType = {
     activationPath: ACTIVATION_PATH,
     deepLinking: {
         projectName: "nuernberg",
-        customScheme: CUSTOM_SCHEME,
+        customScheme: "nuernbergpass",
         android: {
             applicationId: ANDROID_APPLICATION_ID,
             path: `/${ACTIVATION_PATH}/.*`,

--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -26,7 +26,7 @@
 		<dict>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>berechtigungskarte</string>
+				<string>$(BUILD_CONFIG_DEEP_LINKING_CUSTOM_SCHEME)</string>
 			</array>
 			<key>CFBundleURLName</key>
 			<string>$(BUILD_CONFIG_PROJECT_ID_PRODUCTION)</string>


### PR DESCRIPTION
### Short description

Currently we use the same custom scheme for the deeplinks of all our apps `berechtigungskarte://`
If a user has more than just one of these apps installed it is not clear which app should be opened by clicking a deeplink.
While in android there would be a app selection (which is also should be avoided), in ios there will be just one of the apps proposed to open the link. Therefore each app should have its own custom scheme to prevent that

### Proposed changes

<!-- Describe this PR in more detail. -->

- add a custom scheme for each project
- adjust the info.plist file for ios to use this value from the buildConfig instead of a hardcoded string
- adjust tests
- adjust custom deeplink creation to use the correct scheme

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none, since currently custom deeplinks only exist on the /activation route of the administration

### Testing
- Create a card. Copy the code from the console.
- Create a koblenz pass and check the activation link
- install koblenzpass and bavaria on your device. 
- open deeplink:
```js
npx uri-scheme open koblenzpass://koblenz.sozialpass.app/activation/code#<activationCode>/ --ios
npx uri-scheme open koblenzpass://koblenz.sozialpass.app/activation/code#<activationCode>/ --android
npx uri-scheme open ehrenamtbayern://bayern.ehrenamtskarte.app/activation/code#<activationCode>/ --ios
npx uri-scheme open ehrenamtbayern://bayern.ehrenamtskarte.app/activation/code#<activationCode>/ --android
```
- correct app should be opened

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1688
