### PR TITLE
1792: Application url depends environment

### DIFF
--- a/frontend/build-configs/bayern/index.ts
+++ b/frontend/build-configs/bayern/index.ts
@@ -1,4 +1,8 @@
-import { ACTIVATION_PATH, BAYERN_PRODUCTION_ID, BAYERN_STAGING_ID } from "../constants"
+import {
+    ACTIVATION_PATH,
+    BAYERN_PRODUCTION_ID,
+    BAYERN_STAGING_ID,
+} from '../constants'
 import BuildConfigType, { CommonBuildConfigType } from "../types"
 import disclaimerText from "./disclaimerText"
 import publisherText from "./publisherText"
@@ -72,7 +76,11 @@ export const bayernCommon: CommonBuildConfigType = {
         verification: true,
         favorites: false,
     },
-    applicationUrl: "https://bayern.ehrenamtskarte.app/beantragen",
+    applicationUrl: {
+        production: `https://${BAYERN_PRODUCTION_ID}/beantragen`,
+        staging: `https://${BAYERN_STAGING_ID}/beantragen`,
+        local : 'http://localhost:3000/beantragen'
+    },
     dataPrivacyPolicyUrl: "https://bayern.ehrenamtskarte.app/data-privacy-policy",
     publisherAddress:
         "Bayerisches Staatsministerium\nfür Familie, Arbeit und Soziales\nWinzererstraße 9\n80797 München",

--- a/frontend/build-configs/koblenz/index.ts
+++ b/frontend/build-configs/koblenz/index.ts
@@ -73,7 +73,11 @@ export const koblenzCommon: CommonBuildConfigType = {
         verification: true,
         favorites: false,
     },
-    applicationUrl: "https://koblenz.sozialpass.app/erstellen",
+    applicationUrl: {
+       production: `https://${KOBLENZ_PRODUCTION_ID}/erstellen`,
+        staging: `https://${KOBLENZ_STAGING_ID}/erstellen`,
+        local : 'http://localhost:3000/erstellen'
+    },
     dataPrivacyPolicyUrl: "https://koblenz.sozialpass.app/data-privacy-policy",
     publisherAddress: "Stadt Koblenz\nWilli-Hörter-Platz 1\n56068 Koblenz",
     publisherText,

--- a/frontend/build-configs/nuernberg/index.ts
+++ b/frontend/build-configs/nuernberg/index.ts
@@ -1,4 +1,8 @@
-import { ACTIVATION_PATH, NUERNBERG_PRODUCTION_ID, NUERNBERG_STAGING_ID } from "../constants"
+import {
+    ACTIVATION_PATH,
+    NUERNBERG_PRODUCTION_ID,
+    NUERNBERG_STAGING_ID
+} from '../constants'
 import BuildConfigType, { CommonBuildConfigType } from "../types"
 import disclaimerText from "./disclaimerText"
 import publisherText from "./publisherText"
@@ -72,7 +76,11 @@ export const nuernbergCommon: CommonBuildConfigType = {
         verification: true,
         favorites: false,
     },
-    applicationUrl: "https://beantragen.nuernberg.sozialpass.app",
+    applicationUrl: {
+        production: 'https://beantragen.nuernberg.sozialpass.app',
+        staging: 'https://beantragen.nuernberg.sozialpass.app',
+        local : 'https://beantragen.nuernberg.sozialpass.app'
+    },
     publisherAddress:
         "Stadt Nürnberg\nAmt für Existenzsicherung\nund soziale Integration - Sozialamt\nDietzstraße 4\n90443 Nürnberg",
     dataPrivacyPolicyUrl: "https://nuernberg.sozialpass.app/data-privacy-policy",

--- a/frontend/build-configs/types.ts
+++ b/frontend/build-configs/types.ts
@@ -94,7 +94,11 @@ export type CommonBuildConfigType = {
     theme: ThemeType
     categories: number[]
     featureFlags: FeatureFlagsType
-    applicationUrl: string
+    applicationUrl: {
+        staging: string
+        production: string
+        local: string
+    }
     dataPrivacyPolicyUrl: string
     publisherAddress: string
     publisherText: string

--- a/frontend/lib/identification/identification_page.dart
+++ b/frontend/lib/identification/identification_page.dart
@@ -1,5 +1,6 @@
 import 'package:carousel_slider/carousel_controller.dart';
 import 'package:ehrenamtskarte/build_config/build_config.dart' show buildConfig;
+import 'package:ehrenamtskarte/configuration/definitions.dart';
 import 'package:ehrenamtskarte/configuration/settings_model.dart';
 import 'package:ehrenamtskarte/identification/activation_workflow/activation_code_scanner_page.dart';
 import 'package:ehrenamtskarte/identification/card_detail_view/card_carousel.dart';
@@ -103,8 +104,14 @@ class IdentificationPageState extends State<IdentificationPage> {
   }
 
   Future<bool> _startApplication() {
+    final isStagingEnabled = Provider.of<SettingsModel>(context, listen: false).enableStaging;
+    final applicationUrl = isStagingEnabled
+        ? buildConfig.applicationUrl.staging
+        : isProduction()
+            ? buildConfig.applicationUrl.production
+            : buildConfig.applicationUrl.local;
     return launchUrlString(
-      buildConfig.applicationUrl,
+      applicationUrl,
       mode: LaunchMode.externalApplication,
     );
   }


### PR DESCRIPTION
### Short description

Currently we use one particular applicationUrl (Pass beantragen) for the app. For better testing on staging and local we should provide this depending on environment.

### Proposed changes

<!-- Describe this PR in more detail. -->

- add different applicationUrls
- open application process depending environment

### Testing

1. Open "Beantragen"  on local, staging and production environment

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1792
