### PR TITLE
1791: Create application verifications automatically for verein360 applications

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/database/Schema.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/database/Schema.kt
@@ -35,6 +35,11 @@ class ApplicationEntity(id: EntityID<Int>) : IntEntity(id) {
     var cardCreated by Applications.cardCreated
 }
 
+enum class ApplicationVerificationExternalSource {
+    VEREIN360,
+    NONE
+}
+
 object ApplicationVerifications : IntIdTable() {
     val applicationId = reference("applicationId", Applications)
     val contactEmailAddress = varchar("contactEmailAddress", 300)
@@ -43,6 +48,8 @@ object ApplicationVerifications : IntIdTable() {
     val verifiedDate = timestamp("verifiedDate").nullable()
     val rejectedDate = timestamp("rejectedDate").nullable()
     val accessKey = varchar("accessKey", 100).uniqueIndex()
+    val automaticSource = enumerationByName("automaticSource", 20, ApplicationVerificationExternalSource::class)
+        .default(ApplicationVerificationExternalSource.NONE)
 
     init {
         check("notVerifiedAndRejected") {
@@ -63,4 +70,5 @@ class ApplicationVerificationEntity(id: EntityID<Int>) : IntEntity(id) {
     var verifiedDate by ApplicationVerifications.verifiedDate
     var rejectedDate by ApplicationVerifications.rejectedDate
     var accessKey by ApplicationVerifications.accessKey
+    var automaticSource by ApplicationVerifications.automaticSource
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/database/repos/ApplicationRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/database/repos/ApplicationRepository.kt
@@ -2,6 +2,7 @@ package app.ehrenamtskarte.backend.application.database.repos
 
 import app.ehrenamtskarte.backend.application.database.ApplicationEntity
 import app.ehrenamtskarte.backend.application.database.ApplicationVerificationEntity
+import app.ehrenamtskarte.backend.application.database.ApplicationVerificationExternalSource
 import app.ehrenamtskarte.backend.application.database.ApplicationVerifications
 import app.ehrenamtskarte.backend.application.database.Applications
 import app.ehrenamtskarte.backend.application.webservice.schema.view.ApplicationView
@@ -60,6 +61,7 @@ object ApplicationRepository {
                     this.contactName = it.contactName
                     this.organizationName = it.organizationName
                     this.contactEmailAddress = it.contactEmailAddress
+                    this.automaticSource = ApplicationVerificationExternalSource.NONE
                 }
             }
 
@@ -151,6 +153,7 @@ object ApplicationRepository {
                 false
             } else {
                 applicationVerification.verifiedDate = Instant.now()
+                applicationVerification.automaticSource = ApplicationVerificationExternalSource.VEREIN360
                 true
             }
         }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/database/repos/ApplicationRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/database/repos/ApplicationRepository.kt
@@ -116,7 +116,10 @@ object ApplicationRepository {
         }
     }
 
-    fun getApplicationByApplicationVerificationAccessKey(applicationVerificationAccessKey: String, dfe: DataFetchingEnvironment): ApplicationView {
+    fun getApplicationByApplicationVerificationAccessKey(
+        applicationVerificationAccessKey: String,
+        dfe: DataFetchingEnvironment
+    ): ApplicationView {
         val logger = LoggerFactory.getLogger(ApplicationRepository::class.java)
         val context = dfe.getContext<GraphQLContext>()
         return transaction {
@@ -146,14 +149,17 @@ object ApplicationRepository {
         return applicationVerification.verifiedDate != null || applicationVerification.rejectedDate != null
     }
 
-    fun verifyApplicationVerification(accessKey: String): Boolean {
+    fun verifyApplicationVerification(
+        accessKey: String,
+        automaticSource: ApplicationVerificationExternalSource = ApplicationVerificationExternalSource.NONE
+    ): Boolean {
         return transaction {
             val applicationVerification = getApplicationVerification(accessKey)
             if (isAlreadyVerified(applicationVerification)) {
                 false
             } else {
                 applicationVerification.verifiedDate = Instant.now()
-                applicationVerification.automaticSource = ApplicationVerificationExternalSource.VEREIN360
+                applicationVerification.automaticSource = automaticSource
                 true
             }
         }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/EakApplicationMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/EakApplicationMutationService.kt
@@ -40,7 +40,7 @@ class EakApplicationMutationService {
         val (applicationEntity, verificationEntities) = applicationHandler.saveApplication()
 
         if (isPreVerified) {
-            applicationHandler.setApplicationVerificationToVerifiedNow(verificationEntities)
+            applicationHandler.setApplicationVerificationToPreVerifiedNow(verificationEntities)
         }
 
         applicationHandler.sendApplicationMails(applicationEntity, verificationEntities, dataFetcherResultBuilder)

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/utils/ApplicationHandler.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/utils/ApplicationHandler.kt
@@ -2,6 +2,7 @@ package app.ehrenamtskarte.backend.application.webservice.utils
 
 import app.ehrenamtskarte.backend.application.database.ApplicationEntity
 import app.ehrenamtskarte.backend.application.database.ApplicationVerificationEntity
+import app.ehrenamtskarte.backend.application.database.ApplicationVerificationExternalSource
 import app.ehrenamtskarte.backend.application.database.repos.ApplicationRepository
 import app.ehrenamtskarte.backend.application.webservice.schema.create.Application
 import app.ehrenamtskarte.backend.common.webservice.GraphQLContext
@@ -101,10 +102,13 @@ class ApplicationHandler(
         }
     }
 
-    fun setApplicationVerificationToVerifiedNow(verificationEntities: List<ApplicationVerificationEntity>) {
+    fun setApplicationVerificationToPreVerifiedNow(verificationEntities: List<ApplicationVerificationEntity>) {
         transaction {
             verificationEntities.forEach {
-                ApplicationRepository.verifyApplicationVerification(it.accessKey)
+                ApplicationRepository.verifyApplicationVerification(
+                    it.accessKey,
+                    ApplicationVerificationExternalSource.VEREIN360
+                )
             }
         }
     }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/MigrationsRegistry.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/MigrationsRegistry.kt
@@ -25,6 +25,7 @@ object MigrationsRegistry {
         V0021_AlterTokenHashColumn(),
         V0022_AddTypeToApiToken(),
         V0023_DropTypeDefaultOfApiToken(),
-        V0024_AddNewRoleToRoleRegionCombinationConstraint()
+        V0024_AddNewRoleToRoleRegionCombinationConstraint(),
+        V0025_AddSourceFieldToApplicationVerifications()
     )
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/V0025_AddSourceFieldToApplicationVerifications.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/migration/migrations/V0025_AddSourceFieldToApplicationVerifications.kt
@@ -1,0 +1,19 @@
+package app.ehrenamtskarte.backend.migration.migrations
+
+import app.ehrenamtskarte.backend.migration.Migration
+import app.ehrenamtskarte.backend.migration.Statement
+
+/**
+ * Addes the automaticSource field to the applicationverifications table
+ */
+@Suppress("ClassName")
+internal class V0025_AddSourceFieldToApplicationVerifications : Migration() {
+    override val migrate: Statement = {
+        exec(
+            """
+                ALTER TABLE applicationverifications
+                ADD COLUMN "automaticSource" VARCHAR(20) NOT NULL DEFAULT 'NONE' CHECK ("automaticSource" IN ('VEREIN360', 'NONE'));
+            """.trimIndent()
+        )
+    }
+}

--- a/backend/src/test/kotlin/app/ehrenamtskarte/backend/application/webservice/EakApplicationMutationServiceTest.kt
+++ b/backend/src/test/kotlin/app/ehrenamtskarte/backend/application/webservice/EakApplicationMutationServiceTest.kt
@@ -51,7 +51,6 @@ internal class EakApplicationMutationServiceTest : IntegrationTest() {
 
         mockkConstructor(ApplicationHandler::class)
         every { anyConstructed<ApplicationHandler>().sendApplicationMails(any(), any(), any()) } returns Unit
-        every { anyConstructed<ApplicationHandler>().setApplicationVerificationToVerifiedNow(any()) } returns Unit
 
         val application = TestApplicationBuilder.build(false)
 
@@ -64,7 +63,7 @@ internal class EakApplicationMutationServiceTest : IntegrationTest() {
             assertTrue(result.data)
             assertEquals(applicationsBefore + 1, Applications.selectAll().count())
             verify(exactly = 1) { anyConstructed<ApplicationHandler>().sendApplicationMails(any(), any(), any()) }
-            verify(exactly = 0) { anyConstructed<ApplicationHandler>().setApplicationVerificationToVerifiedNow(any()) }
+            verify(exactly = 0) { anyConstructed<ApplicationHandler>().setApplicationVerificationToPreVerifiedNow(any()) }
         }
     }
 
@@ -91,7 +90,7 @@ internal class EakApplicationMutationServiceTest : IntegrationTest() {
                 assertFalse(result.data)
                 assertEquals(applicationsBefore, Applications.selectAll().count())
                 verify(exactly = 0) { anyConstructed<ApplicationHandler>().sendApplicationMails(any(), any(), any()) }
-                verify(exactly = 0) { anyConstructed<ApplicationHandler>().setApplicationVerificationToVerifiedNow(any()) }
+                verify(exactly = 0) { anyConstructed<ApplicationHandler>().setApplicationVerificationToPreVerifiedNow(any()) }
             }
         }
     }


### PR DESCRIPTION
### Short description
Application verifications get source set for verein360 applications

### Proposed changes
- adjusted database to have column "automaticSource"
- refined check for incoming applications

### Side effects
None, maybe affecting normal application creation process

### Testing
create new application with one or more organizations. Check for correct error messages if isAlreadyVerified differs. Check if one or all are true, the applicationVerifications table column automaticSource is set properly to VEREIN360

Feel free to test the complete feature in this PR: https://github.com/digitalfabrik/entitlementcard/pull/1811

### Resolved issues
Fixes: #1791
