### PR TITLE
1824: Card extension jumps to old card

### DIFF
--- a/frontend/lib/activation/deeplink_activation.dart
+++ b/frontend/lib/activation/deeplink_activation.dart
@@ -103,39 +103,41 @@ class _DeepLinkActivationState extends State<DeepLinkActivation> {
                 child: Column(mainAxisSize: MainAxisSize.min, children: [
                   if (_state == _State.waiting) _WarningText(status, userCodeModel),
                   ElevatedButton.icon(
-                    onPressed:
-                        activationCode != null && _state == _State.waiting && status == DeepLinkActivationStatus.valid
-                            ? () async {
+                    onPressed: activationCode != null &&
+                            _state == _State.waiting &&
+                            status == DeepLinkActivationStatus.valid
+                        ? () async {
+                            setState(() {
+                              _state = _State.loading;
+                            });
+                            try {
+                              final activated = await activateCard(context, activationCode);
+                              if (!context.mounted) return;
+                              if (activated) {
+                                final cardAmount = Provider.of<UserCodeModel>(context, listen: false).userCodes.length;
+                                GoRouter.of(context).pushReplacement('$homeRouteName/$identityTabIndex/$cardAmount');
                                 setState(() {
-                                  _state = _State.loading;
+                                  _state = _State.success;
                                 });
-                                try {
-                                  final activated = await activateCard(context, activationCode);
-                                  if (!context.mounted) return;
-                                  if (activated) {
-                                    GoRouter.of(context).pushReplacement('$homeRouteName/$identityTabIndex');
-                                    setState(() {
-                                      _state = _State.success;
-                                    });
-                                  } else {
-                                    setState(() {
-                                      _state = _State.waiting;
-                                    });
-                                  }
-                                } catch (_) {
-                                  setState(() {
-                                    _state = _State.waiting;
-                                  });
-                                  // TODO 1656: Improve error handling!!
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(
-                                      content: Text(t.common.unknownError),
-                                    ),
-                                  );
-                                  rethrow;
-                                }
+                              } else {
+                                setState(() {
+                                  _state = _State.waiting;
+                                });
                               }
-                            : null,
+                            } catch (_) {
+                              setState(() {
+                                _state = _State.waiting;
+                              });
+                              // TODO 1656: Improve error handling!!
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  content: Text(t.common.unknownError),
+                                ),
+                              );
+                              rethrow;
+                            }
+                          }
+                        : null,
                     icon: _state != _State.waiting
                         ? Container(
                             width: 24,

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -21,6 +21,7 @@ const initialRouteName = '/';
 const activationRouteCodeParamName = 'base64qrcode';
 const activationRouteName = 'activation';
 const homeRouteParamTabIndexName = 'tabIndex';
+const homeRouteParamCardIndexName = 'cardIndex';
 const homeRouteName = '/home';
 const introRouteName = '/intro';
 
@@ -40,7 +41,6 @@ final GoRouter router = GoRouter(
         GoRoute(
           path: '$activationRouteName/:$activationRouteCodeParamName',
           builder: (BuildContext context, GoRouterState state) {
-            print(state.uri.fragment);
             return DeepLinkActivation(base64qrcode: Uri.decodeFull(state.uri.fragment));
           },
         ),
@@ -52,9 +52,11 @@ final GoRouter router = GoRouter(
           return HomePage();
         }),
     GoRoute(
-      path: '$homeRouteName/:$homeRouteParamTabIndexName',
+      path: '$homeRouteName/:$homeRouteParamTabIndexName/:$homeRouteParamCardIndexName',
       builder: (BuildContext context, GoRouterState state) {
-        return HomePage(initialTabIndex: int.parse(state.pathParameters[homeRouteParamTabIndexName]!));
+        return HomePage(
+            initialTabIndex: int.parse(state.pathParameters[homeRouteParamTabIndexName]!),
+            initialCardIndex: int.parse(state.pathParameters[homeRouteParamCardIndexName]!));
       },
     ),
     GoRoute(

--- a/frontend/lib/home/home_page.dart
+++ b/frontend/lib/home/home_page.dart
@@ -18,8 +18,9 @@ const identityTabIndex = 2;
 
 class HomePage extends StatefulWidget {
   final int? initialTabIndex;
+  final int? initialCardIndex;
 
-  const HomePage({super.key, this.initialTabIndex});
+  const HomePage({super.key, this.initialTabIndex, this.initialCardIndex});
 
   @override
   HomePageState createState() => HomePageState();
@@ -63,7 +64,7 @@ class HomePageState extends State<HomePage> {
         ),
       if (buildConfig.featureFlags.verification)
         AppFlow(
-          IdentificationPage(),
+          IdentificationPage(initialCardIndex: widget.initialCardIndex),
           Icons.credit_card,
           (BuildContext context) => t.identification.title,
           GlobalKey<NavigatorState>(debugLabel: 'Auth tab key'),

--- a/frontend/lib/identification/identification_page.dart
+++ b/frontend/lib/identification/identification_page.dart
@@ -20,7 +20,8 @@ import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 class IdentificationPage extends StatefulWidget {
-  const IdentificationPage({super.key});
+  final int? initialCardIndex;
+  const IdentificationPage({super.key, this.initialCardIndex});
 
   @override
   IdentificationPageState createState() => IdentificationPageState();
@@ -29,6 +30,15 @@ class IdentificationPage extends StatefulWidget {
 class IdentificationPageState extends State<IdentificationPage> {
   CarouselController carouselController = CarouselController();
   int cardIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    cardIndex = widget.initialCardIndex ?? 0;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      carouselController.jumpToPage(cardIndex);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
### Short description

When a user activates a second card via deeplink, the app directly moves to the first card after activation. This may confuse the user

### Proposed changes

<!-- Describe this PR in more detail. -->

- introduce a `cardIndex` for Home route be able to initialize the identification page  (child of home route) with the particular card index
- add the card index to the route push when activating card via deeplink

### Note
Since we have to wait until the identification page widget is initialized its not possible to just execute a `moveTo` function after activating the deeplink, so i think thats the best way to do.

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- don't think so, worst thing could happen to initialize at cardIndex 0

### Testing

1. Activate a card via deeplink
2. Activate a second card via deeplink
3. Check the after activation the latest card will be displayed


### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1824
