### PR TITLE
1821: Fix wrong map attribution

### DIFF
--- a/frontend/build-configs/bayern/index.ts
+++ b/frontend/build-configs/bayern/index.ts
@@ -31,6 +31,10 @@ export const bayernCommon: CommonBuildConfigType = {
         showcase: "https://api.entitlementcard.app/project/showcase.entitlementcard.app/map",
         local: "http://localhost:8000/project/bayern.ehrenamtskarte.app/map",
     },
+    mapAttribution: {
+        text: 'LBE Bayern',
+        url: 'https://www.lbe.bayern.de/',
+    },
     mapInitialCoordinatesLat: 48.949444,
     mapInitialCoordinatesLng: 11.395,
     mapInitialZoomLevel: 6,

--- a/frontend/build-configs/koblenz/index.ts
+++ b/frontend/build-configs/koblenz/index.ts
@@ -34,6 +34,10 @@ export const koblenzCommon: CommonBuildConfigType = {
         showcase: "https://api.entitlementcard.app/project/showcase.entitlementcard.app/map",
         local: "http://localhost:8000/project/koblenz.sozialpass.app/map",
     },
+    mapAttribution: {
+        text: 'Stadt Koblenz',
+        url: 'https://koblenz.de/',
+    },
     mapInitialCoordinatesLat: 50.3575886,
     mapInitialCoordinatesLng: 7.5846829,
     mapInitialZoomLevel: 10,

--- a/frontend/build-configs/nuernberg/index.ts
+++ b/frontend/build-configs/nuernberg/index.ts
@@ -31,6 +31,10 @@ export const nuernbergCommon: CommonBuildConfigType = {
         showcase: "https://api.entitlementcard.app/project/showcase.entitlementcard.app/map",
         local: "http://localhost:8000/project/nuernberg.sozialpass.app/map",
     },
+    mapAttribution: {
+        text: 'Stadt Nürnberg',
+        url: 'https://nuernberg.de',
+    },
     mapInitialCoordinatesLat: 49.460983,
     mapInitialCoordinatesLng: 11.061859,
     mapInitialZoomLevel: 10,

--- a/frontend/build-configs/types.ts
+++ b/frontend/build-configs/types.ts
@@ -30,6 +30,11 @@ export type ThemeType = {
     fontFamily: string
 }
 
+export type MapAttribution = {
+    text: string
+    url: string
+}
+
 export type CommonBuildConfigType = {
     appName: string
     appIcon: string
@@ -48,6 +53,7 @@ export type CommonBuildConfigType = {
     mapInitialCoordinatesLat: number
     mapInitialCoordinatesLng: number
     mapInitialZoomLevel: number
+    mapAttribution: MapAttribution,
     backendUrl: {
         showcase: string
         staging: string

--- a/frontend/lib/map/map/attribution_dialog.dart
+++ b/frontend/lib/map/map/attribution_dialog.dart
@@ -1,3 +1,4 @@
+import 'package:ehrenamtskarte/build_config/build_config.dart' show buildConfig;
 import 'package:ehrenamtskarte/map/map/attribution_dialog_item.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher_string.dart';
@@ -41,9 +42,9 @@ class AttributionDialog extends StatelessWidget {
         AttributionDialogItem(
           icon: Icons.copyright,
           color: color,
-          text: 'LBE Bayern',
+          text: buildConfig.mapAttribution.text,
           onPressed: () {
-            launchUrlString('https://www.lbe.bayern.de/', mode: LaunchMode.externalApplication);
+            launchUrlString(buildConfig.mapAttribution.url, mode: LaunchMode.externalApplication);
           },
         )
       ],


### PR DESCRIPTION
### Short description

Currently the map attribution was hardcoded (with LBE Bayern) for all whitelabels but the map attribution depends on the particular project.

### Proposed changes

<!-- Describe this PR in more detail. -->

- show different map attribution per project

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

- Open the map attribution for each project (left corner of map)
- Check the text and if the link is working

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1821
