### PR TITLE
1827: Surnames single digit

### DIFF
--- a/administration/src/cards/Card.test.ts
+++ b/administration/src/cards/Card.test.ts
@@ -160,7 +160,7 @@ describe('Card', () => {
     }
   )
 
-  it.each(['Karla', 'Karl L'])('should correctly identify invalid fullname that is incomplete', fullName => {
+  it.each(['Karla', 'Peter'])('should correctly identify invalid fullname that is incomplete', fullName => {
     const card = initializeCard(cardConfig, region, { fullName })
     expect(isValueValid(card, cardConfig, 'Name')).toBeFalsy()
     expect(isValid(card)).toBeFalsy()

--- a/administration/src/cards/Card.ts
+++ b/administration/src/cards/Card.ts
@@ -75,7 +75,7 @@ const hasValidNameLength = (fullName: string): boolean => {
 
 const hasNameAndForename = (fullName: string): boolean => {
   const names = fullName.trim().split(' ')
-  return names.length > 1 && names.every(name => name.length > 1)
+  return names.length > 1 && names.every(name => name.length > 0)
 }
 
 export const isFullNameValid = ({ fullName }: Card): boolean =>


### PR DESCRIPTION
### Short description

Since in some countries exists name with only one digit, we should allow them

### Proposed changes

<!-- Describe this PR in more detail. -->

- reduce minimum name character count to `>0`

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. Go to /erstellen
2. Type in name with just one single character like "A F" or "Karla K"
3. Name shouldn't be marked as invalid anymore

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1827
