### PR TITLE
Remove duplicated * on the application form

### DIFF
--- a/administration/src/mui-modules/application/primitive-inputs/CheckboxForm.tsx
+++ b/administration/src/mui-modules/application/primitive-inputs/CheckboxForm.tsx
@@ -39,12 +39,7 @@ const CheckboxForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
                 }}
               />
             }
-            label={
-              <>
-                {label}
-                {options.required ? ' *' : ''}
-              </>
-            }
+            label={label}
           />
           {(showAllErrors || touched) && isInvalid ? <FormHelperText>{validationResult.message}</FormHelperText> : null}
         </FormControl>


### PR DESCRIPTION
### Short description
The "*" symbol is duplicated for the mandatory checkboxes on the application form.
The asterisks are aligned differently and have different colors if a validation error occurred.
I think it looks strange.
![image](https://github.com/user-attachments/assets/57baee26-613f-472b-b419-a806b42eced0)

### Proposed changes
Remove duplicated "*" from the label

### Side effects
Not sure why it was done this way, maybe I'm missing something?
I have tested the form in Chrome and Firefox

### Testing
check eak application form

### Resolved issues
n/a