### PR TITLE
1835: Fix last store item hidden

### DIFF
--- a/frontend/lib/search/results_loader.dart
+++ b/frontend/lib/search/results_loader.dart
@@ -136,6 +136,7 @@ class ResultsLoaderState extends State<ResultsLoader> {
             ),
           );
         },
+        noMoreItemsIndicatorBuilder: _buildNoMoreItemsSpacer,
         noItemsFoundIndicatorBuilder: _buildNoItemsFoundIndicator,
         firstPageErrorIndicatorBuilder: _buildErrorWithRetry,
         newPageErrorIndicatorBuilder: _buildErrorWithRetry,
@@ -148,6 +149,8 @@ class ResultsLoaderState extends State<ResultsLoader> {
 
   Widget _buildProgressIndicator(BuildContext context) =>
       const Center(child: Padding(padding: EdgeInsets.all(5), child: CircularProgressIndicator()));
+
+  Widget _buildNoMoreItemsSpacer(BuildContext context) => const SizedBox(height: 80);
 
   Widget _buildErrorWithRetry(BuildContext context) {
     final t = context.t;


### PR DESCRIPTION
### Short description
Last store item is hidden in list because its behind the sorting FAB button

### Proposed changes

<!-- Describe this PR in more detail. -->

- add a sized box as spacer

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

Open search page and scroll down to last item. Check if its readable

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1835 
