### PR TITLE
fix-card-test: remove valid case

### DIFF
--- a/administration/src/cards/Card.test.ts
+++ b/administration/src/cards/Card.test.ts
@@ -140,7 +140,7 @@ describe('Card', () => {
     })
   })
 
-  it.each(['$tefan Mayer', 'Karla K', 'Karla Karls😀', 'إئبآء؟ؤئحجرزش'])(
+  it.each(['$tefan Mayer', 'Karla Karls😀', 'إئبآء؟ؤئحجرزش'])(
     'should correctly identify invalid special characters in fullname',
     fullName => {
       const card = initializeCard(cardConfig, region, { fullName })


### PR DESCRIPTION
Looks like due to merging prs this testcase which is now valid wasn't removed.
