### PR TITLE
1415: Update the error message when user entitlement is expired or revoked

### DIFF
--- a/administration/src/errors/DefaultErrorMap.tsx
+++ b/administration/src/errors/DefaultErrorMap.tsx
@@ -99,7 +99,8 @@ const defaultErrorMap = (extensions?: ErrorExtensions): GraphQLErrorMessage => {
       }
     case GraphQlExceptionCode.UserEntitlementExpired:
       return {
-        title: 'Sie sind nicht mehr berechtigt einen KoblenzPass zu erstellen.',
+        title:
+          'Sie sind nicht länger berechtigt einen KoblenzPass zu erstellen. Bitte kontaktieren Sie koblenzpass@stadt.koblenz.de für weitere Informationen.',
       }
     case GraphQlExceptionCode.MailNotSent:
       return {


### PR DESCRIPTION
### Short description
Updated the error message according to the [design](https://www.figma.com/design/SDoGnXIjCCXpE1tAAJkRVc/entitlementcard?node-id=778-663&t=7BmRX1tjzp8daWp1-1) 

### Side effects
no

### Testing
1. Open administration --> login as a koblenz project admin --> go to settings --> create token
2. Try to import users using curl or Postman
`curl -H "Authorization: Bearer <my_token>" -F file=@import_testdata_local.csv http://0.0.0.0:8000/users/import`

**CSV content:**
```
regionKey,userHash,startDate,endDate,revoked
07111,"$argon2id$v=19$m=19456,t=2,p=1$cr3lP9IMUKNz4BLfPGlAOHq1z98G5/2tTbhDIko35tY",01.01.2024,01.01.2025,true
```

3. Go to http://localhost:3000/ and select Koblenz
4. Go to http://localhost:3000/erstellen, create a card with a birthday 10.06.2003 and a reference number 123K
--> **check the new error message**

### Resolved issues:
Follow up for #1674