### PR TITLE
1840: Properly serialize activity log and fix it

### DIFF
--- a/administration/src/bp-modules/cards/hooks/useCardGenerator.ts
+++ b/administration/src/bp-modules/cards/hooks/useCardGenerator.ts
@@ -15,7 +15,7 @@ import getDeepLinkFromQrCode from '../../../util/getDeepLinkFromQrCode'
 import { updateArrayItem } from '../../../util/helper'
 import normalizeString from '../../../util/normalizeString'
 import { useAppToaster } from '../../AppToaster'
-import { ActivityLog } from '../../user-settings/ActivityLog'
+import { saveActivityLog } from '../../user-settings/ActivityLog'
 
 export enum CardActivationState {
   input,
@@ -155,7 +155,7 @@ const useCardGenerator = (region: Region): UseCardGeneratorReturn => {
 
         const dataUri = await generateFunction(codes, cards)
 
-        cards.forEach(card => new ActivityLog(card).saveToSessionStorage())
+        cards.forEach(saveActivityLog)
 
         downloadDataUri(dataUri, filename)
         if (region.activatedForCardConfirmationMail) {

--- a/administration/src/bp-modules/user-settings/ActivityLogCard.tsx
+++ b/administration/src/bp-modules/user-settings/ActivityLogCard.tsx
@@ -1,7 +1,8 @@
 import { Button, Card, Dialog, DialogBody, H2 } from '@blueprintjs/core'
-import React, { ReactElement, useState } from 'react'
+import React, { ReactElement, useContext, useState } from 'react'
 import styled from 'styled-components'
 
+import { ProjectConfigContext } from '../../project-configs/ProjectConfigContext'
 import { ActivityLogConfig } from '../../project-configs/getProjectConfig'
 import { loadActivityLog } from './ActivityLog'
 
@@ -52,7 +53,8 @@ const StyledTable = styled.table`
 `
 const ActivityLogCard = ({ activityLogConfig }: { activityLogConfig: ActivityLogConfig }): ReactElement => {
   const [openLog, setOpenLog] = useState<boolean>(false)
-  const activityLogSorted = loadActivityLog().sort((a, b) => (new Date(a.timestamp) < new Date(b.timestamp) ? 1 : -1))
+  const { card: cardConfig } = useContext(ProjectConfigContext)
+  const activityLogSorted = loadActivityLog(cardConfig).sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1))
 
   return (
     <>
@@ -77,7 +79,7 @@ const ActivityLogCard = ({ activityLogConfig }: { activityLogConfig: ActivityLog
             </StickyTableHeader>
             <tbody>
               {activityLogSorted.length > 0 ? (
-                activityLogSorted.map(logEntry => activityLogConfig.renderLogEntry(logEntry))
+                activityLogSorted.map(activityLogConfig.renderLogEntry)
               ) : (
                 <EmptyLog>Keine Einträge vorhanden</EmptyLog>
               )}

--- a/administration/src/cards/extensions/AddressFieldExtensions.ts
+++ b/administration/src/cards/extensions/AddressFieldExtensions.ts
@@ -24,6 +24,8 @@ const getAddressFieldExtension = <T extends AddressFieldExtension>(
   isValid: () => true,
   fromString: (value: string) => ({ [name]: value } as AddressFieldExtensionState<T>),
   toString: (state): string => state[name],
+  fromSerialized: (value: string) => ({ [name]: value } as AddressFieldExtensionState<T>),
+  serialize: (state): string => state[name],
 })
 
 export const AddressLine1Extension = getAddressFieldExtension(ADDRESS_LINE_1_EXTENSION)

--- a/administration/src/cards/extensions/BavariaCardTypeExtension.tsx
+++ b/administration/src/cards/extensions/BavariaCardTypeExtension.tsx
@@ -46,6 +46,18 @@ const StartDayForm = ({ value, setValue }: ExtensionComponentProps<BavariaCardTy
   )
 }
 
+const fromString = (state: string): BavariaCardTypeExtensionState | null => {
+  if (state === BAVARIA_CARD_TYPE_STANDARD || state === BAVARIA_CARD_TYPE_STANDARD_LEGACY) {
+    return { bavariaCardType: BAVARIA_CARD_TYPE_STANDARD }
+  }
+  if (state === BAVARIA_CARD_TYPE_GOLD || state === BAVARIA_CARD_TYPE_GOLD_LEGACY) {
+    return { bavariaCardType: BAVARIA_CARD_TYPE_GOLD }
+  }
+  return null
+}
+
+const toString = ({ bavariaCardType }: BavariaCardTypeExtensionState): string => bavariaCardType
+
 const BavariaCardTypeExtension: Extension<BavariaCardTypeExtensionState> = {
   name: BAVARIA_CARD_TYPE_EXTENSION_NAME,
   Component: StartDayForm,
@@ -59,16 +71,10 @@ const BavariaCardTypeExtension: Extension<BavariaCardTypeExtensionState> = {
   }),
   isValid: state =>
     state?.bavariaCardType === BAVARIA_CARD_TYPE_STANDARD || state?.bavariaCardType === BAVARIA_CARD_TYPE_GOLD,
-  fromString: (state: string) => {
-    if (state === BAVARIA_CARD_TYPE_STANDARD || state === BAVARIA_CARD_TYPE_STANDARD_LEGACY) {
-      return { bavariaCardType: BAVARIA_CARD_TYPE_STANDARD }
-    }
-    if (state === BAVARIA_CARD_TYPE_GOLD || state === BAVARIA_CARD_TYPE_GOLD_LEGACY) {
-      return { bavariaCardType: BAVARIA_CARD_TYPE_GOLD }
-    }
-    return null
-  },
-  toString: state => state.bavariaCardType,
+  fromString,
+  toString,
+  fromSerialized: fromString,
+  serialize: toString,
 }
 
 export default BavariaCardTypeExtension

--- a/administration/src/cards/extensions/BirthdayExtension.tsx
+++ b/administration/src/cards/extensions/BirthdayExtension.tsx
@@ -73,6 +73,11 @@ const BirthdayExtension: Extension<BirthdayExtensionState> = {
     return birthday === null ? null : { birthday }
   },
   toString: ({ birthday }: BirthdayExtensionState) => birthday?.format() ?? '',
+  fromSerialized: (value: string) => {
+    const birthday = PlainDate.safeFrom(value)
+    return birthday === null ? null : { birthday }
+  },
+  serialize: ({ birthday }: BirthdayExtensionState) => birthday?.formatISO() ?? '',
 }
 
 export default BirthdayExtension

--- a/administration/src/cards/extensions/EMailNotificationExtension.ts
+++ b/administration/src/cards/extensions/EMailNotificationExtension.ts
@@ -3,6 +3,9 @@ import { Extension } from './extensions'
 export const EMAIL_NOTIFICATION_EXTENSION_NAME = 'emailNotification'
 type EmailNotificationExtensionState = { [EMAIL_NOTIFICATION_EXTENSION_NAME]: string }
 
+const fromString = (value: string): EmailNotificationExtensionState => ({ [EMAIL_NOTIFICATION_EXTENSION_NAME]: value })
+const toString = ({ emailNotification }: EmailNotificationExtensionState): string => emailNotification
+
 const EMailNotificationExtension: Extension<EmailNotificationExtensionState> = {
   name: EMAIL_NOTIFICATION_EXTENSION_NAME,
   Component: () => null,
@@ -10,8 +13,10 @@ const EMailNotificationExtension: Extension<EmailNotificationExtensionState> = {
   causesInfiniteLifetime: () => false,
   getProtobufData: () => ({}),
   isValid: () => true,
-  fromString: (value: string) => ({ [EMAIL_NOTIFICATION_EXTENSION_NAME]: value }),
-  toString: (state): string => state[EMAIL_NOTIFICATION_EXTENSION_NAME],
+  fromString,
+  toString,
+  fromSerialized: fromString,
+  serialize: toString,
 }
 
 export default EMailNotificationExtension

--- a/administration/src/cards/extensions/KoblenzReferenceNumberExtension.tsx
+++ b/administration/src/cards/extensions/KoblenzReferenceNumberExtension.tsx
@@ -61,6 +61,9 @@ const KoblenzReferenceNumberExtensionForm = ({
   )
 }
 
+const fromString = (value: string): KoblenzReferenceNumberExtensionState => ({ koblenzReferenceNumber: value })
+const toString = ({ koblenzReferenceNumber }: KoblenzReferenceNumberExtensionState): string => koblenzReferenceNumber
+
 const KoblenzReferenceNumberExtension: Extension<KoblenzReferenceNumberExtensionState> = {
   name: KOBLENZ_REFERENCE_NUMBER_EXTENSION_NAME,
   getInitialState: () => ({ koblenzReferenceNumber: '' }),
@@ -80,8 +83,10 @@ const KoblenzReferenceNumberExtension: Extension<KoblenzReferenceNumberExtension
       !hasSpecialChars(koblenzReferenceNumber)
     )
   },
-  fromString: value => ({ koblenzReferenceNumber: value }),
-  toString: state => state.koblenzReferenceNumber,
+  fromString,
+  toString,
+  fromSerialized: fromString,
+  serialize: toString,
 }
 
 export default KoblenzReferenceNumberExtension

--- a/administration/src/cards/extensions/NuernbergPassIdExtension.tsx
+++ b/administration/src/cards/extensions/NuernbergPassIdExtension.tsx
@@ -33,6 +33,12 @@ const NuernbergPassIdForm = ({
   </FormGroup>
 )
 
+const fromString = (value: string): NuernbergPassIdExtensionState => {
+  const nuernbergPassId = parseInt(value, 10)
+  return { nuernbergPassId: Number.isNaN(nuernbergPassId) ? null : nuernbergPassId }
+}
+const toString = ({ nuernbergPassId }: NuernbergPassIdExtensionState) => nuernbergPassId?.toString() ?? ''
+
 const NuernbergPassIdExtension: Extension<NuernbergPassIdExtensionState> = {
   name: NUERNBERG_PASS_ID_EXTENSION_NAME,
   getInitialState: () => ({ nuernbergPassId: null }),
@@ -48,11 +54,10 @@ const NuernbergPassIdExtension: Extension<NuernbergPassIdExtensionState> = {
     const nuernbergPassId = state?.nuernbergPassId ?? null
     return nuernbergPassId !== null && nuernbergPassId > 0 && nuernbergPassId < 10 ** nuernbergPassIdLength
   },
-  fromString: value => {
-    const nuernbergPassId = parseInt(value, 10)
-    return { nuernbergPassId: Number.isNaN(nuernbergPassId) ? null : nuernbergPassId }
-  },
-  toString: state => state.nuernbergPassId?.toString() ?? '',
+  fromString,
+  toString,
+  fromSerialized: fromString,
+  serialize: toString,
 }
 
 export default NuernbergPassIdExtension

--- a/administration/src/cards/extensions/NuernbergPassIdExtension.tsx
+++ b/administration/src/cards/extensions/NuernbergPassIdExtension.tsx
@@ -37,7 +37,7 @@ const fromString = (value: string): NuernbergPassIdExtensionState => {
   const nuernbergPassId = parseInt(value, 10)
   return { nuernbergPassId: Number.isNaN(nuernbergPassId) ? null : nuernbergPassId }
 }
-const toString = ({ nuernbergPassId }: NuernbergPassIdExtensionState) => nuernbergPassId?.toString() ?? ''
+const toString = ({ nuernbergPassId }: NuernbergPassIdExtensionState): string => nuernbergPassId?.toString() ?? ''
 
 const NuernbergPassIdExtension: Extension<NuernbergPassIdExtensionState> = {
   name: NUERNBERG_PASS_ID_EXTENSION_NAME,

--- a/administration/src/cards/extensions/RegionExtension.ts
+++ b/administration/src/cards/extensions/RegionExtension.ts
@@ -4,6 +4,9 @@ import { Extension } from './extensions'
 export const REGION_EXTENSION_NAME = 'regionId'
 export type RegionExtensionState = { [REGION_EXTENSION_NAME]: number }
 
+const fromString = (value: string): RegionExtensionState => ({ regionId: parseInt(value, 10) })
+const toString = ({ regionId }: RegionExtensionState): string => regionId.toString()
+
 const RegionExtension: Extension<RegionExtensionState> = {
   name: REGION_EXTENSION_NAME,
   Component: () => null,
@@ -15,8 +18,9 @@ const RegionExtension: Extension<RegionExtensionState> = {
     },
   }),
   isValid: () => true,
-  fromString: (value: string) => ({ regionId: parseInt(value, 10) }),
-  toString: ({ regionId }: RegionExtensionState) => regionId.toString(),
+  fromString,
+  fromSerialized: fromString,
+  serialize: toString,
 }
 
 export default RegionExtension

--- a/administration/src/cards/extensions/StartDayExtension.tsx
+++ b/administration/src/cards/extensions/StartDayExtension.tsx
@@ -3,6 +3,7 @@ import { TextField } from '@mui/material'
 import React, { ReactElement } from 'react'
 
 import PlainDate from '../../util/PlainDate'
+import { BirthdayExtensionState } from './BirthdayExtension'
 import { Extension, ExtensionComponentProps } from './extensions'
 
 export const START_DAY_EXTENSION_NAME = 'startDay'
@@ -53,6 +54,11 @@ const StartDayExtension: Extension<StartDayExtensionState> = {
     return startDay === null ? null : { startDay }
   },
   toString: ({ startDay }: StartDayExtensionState) => startDay.format(),
+  fromSerialized: (value: string) => {
+    const startDay = PlainDate.safeFrom(value)
+    return startDay === null ? null : { startDay }
+  },
+  serialize: ({ startDay }: StartDayExtensionState) => startDay.formatISO(),
 }
 
 export default StartDayExtension

--- a/administration/src/cards/extensions/StartDayExtension.tsx
+++ b/administration/src/cards/extensions/StartDayExtension.tsx
@@ -3,7 +3,6 @@ import { TextField } from '@mui/material'
 import React, { ReactElement } from 'react'
 
 import PlainDate from '../../util/PlainDate'
-import { BirthdayExtensionState } from './BirthdayExtension'
 import { Extension, ExtensionComponentProps } from './extensions'
 
 export const START_DAY_EXTENSION_NAME = 'startDay'

--- a/administration/src/cards/extensions/extensions.tsx
+++ b/administration/src/cards/extensions/extensions.tsx
@@ -39,6 +39,8 @@ export type Extension<T = Record<string, unknown>> = {
   getProtobufData(state: T): PartialMessage<CardExtensions>
   fromString(value: string): T | null
   toString(state: T): string
+  fromSerialized(value: string): T | null
+  serialize(state: T): string
 }
 
 const Extensions = [

--- a/administration/src/project-configs/getProjectConfig.ts
+++ b/administration/src/project-configs/getProjectConfig.ts
@@ -9,7 +9,7 @@ import {
 import { ReactElement, ReactNode } from 'react'
 
 import { JsonField } from '../bp-modules/applications/JsonFieldView'
-import { ActivityLog } from '../bp-modules/user-settings/ActivityLog'
+import { ActivityLogEntryType } from '../bp-modules/user-settings/ActivityLog'
 import { Card } from '../cards/Card'
 import { CreateCardsResult } from '../cards/createCards'
 import { Extension } from '../cards/extensions/extensions'
@@ -39,7 +39,7 @@ export type PdfConfig = {
 
 export type ActivityLogConfig = {
   columnNames: string[]
-  renderLogEntry: (logEntry: ActivityLog) => ReactNode
+  renderLogEntry: (logEntry: ActivityLogEntryType) => ReactNode
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/administration/src/project-configs/nuernberg/ActivityLogEntry.tsx
+++ b/administration/src/project-configs/nuernberg/ActivityLogEntry.tsx
@@ -1,18 +1,18 @@
 import React, { ReactNode } from 'react'
 
-import { ActivityLog } from '../../bp-modules/user-settings/ActivityLog'
+import { ActivityLogEntryType } from '../../bp-modules/user-settings/ActivityLog'
 import { BIRTHDAY_EXTENSION_NAME } from '../../cards/extensions/BirthdayExtension'
 import { NUERNBERG_PASS_ID_EXTENSION_NAME } from '../../cards/extensions/NuernbergPassIdExtension'
 
 // Check column names of the activityLogConfig have the same order and amount than here
-const ActivityLogEntry = (logEntry: ActivityLog): ReactNode => {
+const ActivityLogEntry = (logEntry: ActivityLogEntryType): ReactNode => {
   const { card, timestamp } = logEntry
   const birthdayExtension = card.extensions[BIRTHDAY_EXTENSION_NAME] ?? null
   const passIdExtension = card.extensions[NUERNBERG_PASS_ID_EXTENSION_NAME] ?? null
 
   return (
     <tr key={card.id}>
-      <td>{timestamp}</td>
+      <td>{timestamp.toLocaleString()}</td>
       <td>{card.fullName}</td>
       {passIdExtension !== null && <td>{passIdExtension}</td>}
       {birthdayExtension !== null && <td>{birthdayExtension.format()}</td>}

--- a/administration/src/util/PlainDate.ts
+++ b/administration/src/util/PlainDate.ts
@@ -141,18 +141,22 @@ class PlainDate {
   }
 
   /**
-   * Formats the date in ISO 8601 format yyyy-MM-dd (without time part).
-   */
-  toString(): string {
-    return format(this.toLocalDate(), 'yyyy-MM-dd')
-  }
-
-  /**
    * Formats the date in a custom format. `formatString` must comply to date-fns requirements.
    * @param formatString
    */
-  format(formatString: 'dd.MM.yyyy' = 'dd.MM.yyyy'): string {
+  format(formatString: string = 'dd.MM.yyyy'): string {
     return format(this.toLocalDate(), formatString)
+  }
+
+  formatISO(): string {
+    return this.format(ISO_8601_DATE_FORMAT)
+  }
+
+  /**
+   * Formats the date in ISO 8601 format yyyy-MM-dd (without time part).
+   */
+  toString(): string {
+    return this.formatISO()
   }
 
   /**


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
The activity log was broken for a while due to serializing not happening properly. This introduces proper typing and serializing.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Add `fromSerialized` and `serialize` methods to each extension and for cards
- Properly serialize activity log and use iso8601

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Old activity logs break the serializing (but this should not happen as they are only session based)

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See issue.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1840 
