### PR TITLE
1710: Handle empty language overrides

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -51,8 +51,12 @@ Future<String?> loadLocaleOverride(AppLocale locale) async {
   final path = '${buildConfig.localeOverridePath}/override_${locale.languageCode}.json';
   try {
     return await rootBundle.loadString(path);
-  } catch (e) {
-    return null;
+  } on FlutterError catch (e) {
+    if (e.message.contains('Unable to load asset')) {
+      debugPrint('Locale override not found at path: $path. The default translation will be used');
+      return null;
+    }
+    rethrow;
   }
 }
 

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -31,13 +31,7 @@ Future<void> main() async {
   // Use override locales for whitelabels (e.g. nuernberg)
   // ignore: unnecessary_null_comparison
   if (buildConfig.localeOverridePath != null) {
-    void override(AppLocale locale) async {
-      final localeOverridePath = '${buildConfig.localeOverridePath}/override_${locale.languageCode}.json';
-      String overrideLocales = await rootBundle.loadString(localeOverridePath);
-      LocaleSettings.overrideTranslations(locale: locale, fileType: FileType.json, content: overrideLocales);
-    }
-
-    AppLocale.values.forEach(override);
+    AppLocale.values.forEach(overrideLocale);
   }
 
   debugPrint('Environment: $appEnvironment');
@@ -50,5 +44,21 @@ Future<void> main() async {
     runAppWithSentry(run);
   } else {
     run();
+  }
+}
+
+Future<String?> loadLocaleOverride(AppLocale locale) async {
+  final path = '${buildConfig.localeOverridePath}/override_${locale.languageCode}.json';
+  try {
+    return await rootBundle.loadString(path);
+  } catch (e) {
+    return null;
+  }
+}
+
+Future<void> overrideLocale(AppLocale locale) async {
+  final content = await loadLocaleOverride(locale);
+  if (content != null) {
+    LocaleSettings.overrideTranslations(locale: locale, fileType: FileType.json, content: content);
   }
 }


### PR DESCRIPTION
### Short description
Get rid of the exception when starting the Koblenz app

```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: Unable to load asset: "assets/koblenz/l10n/override_en.json".
The asset does not exist or has empty data.
```

### Proposed changes
- override translations only if the asset exists

### Side effects
- no?

### Testing
Start the Koblenz app, check there is no exception in log

### Resolved issues
Fixes: #1710
