### PR TITLE
Downgrade secure storage

### DIFF
--- a/frontend/ios/Podfile.lock
+++ b/frontend/ios/Podfile.lock
@@ -164,7 +164,7 @@ SPEC CHECKSUMS:
   device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
   fk_user_agent: 1f47ec39291e8372b1d692b50084b0d54103c545
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
+  flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
   geolocator_apple: 6cbaf322953988e009e5ecb481f07efece75c450
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleMLKit: 2bd0dc6253c4d4f227aad460f69215a504b2980e

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -349,10 +349,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "165164745e6afb5c0e3e3fcc72a012fb9e58496fb26ffb92cf22e16a821e85d0"
+      sha256: ffdbb60130e4665d2af814a0267c481bcf522c41ae2e43caf69fa0146876d685
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.2"
+    version: "9.0.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -28,7 +28,8 @@ dependencies:
   package_info_plus: ^4.0.1 # for about dialog
   mobile_scanner: ^4.0.1
   fixnum: ^1.1.0
-  flutter_secure_storage: ^9.0.0
+  # Locking this version due to this issue https://github.com/mogol/flutter_secure_storage/issues/762
+  flutter_secure_storage: 9.0.0
   infinite_scroll_pagination: ^4.0.0
   geolocator: ^11.0.0
   geolocator_android: ^4.3.1


### PR DESCRIPTION
### Short description

Due to this issue we should lock the version to 9.0.0
https://github.com/mogol/flutter_secure_storage/issues/762

### Proposed changes

<!-- Describe this PR in more detail. -->

- lock version 9.0.0

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- hopefully none
-

### Testing
1. Activate card and test if the data will be kept in storage after app restart

I tested this with ios 17.5 und 18.0

