### PR TITLE
1670: Show form hints

### DIFF
--- a/administration/src/bp-modules/self-service/CardSelfServiceForm.tsx
+++ b/administration/src/bp-modules/self-service/CardSelfServiceForm.tsx
@@ -1,15 +1,18 @@
 import { Checkbox, FormGroup, InputGroup, Intent } from '@blueprintjs/core'
 import InfoOutlined from '@mui/icons-material/InfoOutlined'
-import { Alert, styled } from '@mui/material'
+import { styled } from '@mui/material'
 import React, { ReactElement, useContext, useState } from 'react'
 
-import { Card, isFullNameValid, isValid } from '../../cards/Card'
+import { Card, getFullNameValidationErrorMessage, isFullNameValid, isValid } from '../../cards/Card'
 import ClearInputButton from '../../cards/extensions/components/ClearInputButton'
 import useWindowDimensions from '../../hooks/useWindowDimensions'
 import BasicDialog from '../../mui-modules/application/BasicDialog'
 import { ProjectConfigContext } from '../../project-configs/ProjectConfigContext'
+import { useAppToaster } from '../AppToaster'
 import ExtensionForms from '../cards/ExtensionForms'
+import { DataPrivacyAcceptingStatus } from './CardSelfServiceView'
 import { ActionButton } from './components/ActionButton'
+import FormErrorMessage from './components/FormErrorMessage'
 import { IconTextButton } from './components/IconTextButton'
 import { UnderlineTextButton } from './components/UnderlineTextButton'
 
@@ -19,11 +22,6 @@ const StyledCheckbox = styled(Checkbox)`
   margin-left: 4px;
 `
 
-const StyledAlert = styled(Alert)`
-  margin-bottom: 24px;
-  white-space: pre-line;
-`
-
 const Container = styled('div')`
   margin-bottom: 24px;
 `
@@ -31,22 +29,11 @@ const Container = styled('div')`
 type CardSelfServiceFormProps = {
   card: Card
   updateCard: (card: Partial<Card>) => void
-  dataPrivacyAccepted: boolean
-  setDataPrivacyAccepted: (value: boolean) => void
+  dataPrivacyAccepted: DataPrivacyAcceptingStatus
+  setDataPrivacyAccepted: (status: DataPrivacyAcceptingStatus) => void
   generateCards: () => Promise<void>
 }
 
-const getTooltipMessage = (cardsValid: boolean, dataPrivacyAccepted: boolean): string => {
-  const tooltipMessages: string[] = []
-  if (!cardsValid) {
-    tooltipMessages.push('Mindestens eine Ihrer Angaben ist ungültig.')
-  }
-  if (!dataPrivacyAccepted) {
-    tooltipMessages.push('Bitte akzeptieren Sie die Datenschutzerklärung.')
-  }
-
-  return tooltipMessages.join('\n')
-}
 const CardSelfServiceForm = ({
   card,
   updateCard,
@@ -59,7 +46,24 @@ const CardSelfServiceForm = ({
   const [openDataPrivacy, setOpenDataPrivacy] = useState<boolean>(false)
   const [openReferenceInformation, setOpenReferenceInformation] = useState<boolean>(false)
   const cardValid = isValid(card, { expirationDateNullable: true })
-  const cardCreationDisabled = !cardValid || !dataPrivacyAccepted
+  const appToaster = useAppToaster()
+
+  const createKoblenzPass = async () => {
+    if (dataPrivacyAccepted === DataPrivacyAcceptingStatus.untouched) {
+      setDataPrivacyAccepted(DataPrivacyAcceptingStatus.denied)
+    }
+    if (!cardValid || dataPrivacyAccepted !== DataPrivacyAcceptingStatus.accepted) {
+      appToaster?.show({
+        message: (
+          <FormErrorMessage style={{ color: 'white' }} errorMessage='Mindestens eine Ihrer Angaben ist ungültig.' />
+        ),
+        timeout: 0,
+        intent: 'danger',
+      })
+      return
+    }
+    await generateCards()
+  }
 
   return (
     <>
@@ -80,23 +84,30 @@ const CardSelfServiceForm = ({
             value={card.fullName}
             onChange={event => updateCard({ fullName: event.target.value })}
           />
+          <FormErrorMessage errorMessage={getFullNameValidationErrorMessage(card.fullName)} />
         </FormGroup>
         <ExtensionForms card={card} updateCard={updateCard} />
         <IconTextButton onClick={() => setOpenReferenceInformation(true)}>
           <InfoOutlined />
           Informationen zur Referenznummer
         </IconTextButton>
-        <StyledCheckbox checked={dataPrivacyAccepted} onChange={() => setDataPrivacyAccepted(!dataPrivacyAccepted)}>
+        <StyledCheckbox
+          checked={dataPrivacyAccepted === DataPrivacyAcceptingStatus.accepted}
+          onChange={() =>
+            setDataPrivacyAccepted(
+              dataPrivacyAccepted === DataPrivacyAcceptingStatus.accepted
+                ? DataPrivacyAcceptingStatus.denied
+                : DataPrivacyAcceptingStatus.accepted
+            )
+          }>
           Ich akzeptiere die{' '}
           <UnderlineTextButton onClick={() => setOpenDataPrivacy(true)}>Datenschutzerklärung</UnderlineTextButton>.
         </StyledCheckbox>
+        {dataPrivacyAccepted === DataPrivacyAcceptingStatus.denied && (
+          <FormErrorMessage errorMessage='Bitte akzeptieren sie die Datenschutzerklärung' />
+        )}
       </Container>
-      {cardCreationDisabled && (
-        <StyledAlert variant='outlined' severity='warning'>
-          {getTooltipMessage(cardValid, dataPrivacyAccepted)}
-        </StyledAlert>
-      )}
-      <ActionButton onClick={generateCards} variant='contained' disabled={cardCreationDisabled} size='large'>
+      <ActionButton onClick={createKoblenzPass} variant='contained' size='large'>
         Pass erstellen
       </ActionButton>
       <BasicDialog

--- a/administration/src/bp-modules/self-service/CardSelfServiceView.tsx
+++ b/administration/src/bp-modules/self-service/CardSelfServiceView.tsx
@@ -70,10 +70,18 @@ const HeaderLogo = styled.img`
   height: 40px;
 `
 
+export enum DataPrivacyAcceptingStatus {
+  untouched,
+  accepted,
+  denied,
+}
+
 // TODO 1646 Add tests for CardSelfService
 const CardSelfServiceView = (): ReactElement => {
   const projectConfig = useContext(ProjectConfigContext)
-  const [dataPrivacyAccepted, setDataPrivacyAccepted] = useState<boolean>(false)
+  const [dataPrivacyCheckbox, setDataPrivacyCheckbox] = useState<DataPrivacyAcceptingStatus>(
+    DataPrivacyAcceptingStatus.untouched
+  )
   const {
     selfServiceState,
     setSelfServiceState,
@@ -113,8 +121,8 @@ const CardSelfServiceView = (): ReactElement => {
         {selfServiceState === CardSelfServiceStep.form && (
           <CardSelfServiceForm
             card={selfServiceCard}
-            dataPrivacyAccepted={dataPrivacyAccepted}
-            setDataPrivacyAccepted={setDataPrivacyAccepted}
+            dataPrivacyAccepted={dataPrivacyCheckbox}
+            setDataPrivacyAccepted={setDataPrivacyCheckbox}
             updateCard={updatedCard => setSelfServiceCard(updateCard(selfServiceCard, updatedCard))}
             generateCards={generateCards}
           />

--- a/administration/src/bp-modules/self-service/components/FormErrorMessage.tsx
+++ b/administration/src/bp-modules/self-service/components/FormErrorMessage.tsx
@@ -1,0 +1,31 @@
+import InfoOutlined from '@mui/icons-material/InfoOutlined'
+import { styled } from '@mui/material'
+import React, { CSSProperties, ReactElement } from 'react'
+
+const Container = styled('div')`
+  margin: 6px 0;
+  color: #ba1a1a;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 14px;
+`
+
+type FormErrorMessageProps = {
+  errorMessage: string | null
+  style?: CSSProperties
+}
+
+const FormErrorMessage = ({ errorMessage, style }: FormErrorMessageProps): ReactElement | null => {
+  if (!errorMessage) {
+    return null
+  }
+  return (
+    <Container style={style}>
+      <InfoOutlined />
+      {errorMessage}
+    </Container>
+  )
+}
+
+export default FormErrorMessage

--- a/administration/src/bp-modules/self-service/hooks/useCardGeneratorSelfService.tsx
+++ b/administration/src/bp-modules/self-service/hooks/useCardGeneratorSelfService.tsx
@@ -1,5 +1,5 @@
 import { ApolloError } from '@apollo/client'
-import { useCallback, useContext, useState } from 'react'
+import React, { useCallback, useContext, useState } from 'react'
 
 import { Card, generateCardInfo, initializeCard } from '../../../cards/Card'
 import { generatePdf } from '../../../cards/PdfFactory'
@@ -12,6 +12,7 @@ import { base64ToUint8Array, uint8ArrayToBase64 } from '../../../util/base64'
 import downloadDataUri from '../../../util/downloadDataUri'
 import getCustomDeepLinkFromQrCode from '../../../util/getCustomDeepLinkFromQrCode'
 import { useAppToaster } from '../../AppToaster'
+import FormErrorMessage from '../components/FormErrorMessage'
 
 export enum CardSelfServiceStep {
   form,
@@ -54,9 +55,9 @@ const useCardGeneratorSelfService = (): UseCardGeneratorSelfServiceReturn => {
       if (error instanceof ApolloError) {
         const { title } = getMessageFromApolloError(error)
         appToaster?.show({
-          message: title,
-          intent: 'danger',
+          message: <FormErrorMessage style={{ color: 'white' }} errorMessage={title} />,
           timeout: 0,
+          intent: 'danger',
         })
       } else {
         appToaster?.show({

--- a/administration/src/cards/Card.test.ts
+++ b/administration/src/cards/Card.test.ts
@@ -2,6 +2,7 @@ import { BavariaCardType } from '../generated/card_pb'
 import { Region } from '../generated/graphql'
 import PlainDate from '../util/PlainDate'
 import {
+  MAX_NAME_LENGTH,
   generateCardInfo,
   getValueByCSVHeader,
   initializeCard,
@@ -137,6 +138,28 @@ describe('Card', () => {
       expect(isValueValid(card, cardConfig, 'Kartentyp')).toBeFalsy()
       expect(isValid(card)).toBeFalsy()
     })
+  })
+
+  it.each(['$tefan Mayer', 'Karla K.', 'Karla 1234 '])(
+    'should correctly identify invalid special characters in fullname',
+    fullName => {
+      const card = initializeCard(cardConfig, region, { fullName })
+      expect(card.fullName).toBe(fullName)
+      expect(isValueValid(card, cardConfig, 'Name')).toBeFalsy()
+      expect(isValid(card)).toBeFalsy()
+    }
+  )
+
+  it.each(['Karla', 'Karl L'])('should correctly identify invalid fullname that is incomplete', fullName => {
+    const card = initializeCard(cardConfig, region, { fullName })
+    expect(isValueValid(card, cardConfig, 'Name')).toBeFalsy()
+    expect(isValid(card)).toBeFalsy()
+  })
+
+  it(`should correctly identify invalid fullname that exceeds max length (${MAX_NAME_LENGTH} characters)`, () => {
+    const card = initializeCard(cardConfig, region, { fullName: 'Karl LauterLauterLauterLauterLauterLauterLauterbach' })
+    expect(isValueValid(card, cardConfig, 'Name')).toBeFalsy()
+    expect(isValid(card)).toBeFalsy()
   })
 
   describe('self service', () => {

--- a/administration/src/cards/extensions/KoblenzReferenceNumberExtension.tsx
+++ b/administration/src/cards/extensions/KoblenzReferenceNumberExtension.tsx
@@ -1,6 +1,7 @@
 import { FormGroup, InputGroup, Intent } from '@blueprintjs/core'
 import React, { ReactElement } from 'react'
 
+import FormErrorMessage from '../../bp-modules/self-service/components/FormErrorMessage'
 import useWindowDimensions from '../../hooks/useWindowDimensions'
 import ClearInputButton from './components/ClearInputButton'
 import { Extension, ExtensionComponentProps } from './extensions'
@@ -11,6 +12,9 @@ type KoblenzReferenceNumberExtensionState = { [KOBLENZ_REFERENCE_NUMBER_EXTENSIO
 
 const KoblenzReferenceNumberMinLength = 4
 const KoblenzReferenceNumberMaxLength = 15
+const hasSpecialChars = (referenceNr: string): boolean => /[`!@#$%^&*()_+\-=\]{};':"\\|,<>?~]/.test(referenceNr)
+const hasInvalidLength = (referenceNumberLength: number): boolean =>
+  referenceNumberLength < KoblenzReferenceNumberMinLength || referenceNumberLength > KoblenzReferenceNumberMaxLength
 
 const KoblenzReferenceNumberExtensionForm = ({
   value,
@@ -19,6 +23,16 @@ const KoblenzReferenceNumberExtensionForm = ({
 }: ExtensionComponentProps<KoblenzReferenceNumberExtensionState>): ReactElement => {
   const { viewportSmall } = useWindowDimensions()
   const clearInput = () => setValue({ koblenzReferenceNumber: '' })
+
+  const getErrorMessage = (): string | null => {
+    if (hasSpecialChars(value.koblenzReferenceNumber)) {
+      return 'Das Aktenzeichen enthält ungültige Sonderzeichen.'
+    }
+    if (hasInvalidLength(value.koblenzReferenceNumber.length)) {
+      return `Das Aktenzeichen muss eine Länge zwischen ${KoblenzReferenceNumberMinLength} und ${KoblenzReferenceNumberMaxLength} haben.`
+    }
+    return null
+  }
 
   return (
     <FormGroup
@@ -32,18 +46,12 @@ const KoblenzReferenceNumberExtensionForm = ({
         placeholder='5.012.067.281, 000D000001, 99478'
         intent={isValid ? undefined : Intent.DANGER}
         value={value.koblenzReferenceNumber}
-        minLength={KoblenzReferenceNumberMinLength}
-        maxLength={KoblenzReferenceNumberMaxLength}
         rightElement={
           <ClearInputButton viewportSmall={viewportSmall} onClick={clearInput} input={value.koblenzReferenceNumber} />
         }
-        onChange={event => {
-          const value = event.target.value
-          if (value.length <= KoblenzReferenceNumberMaxLength) {
-            setValue({ koblenzReferenceNumber: value })
-          }
-        }}
+        onChange={event => setValue({ koblenzReferenceNumber: event.target.value })}
       />
+      <FormErrorMessage errorMessage={getErrorMessage()} />
     </FormGroup>
   )
 }

--- a/administration/src/errors/DefaultErrorMap.tsx
+++ b/administration/src/errors/DefaultErrorMap.tsx
@@ -99,7 +99,8 @@ const defaultErrorMap = (extensions?: ErrorExtensions): GraphQLErrorMessage => {
       }
     case GraphQlExceptionCode.UserEntitlementExpired:
       return {
-        title: 'Sie sind nicht mehr berechtigt einen KoblenzPass zu erstellen.',
+        title:
+          'Sie sind nicht länger berechtigt, einen KoblenzPass zu erstellen. Bitte kontaktieren Sie koblenzpass@stadt.koblenz.de für weitere Informationen.',
       }
     case GraphQlExceptionCode.MailNotSent:
       return {


### PR DESCRIPTION
### Short description

Show error messages/hints to the user for the self service form

### Proposed changes

<!-- Describe this PR in more detail. -->

- add error messages and validation for name input field (should this also apply to other projects? I think it makes sense)
- add validation to koblenz reference number
- adjust error messages
- add error message and untouched state to data privacy acceptance
- increase name length to 40

### not included
- error handling for Birthday extensions since not all requirements are clarified and the final implementation of the form field is not done yet (https://github.com/digitalfabrik/entitlementcard/issues/1672) 
- final text adjustments

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. Name field: Test special characters, name length and name includes 2 strings with at least 2chars. The particular error message should be displayed
2. Check that the reference number does not include special chars except of "." Check the min(4) and max length (15). The particular error message should be displayed
3. Check the data privacy accepting field: now it has a untouched state and if unchecked there should be an error message display
4. Check that the card creation button is not disabled but clicking on it with some invalid fields will lead to proper error message
5. Check the adjusted error message if you want to create a card for a revoked entitlement user


### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
