### PR TITLE
1817: Allow certain special characters

### DIFF
--- a/administration/src/cards/Card.test.ts
+++ b/administration/src/cards/Card.test.ts
@@ -140,13 +140,23 @@ describe('Card', () => {
     })
   })
 
-  it.each(['$tefan Mayer', 'Karla K.', 'Karla Karls😀', 'إئبآء؟ؤئحجرزش'])(
+  it.each(['$tefan Mayer', 'Karla K', 'Karla Karls😀', 'إئبآء؟ؤئحجرزش'])(
     'should correctly identify invalid special characters in fullname',
     fullName => {
       const card = initializeCard(cardConfig, region, { fullName })
       expect(card.fullName).toBe(fullName)
       expect(isValueValid(card, cardConfig, 'Name')).toBeFalsy()
       expect(isValid(card)).toBeFalsy()
+    }
+  )
+
+  it.each(['Dr. Karl Lauterbach', " Mac O'Connor", 'Hans-Wilhelm Müller-Wohlfahrt'])(
+    'should correctly create a cards that contain some certain special characters in the name',
+    fullName => {
+      const card = initializeCard(cardConfig, region, { fullName })
+      expect(card.fullName).toBe(fullName)
+      expect(isValueValid(card, cardConfig, 'Name')).toBeTruthy()
+      expect(isValid(card)).toBeTruthy()
     }
   )
 

--- a/administration/src/util/helper.ts
+++ b/administration/src/util/helper.ts
@@ -16,7 +16,7 @@ export type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) ex
 const multipleSpacePattern = /\s\s+/g
 export const removeMultipleSpaces = (value: string): string => value.replace(multipleSpacePattern, ' ')
 export const containsSpecialCharacters = (value: string): boolean =>
-  /[`!@#$%^&*()_+\-=\]{};':"\\|,.<>?~0123456789]/.test(value)
+  /[`!@#$%^&*()_+=\]{};:"\\|,<>?€¥°[£¢§~¡“¶≠¿«∑®†Ω¨øπ•±‘æœ∆ª©ƒ∂å≈ç√∫–µ0123456789]/.test(value)
 
 /** This regEx is needed to avoid breaking pdf creation due to incompatible charsets in form fields
  * Common charset includes common pattern f.e. empty spaces.


### PR DESCRIPTION
### Short description
Since some names may contain "-", "." or "'" we have to allow some certain special chars.
If you find anything thats missing here please let me know

### Proposed changes

<!-- Describe this PR in more detail. -->

- remove some special chars from the not allowed regex pattern
- add some missing special characters
- added some additional tests

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

- Create a koblenz card and test some names that include allowed special chars
- Test some names like "Dr. Vorname Nachname" , "Mac O'Connor", "Hans-Wilhelm Müller-Wohlfahrt"

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1817
