### PR TITLE
435: Use build context synchronously.

### DIFF
--- a/frontend/analysis_options.yaml
+++ b/frontend/analysis_options.yaml
@@ -142,6 +142,7 @@ analyzer:
     unnecessary_this: error
     unrelated_type_equality_checks: error
     unsafe_html: error
+    use_build_context_synchronously: error
     use_full_hex_values_for_flutter_colors: error
     use_function_type_syntax_for_parameters: error
     use_named_constants: error
@@ -165,5 +166,4 @@ linter:
     prefer_single_quotes: true
     always_use_package_imports: true
 
-    # TODO: Enable in #435
-    use_build_context_synchronously: false
+    use_build_context_synchronously: true

--- a/frontend/lib/about/backend_switch_dialog.dart
+++ b/frontend/lib/about/backend_switch_dialog.dart
@@ -79,7 +79,9 @@ class BackendSwitchDialogState extends State<BackendSwitchDialog> {
     final updatedEnableStaging = !settings.enableStaging;
     await clearData();
     await settings.setEnableStaging(enabled: updatedEnableStaging);
-    Navigator.of(context, rootNavigator: true).pop();
+    if (context.mounted) {
+      Navigator.of(context, rootNavigator: true).pop();
+    }
   }
 
   Future<void> clearData() async {

--- a/frontend/lib/about/language_change.dart
+++ b/frontend/lib/about/language_change.dart
@@ -8,6 +8,7 @@ Map<String, String> nativeLanguageNames = {'en': 'English', 'de': 'Deutsch'};
 
 class LanguageChange extends StatelessWidget {
   const LanguageChange({super.key});
+
   @override
   Widget build(BuildContext context) {
     return Column(children: [
@@ -31,6 +32,7 @@ class LanguageChange extends StatelessWidget {
     final settings = Provider.of<SettingsModel>(context, listen: false);
     LocaleSettings.setLocaleRaw(language);
     await settings.setLanguage(language: language);
+    if (!context.mounted) return;
     Navigator.pop(context);
     messengerState.showSnackBar(
       SnackBar(

--- a/frontend/lib/activation/deeplink_activation.dart
+++ b/frontend/lib/activation/deeplink_activation.dart
@@ -111,6 +111,7 @@ class _DeepLinkActivationState extends State<DeepLinkActivation> {
                                 });
                                 try {
                                   final activated = await activateCard(context, activationCode);
+                                  if (!context.mounted) return;
                                   if (activated) {
                                     GoRouter.of(context).pushReplacement('$homeRouteName/$identityTabIndex');
                                     setState(() {

--- a/frontend/lib/home/home_page.dart
+++ b/frontend/lib/home/home_page.dart
@@ -93,6 +93,7 @@ class HomePageState extends State<HomePage> {
       floatingActionButton: FloatingActionMapBar(
         bringCameraToUser: (position) async {
           await mapPageController?.bringCameraToUser(position);
+          if (!mounted) return;
           setState(() => followUserLocation = true);
         },
         selectedAcceptingStoreId: selectedAcceptingStoreId,

--- a/frontend/lib/identification/activation_workflow/activation_code_scanner_page.dart
+++ b/frontend/lib/identification/activation_workflow/activation_code_scanner_page.dart
@@ -36,8 +36,11 @@ class ActivationCodeScannerPage extends StatelessWidget {
   }
 
   Future<void> _onCodeScanned(BuildContext context, Uint8List code) async {
-    Future<void> showError(String msg, dynamic stackTrace) async =>
-        [await QrParsingErrorDialog.showErrorDialog(context, msg), await reportError(msg, stackTrace)];
+    Future<void> showError(String msg, dynamic stackTrace) async {
+      reportError(msg, stackTrace);
+      if (!context.mounted) return;
+      await QrParsingErrorDialog.showErrorDialog(context, msg);
+    }
 
     try {
       final activationCode = const ActivationCodeParser().parseQrCodeContent(code);
@@ -51,11 +54,13 @@ class ActivationCodeScannerPage extends StatelessWidget {
     } on QrCodeFieldMissingException catch (e) {
       await showError(t.identification.codeInvalidMissing(missing: e.missingFieldName), null);
     } on QrCodeWrongTypeException catch (_) {
+      if (!context.mounted) return;
       await QrParsingErrorDialog.showErrorDialog(context, t.identification.codeInvalidType);
     } on CardExpiredException catch (e) {
       final expirationDate = DateFormat('dd.MM.yyyy').format(e.expiry);
       await showError(t.identification.codeExpired(expirationDate: expirationDate), null);
     } on ServerCardActivationException catch (_) {
+      if (!context.mounted) return;
       await ConnectionFailedDialog.show(context, t.identification.codeActivationFailedConnection);
     } on Exception catch (e, stacktrace) {
       debugPrintStack(stackTrace: stacktrace, label: e.toString());

--- a/frontend/lib/identification/identification_page.dart
+++ b/frontend/lib/identification/identification_page.dart
@@ -75,7 +75,9 @@ class IdentificationPageState extends State<IdentificationPage> {
 
   Future<void> _showVerificationDialog(
       BuildContext context, SettingsModel settings, UserCodeModel userCodeModel) async {
-    if (await Permission.camera.request().isGranted) {
+    final isGranted = await Permission.camera.request().isGranted;
+    if (!context.mounted) return;
+    if (isGranted) {
       DynamicUserCode? userCode = userCodeModel.userCodes.isNotEmpty ? userCodeModel.userCodes[cardIndex] : null;
       await VerificationWorkflow.startWorkflow(context, settings, userCode);
       return;
@@ -90,7 +92,9 @@ class IdentificationPageState extends State<IdentificationPage> {
   }
 
   Future<void> _startActivation(BuildContext context) async {
-    if (await Permission.camera.request().isGranted) {
+    final isGranted = await Permission.camera.request().isGranted;
+    if (!context.mounted) return;
+    if (isGranted) {
       Navigator.of(context, rootNavigator: true)
           .push(AppRoute(builder: (context) => ActivationCodeScannerPage(moveToLastCard: _moveCarouselToLastPosition)));
       return;

--- a/frontend/lib/identification/qr_code_scanner/qr_code_scanner.dart
+++ b/frontend/lib/identification/qr_code_scanner/qr_code_scanner.dart
@@ -152,11 +152,13 @@ class _QRViewState extends State<QrCodeScanner> {
     try {
       await widget.onCodeScanned(code);
     } finally {
-      setState(() {
-        showWaiting = false;
-      });
-      await Future.delayed(Duration(milliseconds: 500));
-      processingCode = false;
+      if (mounted) {
+        setState(() => showWaiting = false);
+        // Block the processing of further QR codes for a short time so that the user knows that we are back to
+        // the scanning activity.
+        await Future.delayed(Duration(milliseconds: 500));
+        processingCode = false;
+      }
     }
   }
 

--- a/frontend/lib/identification/util/activate_card.dart
+++ b/frontend/lib/identification/util/activate_card.dart
@@ -63,31 +63,36 @@ Future<bool> activateCard(
 
       userCodesModel.insertCode(userCode);
       debugPrint('Card Activation: Successfully activated.');
-      messengerState.showSnackBar(
-        SnackBar(
-          backgroundColor: Theme.of(context).colorScheme.primary,
-          content: Text(t.deeplinkActivation.activationSuccessful),
-        ),
-      );
-      if (Navigator.canPop(context)) Navigator.maybePop(context);
+      if (context.mounted) {
+        messengerState.showSnackBar(
+          SnackBar(
+            backgroundColor: Theme.of(context).colorScheme.primary,
+            content: Text(t.deeplinkActivation.activationSuccessful),
+          ),
+        );
+        if (Navigator.canPop(context)) Navigator.maybePop(context);
+      }
       return true;
     case ActivationState.failed:
-      await QrParsingErrorDialog.showErrorDialog(
-        context,
-        t.identification.codeInvalid,
-      );
+      if (context.mounted) {
+        await QrParsingErrorDialog.showErrorDialog(context, t.identification.codeInvalid);
+      }
       return false;
     case ActivationState.didNotOverwriteExisting:
       if (overwriteExisting) {
         throw const ActivationDidNotOverwriteExisting();
       }
       if (isAlreadyInList(userCodesModel.userCodes, activationCode.info)) {
-        await ActivationExistingCardDialog.showExistingCardDialog(context);
+        if (context.mounted) {
+          await ActivationExistingCardDialog.showExistingCardDialog(context);
+        }
         return false;
       }
       debugPrint(
           'Card Activation: Card had been activated already and was not overwritten. Waiting for user feedback.');
-      if (await ActivationOverwriteExistingDialog.showActivationOverwriteExistingDialog(context)) {
+      if (context.mounted &&
+          await ActivationOverwriteExistingDialog.showActivationOverwriteExistingDialog(context) &&
+          context.mounted) {
         return await activateCard(context, activationCode, overwriteExisting = true);
       } else {
         return false;

--- a/frontend/lib/identification/verification_workflow/dialogs/verification_info_dialog.dart
+++ b/frontend/lib/identification/verification_workflow/dialogs/verification_info_dialog.dart
@@ -38,7 +38,7 @@ class VerificationInfoDialog extends StatelessWidget {
           child: Text(t.identification.stopShowing),
           onPressed: () async {
             await settings.setHideVerificationInfo(enabled: true);
-            _onDone(context);
+            if (context.mounted) _onDone(context);
           },
         ),
         TextButton(

--- a/frontend/lib/identification/verification_workflow/verification_qr_scanner_page.dart
+++ b/frontend/lib/identification/verification_workflow/verification_qr_scanner_page.dart
@@ -1,3 +1,4 @@
+import 'dart:core';
 import 'dart:typed_data';
 
 import 'package:ehrenamtskarte/configuration/configuration.dart';
@@ -22,6 +23,7 @@ import 'package:ehrenamtskarte/l10n/translations.g.dart';
 
 class VerificationQrScannerPage extends StatelessWidget {
   final DynamicUserCode? userCode;
+
   const VerificationQrScannerPage({super.key, this.userCode});
 
   @override
@@ -40,7 +42,7 @@ class VerificationQrScannerPage extends StatelessWidget {
               color: Theme.of(context).appBarTheme.foregroundColor,
               onPressed: () async {
                 await settings.setHideVerificationInfo(enabled: false);
-                await VerificationInfoDialog.show(context);
+                if (context.mounted) await VerificationInfoDialog.show(context);
               },
             )
           ],
@@ -69,69 +71,57 @@ class VerificationQrScannerPage extends StatelessWidget {
   }
 
   Future<void> _handleQrCode(BuildContext context, Uint8List rawQrContent) async {
+    Future<void> onError(String message, [Exception? exception]) async {
+      if (exception != null) {
+        debugPrint('Verification failed: $exception');
+      }
+      if (context.mounted) {
+        await NegativeVerificationResultDialog.show(context, message);
+      }
+    }
+
+    Future<void> onConnectionError(String message, [Exception? exception]) async {
+      if (exception != null) {
+        debugPrint('Connection failed: $exception');
+      }
+      if (context.mounted) {
+        await ConnectionFailedDialog.show(context, message);
+      }
+    }
+
+    Future<void> onSuccess(CardInfo cardInfo, bool isStaticVerificationCode) async {
+      await PositiveVerificationResultDialog.show(
+          context: context, cardInfo: cardInfo, isStaticVerificationCode: isStaticVerificationCode);
+    }
+
     try {
       final qrcode = rawQrContent.parseQRCodeContent();
 
       final cardInfo = await verifyQrCodeContent(context, qrcode);
       if (cardInfo == null) {
-        await _onError(
-          context,
-          t.identification.codeVerificationFailed,
-        );
-      } else {
-        await _onSuccess(context, cardInfo, qrcode.hasStaticVerificationCode());
-        await Navigator.of(context).maybePop();
+        await onError(t.identification.codeVerificationFailed);
+        return;
       }
+      if (!context.mounted) {
+        return;
+      }
+      await onSuccess(cardInfo, qrcode.hasStaticVerificationCode());
+      if (!context.mounted) {
+        return;
+      }
+      await Navigator.of(context).maybePop();
+      return;
     } on ServerVerificationException catch (e) {
-      await _onConnectionError(
-        context,
-        t.identification.codeVerificationFailedConnection,
-        e,
-      );
+      await onConnectionError(t.identification.codeVerificationFailedConnection, e);
     } on QrCodeFieldMissingException catch (e) {
-      await _onError(
-        context,
-        t.identification.codeInvalidMissing(missing: e.missingFieldName),
-        e,
-      );
+      await onError(t.identification.codeInvalidMissing(missing: e.missingFieldName), e);
     } on CardExpiredException catch (e) {
       final expirationDate = DateFormat('dd.MM.yyyy').format(e.expiry);
-      await _onError(
-        context,
-        t.identification.codeExpired(expirationDate: expirationDate),
-        e,
-      );
+      await onError(t.identification.codeExpired(expirationDate: expirationDate), e);
     } on QrCodeParseException catch (e) {
-      await _onError(
-        context,
-        t.identification.codeInvalid,
-        e,
-      );
+      await onError(t.identification.codeInvalid, e);
     } on Exception catch (e) {
-      await _onError(
-        context,
-        t.identification.codeUnknownType,
-        e,
-      );
+      await onError(t.identification.codeUnknownType, e);
     }
-  }
-
-  Future<void> _onError(BuildContext context, String message, [Exception? exception]) async {
-    if (exception != null) {
-      debugPrint('Verification failed: $exception');
-    }
-    await NegativeVerificationResultDialog.show(context, message);
-  }
-
-  Future<void> _onConnectionError(BuildContext context, String message, [Exception? exception]) async {
-    if (exception != null) {
-      debugPrint('Connection failed: $exception');
-    }
-    await ConnectionFailedDialog.show(context, message);
-  }
-
-  Future<void> _onSuccess(BuildContext context, CardInfo cardInfo, bool isStaticVerificationCode) async {
-    await PositiveVerificationResultDialog.show(
-        context: context, cardInfo: cardInfo, isStaticVerificationCode: isStaticVerificationCode);
   }
 }

--- a/frontend/lib/identification/verification_workflow/verification_workflow.dart
+++ b/frontend/lib/identification/verification_workflow/verification_workflow.dart
@@ -15,6 +15,7 @@ class VerificationWorkflow {
     if (settings.hideVerificationInfo != true) {
       // show info dialog and cancel if it is not accepted
       if (await VerificationInfoDialog.show(context) != true) return;
+      if (!context.mounted) return;
     }
 
     // show the QR scanner that will handle the rest

--- a/frontend/lib/intro_slides/location_request_button.dart
+++ b/frontend/lib/intro_slides/location_request_button.dart
@@ -19,23 +19,17 @@ class _LocationRequestButtonState extends State<LocationRequestButton> {
   void initState() {
     super.initState();
 
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      checkAndRequestLocationPermission(context, requestIfNotGranted: false).then(
-        (LocationStatus permission) => setState(() {
-          _locationPermissionStatus = permission;
-        }),
-      );
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) async {
+      final permission = await checkAndRequestLocationPermission(context, requestIfNotGranted: false);
+      if (!mounted) return;
+      setState(() => _locationPermissionStatus = permission);
     });
   }
 
   Future<void> _onLocationButtonClicked(SettingsModel settings) async {
-    final permission = await checkAndRequestLocationPermission(
-      context,
-      requestIfNotGranted: true,
-    );
-    setState(() {
-      _locationPermissionStatus = permission;
-    });
+    final permission = await checkAndRequestLocationPermission(context, requestIfNotGranted: true);
+    if (!mounted) return;
+    setState(() => _locationPermissionStatus = permission);
   }
 
   @override

--- a/frontend/lib/location/determine_position.dart
+++ b/frontend/lib/location/determine_position.dart
@@ -108,7 +108,7 @@ Future<LocationStatus> checkAndRequestLocationPermission(
       ? await isNonGoogleLocationServiceEnabled()
       : await Geolocator.isLocationServiceEnabled();
   if (!serviceEnabled) {
-    if (requestIfNotGranted) {
+    if (requestIfNotGranted && context.mounted) {
       final bool? result =
           await showDialog<bool>(context: context, builder: (context) => const LocationServiceDialog());
       if (result == true) {
@@ -135,15 +135,17 @@ Future<LocationStatus> checkAndRequestLocationPermission(
         // returned true. According to Android guidelines
         // your App should show an explanatory UI now.
 
-        final result = await showDialog(
-            context: context,
-            builder: (context) => RationaleDialog(rationale: t.location.activateLocationAccessRationale));
+        if (context.mounted) {
+          final result = await showDialog(
+              context: context,
+              builder: (context) => RationaleDialog(rationale: t.location.activateLocationAccessRationale));
 
-        if (result == true) {
-          return checkAndRequestLocationPermission(
-            context,
-            requestIfNotGranted: requestIfNotGranted,
-          );
+          if (result == true && context.mounted) {
+            return checkAndRequestLocationPermission(
+              context,
+              requestIfNotGranted: requestIfNotGranted,
+            );
+          }
         }
 
         return LocationPermission.denied.toLocationStatus();

--- a/frontend/lib/map/location_button.dart
+++ b/frontend/lib/map/location_button.dart
@@ -81,7 +81,7 @@ class _LocationButtonState extends State<LocationButton> {
     );
   }
 
-  Future<void> _showFeatureDisabled() async {
+  void _showFeatureDisabled() {
     final messengerState = ScaffoldMessenger.of(context);
     final t = context.t;
     messengerState.showSnackBar(
@@ -101,11 +101,14 @@ class _LocationButtonState extends State<LocationButton> {
   Future<void> _determinePosition() async {
     setState(() => _locationStatus = null);
     final requestedPosition = await determinePosition(context, requestIfNotGranted: true);
+    if (!mounted) return;
+
     if (requestedPosition.locationStatus == LocationStatus.deniedForever) {
-      await _showFeatureDisabled();
+      _showFeatureDisabled();
     }
 
     await widget.bringCameraToUser(requestedPosition);
+    if (!mounted) return;
 
     setState(() => _locationStatus = requestedPosition.locationStatus);
   }

--- a/frontend/lib/map/map/map.dart
+++ b/frontend/lib/map/map/map.dart
@@ -125,9 +125,10 @@ class _MapContainerState extends State<MapContainer> implements MapController {
   }
 
   void _onMapCreated(MaplibreMapController controller) {
-    _controller = controller;
+    if (!mounted) return;
 
     setState(() {
+      _controller = controller;
       _isMapInitialized = true;
     });
 
@@ -163,6 +164,7 @@ class _MapContainerState extends State<MapContainer> implements MapController {
       return;
     }
     final targetLatLng = await controller.toLatLng(point);
+    if (!mounted) return;
 
     final onFeatureClick = widget.onFeatureClick;
     final onNoFeatureClick = widget.onNoFeatureClick;
@@ -252,8 +254,10 @@ class _MapContainerState extends State<MapContainer> implements MapController {
       ),
     );
     await controller.animateCamera(cameraUpdate);
+    if (!mounted) return;
 
     await controller.updateMyLocationTrackingMode(MyLocationTrackingMode.Tracking);
+    if (!mounted) return;
     if (!_permissionGiven) {
       setState(() => _permissionGiven = true);
     }

--- a/frontend/lib/search/results_loader.dart
+++ b/frontend/lib/search/results_loader.dart
@@ -71,6 +71,8 @@ class ResultsLoaderState extends State<ResultsLoader> {
       }
 
       final result = await client.query(QueryOptions(document: query.document, variables: query.getVariablesMap()));
+      if (!mounted) return;
+
       final exception = result.exception;
       if (result.hasException && exception != null) {
         throw exception;
@@ -91,16 +93,15 @@ class ResultsLoaderState extends State<ResultsLoader> {
 
       final newItems = query.parse(newData).searchAcceptingStoresInProject;
 
-      if (mounted) {
-        final isLastPage = newItems.length < _pageSize;
-        if (isLastPage) {
-          _pagingController.appendLastPage(newItems);
-        } else {
-          final nextPageKey = pageKey + newItems.length;
-          _pagingController.appendPage(newItems, nextPageKey);
-        }
+      final isLastPage = newItems.length < _pageSize;
+      if (isLastPage) {
+        _pagingController.appendLastPage(newItems);
+      } else {
+        final nextPageKey = pageKey + newItems.length;
+        _pagingController.appendPage(newItems, nextPageKey);
       }
     } on Exception catch (error) {
+      if (!mounted) return;
       if (widget != oldWidget) {
         // Params are outdated.
         // If we're still at the first key, we must manually retrigger fetching.
@@ -108,9 +109,7 @@ class ResultsLoaderState extends State<ResultsLoader> {
           return await _fetchPage(pageKey);
         }
       }
-      if (mounted) {
-        _pagingController.error = error;
-      }
+      _pagingController.error = error;
     }
   }
 

--- a/frontend/lib/search/sorting_button.dart
+++ b/frontend/lib/search/sorting_button.dart
@@ -58,7 +58,7 @@ class _SortingButtonState extends State<SortingButton> {
     }
   }
 
-  Future<void> _showFeatureDisabled() async {
+  void _showFeatureDisabled() {
     final messengerState = ScaffoldMessenger.of(context);
     final t = context.t;
     messengerState.showSnackBar(
@@ -85,16 +85,20 @@ class _SortingButtonState extends State<SortingButton> {
 
   Future<void> _determinePosition(bool userInteract) async {
     setState(() => _locationStatus = LocationRequestStatus.requesting);
-    final requiredPosition = userInteract
-        ? await determinePosition(context, requestIfNotGranted: true)
-        : await determinePosition(context, requestIfNotGranted: false)
-            .timeout(const Duration(milliseconds: 2000), onTimeout: () => RequestedPosition.unknown());
+    final RequestedPosition requestedPosition;
+    if (userInteract) {
+      requestedPosition = await determinePosition(context, requestIfNotGranted: true);
+    } else {
+      requestedPosition = await determinePosition(context, requestIfNotGranted: false)
+          .timeout(const Duration(milliseconds: 2000), onTimeout: () => RequestedPosition.unknown());
+    }
+    if (!mounted) return;
 
-    if (userInteract && requiredPosition.locationStatus == LocationStatus.deniedForever) {
-      await _showFeatureDisabled();
+    if (userInteract && requestedPosition.locationStatus == LocationStatus.deniedForever) {
+      _showFeatureDisabled();
     }
 
-    final position = requiredPosition.position;
+    final position = requestedPosition.position;
     if (position != null) {
       widget.setCoordinates(position);
       setState(() => _locationStatus = LocationRequestStatus.requestSuccessful);

--- a/frontend/lib/store_widgets/detail/detail_app_bar.dart
+++ b/frontend/lib/store_widgets/detail/detail_app_bar.dart
@@ -150,13 +150,16 @@ class DetailAppBar extends StatelessWidget {
     try {
       if (model.isFavorite(storeId)) {
         await model.removeFavorite(storeId);
+        if (!context.mounted) return;
         showSnackBar(context, t.favorites.favoriteHasBeenRemoved, categoryColor);
       } else {
         await model.saveFavorite(FavoriteStore(storeId, storeName, categoryId));
+        if (!context.mounted) return;
         showSnackBar(context, t.favorites.favoriteHasBeenAdded, categoryColor);
       }
     } catch (error) {
       log('Failed to update favorites', error: error);
+      if (!context.mounted) return;
       showSnackBar(context, t.favorites.updateFailed, errorColor);
     }
   }

--- a/frontend/lib/store_widgets/removed_store_content.dart
+++ b/frontend/lib/store_widgets/removed_store_content.dart
@@ -1,5 +1,4 @@
-import 'dart:developer';
-
+import 'package:ehrenamtskarte/sentry.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -52,10 +51,12 @@ class RemovedStoreContent extends StatelessWidget {
   Future<void> _removeFavorite(BuildContext context, FavoritesModel model) async {
     try {
       await model.removeFavorite(storeId);
+      if (!context.mounted) return;
       showSnackBar(context, t.favorites.favoriteHasBeenRemoved);
       Navigator.of(context).maybePop();
-    } catch (error) {
-      log('Failed to update favorites', error: error);
+    } catch (error, stackTrace) {
+      reportError(error, stackTrace);
+      if (!context.mounted) return;
       showSnackBar(context, t.favorites.updateFailed, Theme.of(context).colorScheme.error);
     }
   }


### PR DESCRIPTION
### Short description

Enable the linting rule ["use_build_context_synchronously"](https://dart.dev/tools/linter-rules/use_build_context_synchronously) and fix errors in our code.

### Proposed changes

This PR sprinkles the codebase with some `mounted`  guards that check whether the widget is still mounted and the BuildContext can still be used, e.g. for displaying a dialog, etc.

### Notes

I noticed that the linting rule is not perfect, ie. it has both false positives and false negatives. However, as we have had some error reports due to incorrect usage of context, I think it's still a good idea to activate it.

### Testing

* Sorting by location in map & search
* Card Activation & verification
* Deeplink card activation

### Resolved issues

Fixes: #435, #1725, #1726, #1729, #1730, #1731, #1732, #1733, #1734, #1735