### PR TITLE
Remove normalize-strings dependency

### DIFF
--- a/administration/package.json
+++ b/administration/package.json
@@ -28,7 +28,6 @@
     "date-fns": "^2.30.0",
     "graphql": "^16.8.1",
     "localforage": "^1.10.0",
-    "normalize-strings": "^1.1.1",
     "normalize.css": "^8.0.1",
     "notistack": "^3.0.1",
     "pdf-lib": "^1.17.1",

--- a/administration/src/util/__tests__/normalizeString.test.ts
+++ b/administration/src/util/__tests__/normalizeString.test.ts
@@ -4,6 +4,7 @@ describe('normalizeString', () => {
   it('should normalize search string', () => {
     expect(normalizeString('Donauwörth')).toBe('donauworth')
     expect(normalizeString('äöUEJJ')).toBe('aouejj')
+    expect(normalizeString('äöUEJJß')).toBe('aouejj')
   })
 
   it('should trim whitespaces', () => {

--- a/administration/src/util/normalizeString.ts
+++ b/administration/src/util/normalizeString.ts
@@ -1,6 +1,11 @@
-import normalizeStrings from 'normalize-strings'
+// eslint-disable-next-line no-control-regex
+const nonAsciiRegex = /[^\x00-\x7F]/g
 
-const normalizeString = (str: string): string => normalizeStrings(str).toLowerCase().trim()
-export const normalizeName = (name: string): string => normalizeString(name).replaceAll(/[^a-zA-Z0-9]/g, '')
+const normalizeToAscii = (str: string): string => str.normalize('NFKD').replace(nonAsciiRegex, '')
+
+const normalizeString = (str: string): string => normalizeToAscii(str).toLowerCase().trim()
+
+const disallowedCharsInNameRegex = /[^a-zA-Z0-9]/g
+export const normalizeName = (name: string): string => normalizeString(name).replace(disallowedCharsInNameRegex, '')
 
 export default normalizeString

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "date-fns": "^2.30.0",
         "graphql": "^16.8.1",
         "localforage": "^1.10.0",
-        "normalize-strings": "^1.1.1",
         "normalize.css": "^8.0.1",
         "notistack": "^3.0.1",
         "pdf-lib": "^1.17.1",
@@ -18944,12 +18943,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/normalize-strings": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-strings/-/normalize-strings-1.1.1.tgz",
-      "integrity": "sha512-fARPRdTwmrQDLYhmeh7j/eZwrCP6WzxD6uKOdK/hT/uKACAE9AG2Bc2dgqOZLkfmmctHpfcJ9w3AQnfLgg3GYg==",
-      "license": "MIT"
     },
     "node_modules/normalize.css": {
       "version": "8.0.1",


### PR DESCRIPTION
### Short description

Remove normalize-strings dependency.

Very similar functionality can be achieved by using `String.normalize` ([caniuse.com](https://caniuse.com/?search=String.normalize)) without this dependency.

### Side effects

Possibly slightly different outcomes of `normalizeName` and `normalizeString`. However, it's only used for comparing two names, so it should not be critical.

### Testing

For enthuastic testers: test the organization form in the application form.
