### PR TITLE
Fix number of licenses

### DIFF
--- a/frontend/assets/l10n/app_de.json
+++ b/frontend/assets/l10n/app_de.json
@@ -13,7 +13,7 @@
     "moreInformation": "Mehr Informationen",
     "numberLicenses": {
       "one": "1 Lizenz",
-      "other": "$n Lizenzen",
+      "other": "{{n}} Lizenzen",
       "zero": "Keine Lizenzen"
     },
     "privacyPolicy": "Datenschutzerklärung",

--- a/frontend/assets/l10n/app_en.json
+++ b/frontend/assets/l10n/app_en.json
@@ -13,7 +13,7 @@
     "moreInformation": "More information",
     "numberLicenses": {
       "one": "1 license",
-      "other": "$n licenses",
+      "other": "{{n}} licenses",
       "zero": "No licenses"
     },
     "privacyPolicy": "Privacy policy",


### PR DESCRIPTION
### Short description

The interpolation of the number of licenses is currently broken.

### Proposed changes

Fix it by using the correct interpolation syntax.

### Side effects

None

### Testing

Open the licenses page
