### PR TITLE
1283: Fix physical store by store loader

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/PhysicalStoreByStoreIdLoader.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/dataloader/PhysicalStoreByStoreIdLoader.kt
@@ -11,7 +11,7 @@ import org.jetbrains.exposed.sql.transactions.transaction
 val physicalStoreByStoreIdLoader = newNamedDataLoader<Int, _>("PHYSICAL_STORE_BY_STORE_ID_LOADER") { ids ->
     transaction {
         PhysicalStoreEntity.find { PhysicalStores.storeId inList ids }
-            .sortByKeys({ it.storeId }, ids)
+            .sortByKeys({ it.storeId.value }, ids)
             .map {
                 it?.let {
                     PhysicalStore(


### PR DESCRIPTION
### Short description

The `searchAcceptingStoresInProject` query never returns physical stores.
Therefore, the functionality to show the distance (or location) of an accepting store, that is already implemented in Flutter in the search page, never worked (or rather stopped working at some point).

### Proposed changes

Fix the data loader responsible for querying the physical store given a store.

### Side effects

The functionality will kick in once the backend is deployed without needing to release the app again.

### Testing

Check out the search page.

### Resolved issues

Fixes: #1283 
