### PR TITLE
1647: Add store links

### DIFF
--- a/administration/src/bp-modules/components/AppStoreLinks.tsx
+++ b/administration/src/bp-modules/components/AppStoreLinks.tsx
@@ -1,0 +1,45 @@
+import { styled } from '@mui/system'
+import React, { ReactElement } from 'react'
+
+import AndroidStoreIcon from '../../assets/android_appstore_icon.svg'
+import AppleStoreIcon from '../../assets/ios_appstore_icon.svg'
+
+const StoreLink = styled('a')`
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  text-decoration: none;
+  color: black;
+  margin: 24px 0;
+`
+
+const StoreIcon = styled('img')`
+  height: 40px;
+  width: 130px;
+`
+
+const LinkContainer = styled('div')`
+  margin-bottom: 8px;
+  font-size: 16px;
+`
+type AppStoreLinksProps = {
+  playStoreUrl: string
+  appStoreUrl: string
+}
+const AppStoreLinks = ({ appStoreUrl, playStoreUrl }: AppStoreLinksProps): ReactElement => {
+  console.log(appStoreUrl)
+  return (
+    <LinkContainer>
+      <StoreLink href={appStoreUrl} target='_blank' rel='noreferrer'>
+        <StoreIcon src={AppleStoreIcon} alt='AppStore öffnen' />
+        AppStore öffnen
+      </StoreLink>
+      <StoreLink href={playStoreUrl} target='_blank' rel='noreferrer'>
+        <StoreIcon src={AndroidStoreIcon} alt='Google Play öffnen' />
+        Google Play öffnen
+      </StoreLink>
+    </LinkContainer>
+  )
+}
+
+export default AppStoreLinks

--- a/administration/src/bp-modules/components/AppStoreLinks.tsx
+++ b/administration/src/bp-modules/components/AppStoreLinks.tsx
@@ -2,7 +2,7 @@ import { styled } from '@mui/system'
 import React, { ReactElement } from 'react'
 
 import AndroidStoreIcon from '../../assets/android_appstore_icon.svg'
-import AppleStoreIcon from '../../assets/ios_appstore_icon.svg'
+import AppStoreIcon from '../../assets/ios_appstore_icon.svg'
 
 const StoreLink = styled('a')`
   display: flex;
@@ -23,23 +23,20 @@ const LinkContainer = styled('div')`
   font-size: 16px;
 `
 type AppStoreLinksProps = {
-  playStoreUrl: string
-  appStoreUrl: string
+  playStoreLink: string
+  appStoreLink: string
 }
-const AppStoreLinks = ({ appStoreUrl, playStoreUrl }: AppStoreLinksProps): ReactElement => {
-  console.log(appStoreUrl)
-  return (
-    <LinkContainer>
-      <StoreLink href={appStoreUrl} target='_blank' rel='noreferrer'>
-        <StoreIcon src={AppleStoreIcon} alt='AppStore öffnen' />
-        AppStore öffnen
-      </StoreLink>
-      <StoreLink href={playStoreUrl} target='_blank' rel='noreferrer'>
-        <StoreIcon src={AndroidStoreIcon} alt='Google Play öffnen' />
-        Google Play öffnen
-      </StoreLink>
-    </LinkContainer>
-  )
-}
+const AppStoreLinks = ({ appStoreLink, playStoreLink }: AppStoreLinksProps): ReactElement => (
+  <LinkContainer>
+    <StoreLink href={appStoreLink} target='_blank' rel='noreferrer'>
+      <StoreIcon src={AppStoreIcon} alt='App Store öffnen' />
+      AppStore öffnen
+    </StoreLink>
+    <StoreLink href={playStoreLink} target='_blank' rel='noreferrer'>
+      <StoreIcon src={AndroidStoreIcon} alt='Google Play öffnen' />
+      Google Play öffnen
+    </StoreLink>
+  </LinkContainer>
+)
 
 export default AppStoreLinks

--- a/administration/src/bp-modules/self-service/CardSelfServiceInformation.tsx
+++ b/administration/src/bp-modules/self-service/CardSelfServiceInformation.tsx
@@ -13,7 +13,7 @@ const CardSelfServiceInformation = ({ goToActivation }: CardSelfServiceInformati
   const { ios, android } = getBuildConfig(window.location.hostname)
   return (
     <>
-      <AppStoreLinks playStoreUrl={android.appStoreLink} appStoreUrl={ios.appStoreLink} />
+      <AppStoreLinks playStoreLink={android.appStoreLink} appStoreLink={ios.appStoreLink} />
       <InfoText>
         <div>
           <b>App bereits installiert?</b>

--- a/administration/src/bp-modules/self-service/CardSelfServiceInformation.tsx
+++ b/administration/src/bp-modules/self-service/CardSelfServiceInformation.tsx
@@ -1,8 +1,7 @@
-import { styled } from '@mui/material'
 import React, { ReactElement } from 'react'
 
-import AndroidStoreIcon from '../../assets/android_appstore_icon.svg'
-import AppleStoreIcon from '../../assets/ios_appstore_icon.svg'
+import { getBuildConfig } from '../../util/getBuildConfig'
+import AppStoreLinks from '../components/AppStoreLinks'
 import { ActionButton } from './components/ActionButton'
 import { InfoText } from './components/InfoText'
 
@@ -10,47 +9,22 @@ type CardSelfServiceInformationProps = {
   goToActivation: () => void
 }
 
-const StoreLink = styled('a')`
-  display: flex;
-  gap: 20px;
-  align-items: center;
-  text-decoration: none;
-  color: black;
-  margin: 24px 0;
-`
-
-const StoreIcon = styled('img')`
-  height: 40px;
-  width: 130px;
-`
-
-const LinkContainer = styled('div')`
-  margin-bottom: 8px;
-  font-size: 16px;
-`
-// TODO 1647 provide store links
-const CardSelfServiceInformation = ({ goToActivation }: CardSelfServiceInformationProps): ReactElement => (
-  <>
-    <LinkContainer>
-      <StoreLink href='https://apple.com' target='_blank' rel='noreferrer'>
-        <StoreIcon src={AppleStoreIcon} alt='AppStore öffnen' />
-        AppStore öffnen
-      </StoreLink>
-      <StoreLink href='https://google.com' target='_blank' rel='noreferrer'>
-        <StoreIcon src={AndroidStoreIcon} alt='Google Play öffnen' />
-        Google Play öffnen
-      </StoreLink>
-    </LinkContainer>
-    <InfoText>
-      <div>
-        <b>App bereits installiert?</b>
-      </div>
-      <div>Einfach weiter klicken.</div>
-    </InfoText>
-    <ActionButton onClick={goToActivation} variant='contained' size='large'>
-      Zur Aktivierung
-    </ActionButton>
-  </>
-)
+const CardSelfServiceInformation = ({ goToActivation }: CardSelfServiceInformationProps): ReactElement => {
+  const { ios, android } = getBuildConfig(window.location.hostname)
+  return (
+    <>
+      <AppStoreLinks playStoreUrl={android.appStoreLink} appStoreUrl={ios.appStoreLink} />
+      <InfoText>
+        <div>
+          <b>App bereits installiert?</b>
+        </div>
+        <div>Einfach weiter klicken.</div>
+      </InfoText>
+      <ActionButton onClick={goToActivation} variant='contained' size='large'>
+        Zur Aktivierung
+      </ActionButton>
+    </>
+  )
+}
 
 export default CardSelfServiceInformation

--- a/administration/src/bp-modules/self-service/constants/selfServiceStepInfo.tsx
+++ b/administration/src/bp-modules/self-service/constants/selfServiceStepInfo.tsx
@@ -23,7 +23,7 @@ const selfServiceStepInfo: SelfServiceStepInfo[] = [
   {
     stepNr: 2,
     headline: 'Ihr KoblenzPass wurde erstellt.',
-    subHeadline: 'Nur noch ein paar Klicks, bis Sie alle Vorteile nutzen zu können.',
+    subHeadline: 'Nur noch ein paar Klicks, bis Sie alle Vorteile nutzen können.',
     text: (
       <span>
         Haben Sie die App noch nicht? <b>Laden Sie sie jetzt herunter, um fortzufahren.</b>

--- a/frontend/build-configs/bayern/index.ts
+++ b/frontend/build-configs/bayern/index.ts
@@ -104,11 +104,13 @@ const bayern: BuildConfigType = {
             excludeLocationPlayServices: false,
             excludeX86: false,
         },
+        appStoreLink: `https://play.google.com/store/apps/details?id=${ANDROID_APPLICATION_ID}`,
     },
     ios: {
         ...bayernCommon,
         bundleIdentifier: IOS_BUNDLE_IDENTIFIER,
         provisioningProfileSpecifier: "match AppStore de.nrw.it.ehrensachebayern",
+        appStoreLink: "https://apps.apple.com/de/app/ehrenamtskarte-bayern/id1261285110",
     },
 }
 

--- a/frontend/build-configs/koblenz/index.ts
+++ b/frontend/build-configs/koblenz/index.ts
@@ -104,11 +104,13 @@ const koblenz: BuildConfigType = {
             excludeLocationPlayServices: false,
             excludeX86: false,
         },
+        appStoreLink: `https://play.google.com/store/apps/details?id=${ANDROID_APPLICATION_ID}`
     },
     ios: {
         ...koblenzCommon,
         bundleIdentifier: IOS_BUNDLE_IDENTIFIER,
         provisioningProfileSpecifier: "match AppStore app.sozialpass.koblenz",
+        appStoreLink: "https://apps.apple.com/de/app/koblenzpass/id6670392532"
     },
 }
 

--- a/frontend/build-configs/nuernberg/index.ts
+++ b/frontend/build-configs/nuernberg/index.ts
@@ -110,7 +110,7 @@ const nuernberg: BuildConfigType = {
         ...nuernbergCommon,
         bundleIdentifier: IOS_BUNDLE_IDENTIFIER,
         provisioningProfileSpecifier: "match AppStore app.sozialpass.nuernberg",
-        appStoreLink: "https://apps.apple.com/ky/app/n%C3%BCrnberg-pass/id1667599309",
+        appStoreLink: "https://apps.apple.com/de/app/n%C3%BCrnberg-pass/id1667599309",
     },
 }
 

--- a/frontend/build-configs/nuernberg/index.ts
+++ b/frontend/build-configs/nuernberg/index.ts
@@ -104,11 +104,13 @@ const nuernberg: BuildConfigType = {
             excludeLocationPlayServices: false,
             excludeX86: false,
         },
+        appStoreLink: `https://play.google.com/store/apps/details?id=${ANDROID_APPLICATION_ID}`,
     },
     ios: {
         ...nuernbergCommon,
         bundleIdentifier: IOS_BUNDLE_IDENTIFIER,
         provisioningProfileSpecifier: "match AppStore app.sozialpass.nuernberg",
+        appStoreLink: "https://apps.apple.com/ky/app/n%C3%BCrnberg-pass/id1667599309",
     },
 }
 

--- a/frontend/build-configs/types.ts
+++ b/frontend/build-configs/types.ts
@@ -109,12 +109,14 @@ export type AndroidBuildConfigType = CommonBuildConfigType & {
         excludeLocationPlayServices: boolean
         excludeX86: boolean
     }
+    appStoreLink: string
 }
 
 export type iOSBuildConfigType = CommonBuildConfigType & {
     // iOS application identifier.
     bundleIdentifier: string
     provisioningProfileSpecifier: string
+    appStoreLink: string
 }
 
 export default BuildConfigType


### PR DESCRIPTION
### Short description

For the download instructions of the koblenz pass self service we need store links. in #1707 we may also create a separate app download route and need also the urls for the other projects

### Proposed changes

<!-- Describe this PR in more detail. -->

- add store urls for all project in buildConfig
- extract `AppStoreLinks` component to make it reusable for #1707 

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-none

### Testing

1. Ensure `npm i` ran on root folder to have new buildConfig variables
2. Start koblenz pass go to /erstellen and create a pass.
3. Go to next and check that the store links are properly set. Note that for ios the app is not visible until first production release

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1647

