### PR TITLE
Fortify Code Store

### DIFF
--- a/frontend/lib/about/dev_settings_view.dart
+++ b/frontend/lib/about/dev_settings_view.dart
@@ -78,7 +78,7 @@ class DevSettingsView extends StatelessWidget {
               title: const Text('Trigger self-verification'),
               onTap: () => {
                     for (final userCode in userCodeModel.userCodes)
-                      {selfVerifyCard(context, userCode, Configuration.of(context).projectId, client)}
+                      {selfVerifyCard(userCodeModel, userCode, Configuration.of(context).projectId, client)}
                   }),
           ListTile(
             title: const Text('Log sample exception'),

--- a/frontend/lib/activation/deeplink_activation.dart
+++ b/frontend/lib/activation/deeplink_activation.dart
@@ -30,7 +30,7 @@ enum DeepLinkActivationStatus {
   factory DeepLinkActivationStatus.from(UserCodeModel userCodeModel, DynamicActivationCode? activationCode) {
     if (activationCode == null) {
       return DeepLinkActivationStatus.invalidLink;
-    } else if (isAlreadyInList(userCodeModel.userCodes, activationCode.info)) {
+    } else if (isAlreadyInList(userCodeModel.userCodes, activationCode.info, activationCode.pepper)) {
       return DeepLinkActivationStatus.alreadyExists;
     } else if (hasReachedCardLimit(userCodeModel.userCodes)) {
       return DeepLinkActivationStatus.limitReached;

--- a/frontend/lib/identification/card_detail_view/card_detail_view.dart
+++ b/frontend/lib/identification/card_detail_view/card_detail_view.dart
@@ -2,6 +2,7 @@ import 'package:ehrenamtskarte/configuration/configuration.dart';
 import 'package:ehrenamtskarte/identification/card_detail_view/more_actions_dialog.dart';
 import 'package:ehrenamtskarte/identification/card_detail_view/self_verify_card.dart';
 import 'package:ehrenamtskarte/identification/id_card/id_card_with_region_query.dart';
+import 'package:ehrenamtskarte/identification/user_code_model.dart';
 import 'package:ehrenamtskarte/identification/util/card_info_utils.dart';
 import 'package:ehrenamtskarte/proto/card.pb.dart';
 import 'package:flutter/material.dart';
@@ -9,6 +10,7 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
 import 'package:ehrenamtskarte/identification/card_detail_view/verification_code_view.dart';
+import 'package:provider/provider.dart';
 
 class CardDetailView extends StatefulWidget {
   final DynamicUserCode userCode;
@@ -50,7 +52,8 @@ class _CardDetailViewState extends State<CardDetailView> {
   Future<void> _selfVerifyCard(DynamicUserCode userCode) async {
     final projectId = Configuration.of(context).projectId;
     final client = GraphQLProvider.of(context).value;
-    selfVerifyCard(context, userCode, projectId, client);
+    final userCodeModel = Provider.of<UserCodeModel>(context, listen: false);
+    selfVerifyCard(userCodeModel, userCode, projectId, client);
   }
 
   @override

--- a/frontend/lib/identification/user_code_store.dart
+++ b/frontend/lib/identification/user_code_store.dart
@@ -5,9 +5,10 @@ import 'package:ehrenamtskarte/proto/card.pb.dart';
 import 'package:ehrenamtskarte/sentry.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
-class UserCodeStore {
-  const UserCodeStore();
+import 'package:ehrenamtskarte/util/read_write_lock.dart';
 
+class UserCodeStore {
+  final _storage = ReadWriteLock(FlutterSecureStorage());
   static const _userCodesBase64Key = 'userCodesBase64';
 
   // legacy key for single card
@@ -15,34 +16,33 @@ class UserCodeStore {
   static const _storageDelimiter = ',';
 
   Future<void> store(List<DynamicUserCode> userCodes) async {
-    const storage = FlutterSecureStorage();
-    Iterable<String> userCodeString = userCodes.map((code) => const Base64Encoder().convert(code.writeToBuffer()));
-    await storage.write(key: _userCodesBase64Key, value: userCodeString.join(_storageDelimiter));
+    String userCodesString =
+        userCodes.map((code) => const Base64Encoder().convert(code.writeToBuffer())).join(_storageDelimiter);
+    await _storage.use((it) => it.write(key: _userCodesBase64Key, value: userCodesString));
   }
 
   Future<void> remove() async {
-    const storage = FlutterSecureStorage();
-    await storage.delete(key: _userCodesBase64Key);
+    await _storage.use((it) => it.delete(key: _userCodesBase64Key));
   }
 
   Future<List<DynamicUserCode>> load() async {
-    const storage = FlutterSecureStorage();
-    String? userCodesBase64;
-    // make fake read on android - workaround for https://github.com/mogol/flutter_secure_storage/issues/653
-    if (Platform.isAndroid) {
-      String? userCodesBase64FirstRead = await storage.read(key: _userCodesBase64Key);
-      userCodesBase64 = await storage.read(key: _userCodesBase64Key);
-      // report error if first read is null but second read contains data to collect sentry data for reproduction
-      if (userCodesBase64FirstRead != userCodesBase64) {
-        bool firstIsNull = userCodesBase64FirstRead == null;
-        bool secondIsNull = userCodesBase64 == null;
-        reportError(
-            'First read from secure storage differs from second: firstNull=$firstIsNull, secondNull=$secondIsNull',
-            null);
+    String? userCodesBase64 = await _storage.use((storage) async {
+      // make fake read on android - workaround for https://github.com/mogol/flutter_secure_storage/issues/653
+      if (Platform.isAndroid) {
+        String? userCodesBase64FirstRead = await storage.read(key: _userCodesBase64Key);
+        final userCodesBase64 = await storage.read(key: _userCodesBase64Key);
+        // report error if first read is null but second read contains data to collect sentry data for reproduction
+        if (userCodesBase64FirstRead != userCodesBase64) {
+          bool firstIsNull = userCodesBase64FirstRead == null;
+          bool secondIsNull = userCodesBase64 == null;
+          reportError(
+              'First read from secure storage differs from second: firstNull=$firstIsNull, secondNull=$secondIsNull',
+              null);
+        }
+        return userCodesBase64;
       }
-    } else {
-      userCodesBase64 = await storage.read(key: _userCodesBase64Key);
-    }
+      return await storage.read(key: _userCodesBase64Key);
+    });
 
     if (userCodesBase64 == null) return [];
     return userCodesBase64
@@ -53,11 +53,12 @@ class UserCodeStore {
 
   // legacy import of existing card to keep them in storage after update
   Future<DynamicUserCode?> loadAndDeleteLegacyCard() async {
-    const storage = FlutterSecureStorage();
-    final String? userCodeBase64 = await storage.read(key: _legacyUserCodeBase64Key);
-    if (userCodeBase64 == null) return null;
-    DynamicUserCode importedLegacyCard = DynamicUserCode.fromBuffer(const Base64Decoder().convert(userCodeBase64));
-    await storage.delete(key: _legacyUserCodeBase64Key);
-    return importedLegacyCard;
+    return await _storage.use((storage) async {
+      final String? userCodeBase64 = await storage.read(key: _legacyUserCodeBase64Key);
+      if (userCodeBase64 == null) return null;
+      DynamicUserCode importedLegacyCard = DynamicUserCode.fromBuffer(const Base64Decoder().convert(userCodeBase64));
+      await storage.delete(key: _legacyUserCodeBase64Key);
+      return importedLegacyCard;
+    });
   }
 }

--- a/frontend/lib/identification/util/activate_card.dart
+++ b/frontend/lib/identification/util/activate_card.dart
@@ -61,7 +61,7 @@ Future<bool> activateCard(
           ..cardValid = true
           ..verificationTimeStamp = secondsSinceEpoch(DateTime.parse(activationResult.activationTimeStamp)));
 
-      userCodesModel.insertCode(userCode);
+      await userCodesModel.insertCode(userCode);
       debugPrint('Card Activation: Successfully activated.');
       if (context.mounted) {
         messengerState.showSnackBar(
@@ -82,7 +82,7 @@ Future<bool> activateCard(
       if (overwriteExisting) {
         throw const ActivationDidNotOverwriteExisting();
       }
-      if (isAlreadyInList(userCodesModel.userCodes, activationCode.info)) {
+      if (isAlreadyInList(userCodesModel.userCodes, activationCode.info, activationCode.pepper)) {
         if (context.mounted) {
           await ActivationExistingCardDialog.showExistingCardDialog(context);
         }

--- a/frontend/lib/util/read_write_lock.dart
+++ b/frontend/lib/util/read_write_lock.dart
@@ -1,0 +1,14 @@
+import 'package:mutex/mutex.dart';
+
+class ReadWriteLock<T> {
+  final mutex = Mutex();
+  final T obj;
+
+  ReadWriteLock(this.obj);
+
+  /// Allows exclusive access to the protected object.
+  /// Users are responsible to not leak any reference to the protected object outside the critical section.
+  Future<R> use<R>(Future<R> Function(T) criticalSection) async {
+    return await mutex.protect(() async => await criticalSection(obj));
+  }
+}

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -806,6 +806,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  mutex:
+    dependency: "direct main"
+    description:
+      name: mutex
+      sha256: "8827da25de792088eb33e572115a5eb0d61d61a3c01acbc8bcbe76ed78f1a1f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   nested:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   intl: ^0.18.0
+  mutex: ^3.1.0
   maplibre_gl:
     git:
       url: https://github.com/maplibre/flutter-maplibre-gl.git


### PR DESCRIPTION
* Use Mutex to ensure that FlutterSecureStorage is only ever used by a single operation at once (I personally believe, that this will not fix the existing issues; it's still a good idea to be certain)
* self_verify_card.dart:
  - I removed some code paths that were unreachable.
  - I added userCodeModel as an attribute so that it outlives the context. (should likely fix https://sentry.tuerantuer.org/organizations/digitalfabrik/issues/4478/)
* UserCodeModel now looks for existing cards by comparing card info AND pepper (as opposed to only card info). This should only be relevant if a card with the exact same information is issued twice (e.g. if the first one was accidentally revoked or did not work or ...)

I could have probably split these into three separate PRs... Let me know if I should do that.

### Testing

- Please test that activation, removal, etc. of cards still works as expected

### Issues

Fixes #1722 