### PR TITLE
1685: Add the ability to remove an old card during deep link activation

### DIFF
--- a/frontend/assets/koblenz/l10n/override_de.json
+++ b/frontend/assets/koblenz/l10n/override_de.json
@@ -38,6 +38,7 @@
     "headline": "Pass aktivieren",
     "description": "Wollen Sie diesen Pass aktivieren?",
     "limitReached": "Ihr Passlimit wurde erreicht. Bitte entfernen Sie vorher einen Pass, damit Sie einen neuen aktivieren können.",
+    "replaceCard": "Sie haben bereits einen aktivierten Pass auf diesem Gerät. Wenn Sie fortfahren, wird der alte Pass gelöscht.",
     "buttonText": "Pass aktivieren",
     "invalidCode": "Ihr Aktivierungscode ist ungültig.",
     "alreadyExists": "Dieser Pass wurde bereits auf dem Gerät aktiviert.",

--- a/frontend/assets/l10n/app_de.json
+++ b/frontend/assets/l10n/app_de.json
@@ -73,6 +73,7 @@
     "headline": "Karte aktivieren",
     "description": "Wollen Sie diese Karte aktivieren?",
     "limitReached": "Ihr Kartenlimit wurde erreicht. Bitte entfernen Sie vorher eine Karte, damit Sie eine neue aktivieren können.",
+    "replaceCard": "Sie haben bereits eine aktivierte Karte auf diesem Gerät. Wenn Sie fortfahren, wird die alte Karte gelöscht.",
     "buttonText": "Karte aktivieren",
     "invalidCode": "Ihr Aktivierungscode ist ungültig.",
     "alreadyExists": "Diese Karte wurde bereits auf dem Gerät aktiviert.",

--- a/frontend/assets/l10n/app_en.json
+++ b/frontend/assets/l10n/app_en.json
@@ -27,6 +27,7 @@
     "headline": "Activate card",
     "description": "Do you want to activate this card?",
     "limitReached": "Your card limit has been reached. Please remove a card first.",
+    "replaceCard": "You already have an activated card on this device. If you continue, the old card will be removed.",
     "buttonText": "Activate Card",
     "invalidCode": "The activation code is invalid.",
     "alreadyExists": "This card has already been activated on this device.",

--- a/frontend/lib/identification/identification_page.dart
+++ b/frontend/lib/identification/identification_page.dart
@@ -49,7 +49,7 @@ class IdentificationPageState extends State<IdentificationPage> {
               startVerification: () => _showVerificationDialog(context, settings, userCodeModel),
               startActivation: () => _startActivation(context),
               startApplication: _startApplication,
-              openRemoveCardDialog: () => _openRemoveCardDialog(context),
+              openRemoveCardDialog: () => _openRemoveCardDialog(context, userCodeModel),
             ));
           }
 
@@ -105,10 +105,12 @@ class IdentificationPageState extends State<IdentificationPage> {
     );
   }
 
-  Future<void> _openRemoveCardDialog(BuildContext context) async {
-    final userCodeModel = Provider.of<UserCodeModel>(context, listen: false);
-    await RemoveCardConfirmationDialog.show(
-        context: context, userCode: userCodeModel.userCodes[cardIndex], carouselController: carouselController);
+  Future<void> _openRemoveCardDialog(BuildContext context, UserCodeModel userCodeModel) async {
+    final removed =
+        await RemoveCardConfirmationDialog.show(context: context, userCode: userCodeModel.userCodes[cardIndex]);
+    if (removed && userCodeModel.userCodes.isNotEmpty) {
+      carouselController.previousPage(duration: Duration(milliseconds: 500), curve: Curves.linear);
+    }
   }
 
   void _moveCarouselToLastPosition() {

--- a/frontend/lib/identification/verification_workflow/dialogs/remove_card_confirmation_dialog.dart
+++ b/frontend/lib/identification/verification_workflow/dialogs/remove_card_confirmation_dialog.dart
@@ -8,18 +8,15 @@ import 'package:provider/provider.dart';
 
 class RemoveCardConfirmationDialog extends StatefulWidget {
   final DynamicUserCode userCode;
-  final CarouselController carouselController;
 
-  const RemoveCardConfirmationDialog({super.key, required this.userCode, required this.carouselController});
+  const RemoveCardConfirmationDialog({super.key, required this.userCode});
 
-  static Future<void> show(
-          {required BuildContext context,
-          required DynamicUserCode userCode,
-          required CarouselController carouselController}) =>
-      showDialog(
+  static Future<bool> show(
+          {required BuildContext context, required DynamicUserCode userCode, CarouselController? carouselController}) =>
+      showDialog<bool>(
         context: context,
-        builder: (_) => RemoveCardConfirmationDialog(userCode: userCode, carouselController: carouselController),
-      );
+        builder: (_) => RemoveCardConfirmationDialog(userCode: userCode),
+      ).then((removed) => removed ?? false);
 
   @override
   RemoveCardConfirmationDialogState createState() => RemoveCardConfirmationDialogState();
@@ -33,7 +30,6 @@ class RemoveCardConfirmationDialogState extends State<RemoveCardConfirmationDial
       userCodeModel.removeCodes();
     } else {
       userCodeModel.removeCode(widget.userCode);
-      widget.carouselController.previousPage(duration: Duration(milliseconds: 500), curve: Curves.linear);
     }
     Navigator.of(context).pop(true);
   }


### PR DESCRIPTION
### Short description
Currently when a user already has a card in the app and tries to activate a new card via a deep link, he receives the message `Ihr Kartenlimit wurde erreicht. Bitte entfernen Sie vorher eine Karte, damit Sie eine neue aktivieren können.` and is forced to first delete the old card and then repeat the activation.

This PR adds the ability to delete the old card during activation.

### Proposed changes
- change the displayed message to `Sie haben bereits einen aktivierten Pass auf diesem Gerät. Wenn Sie fortfahren, wird der alte Pass gelöscht.`
- if the user proceeds, first delete the old card and then activate the new card
- this only applies to projects, where only 1 card is allowed (so, Nürnberg shouldn't be affected)
- small refactoring of RemoveCardConfirmationDialog to be able to reuse it

### Side effects
If the user proceeds and deletes the old card, but then some error occurs (`Fehler beim Lesen des Codes` for example), the user will have neither the old nor the new card in the app. Not sure if this is an issue though. If he keeps the old QR code, he should be able to activate the old card again.

### Testing
Instruction for Koblenz:

1. Open administration --> login as a koblenz project admin --> go to settings --> create token
2. Import users using curl or Postman
`curl -H "Authorization: Bearer <my_token>" -F file=@import_testdata_local.csv http://0.0.0.0:8000/users/import`

**CSV content:**
```
regionKey,userHash,startDate,endDate,revoked
07111,"$argon2id$v=19$m=19456,t=2,p=1$cr3lP9IMUKNz4BLfPGlAOHq1z98G5/2tTbhDIko35tY",01.01.2024,01.01.2025,false
```

3. Go to http://localhost:3000/ and select Koblenz
4. Go to http://localhost:3000/erstellen, create a card with a birthday 10.06.2003 and a reference number 123K
5. Activate the card in the app
6. Go to http://localhost:3000/erstellen again, create another card with a birthday 10.06.2003 and a reference number 123K, _but enter some different name_ (required to produce a different cardInfo, otherwise you get the `Dieser Pass wurde bereits auf dem Gerät aktiviert.` message; alternatively some other data should differ)
7. Try to activate the new card via deep link:
`npx uri-scheme open berechtigungskarte://koblenz.sozialpass.app/activation/code#<activation-code> --android`
**It should be possible to remove the old card during the activation.**

### Resolved issues
Fixes: #1685
