### PR TITLE
1851: Fix card deletion

### DIFF
--- a/frontend/lib/activation/deeplink_activation.dart
+++ b/frontend/lib/activation/deeplink_activation.dart
@@ -103,41 +103,41 @@ class _DeepLinkActivationState extends State<DeepLinkActivation> {
                 child: Column(mainAxisSize: MainAxisSize.min, children: [
                   if (_state == _State.waiting) _WarningText(status, userCodeModel),
                   ElevatedButton.icon(
-                    onPressed: activationCode != null &&
-                            _state == _State.waiting &&
-                            status == DeepLinkActivationStatus.valid
-                        ? () async {
-                            setState(() {
-                              _state = _State.loading;
-                            });
-                            try {
-                              final activated = await activateCard(context, activationCode);
-                              if (!context.mounted) return;
-                              if (activated) {
-                                final cardAmount = Provider.of<UserCodeModel>(context, listen: false).userCodes.length;
-                                GoRouter.of(context).pushReplacement('$homeRouteName/$identityTabIndex/$cardAmount');
+                    onPressed:
+                        activationCode != null && _state == _State.waiting && status == DeepLinkActivationStatus.valid
+                            ? () async {
                                 setState(() {
-                                  _state = _State.success;
+                                  _state = _State.loading;
                                 });
-                              } else {
-                                setState(() {
-                                  _state = _State.waiting;
-                                });
+                                try {
+                                  final activated = await activateCard(context, activationCode);
+                                  if (!context.mounted) return;
+                                  if (activated) {
+                                    final cardIndex =
+                                        Provider.of<UserCodeModel>(context, listen: false).userCodes.length - 1;
+                                    GoRouter.of(context).pushReplacement('$homeRouteName/$identityTabIndex/$cardIndex');
+                                    setState(() {
+                                      _state = _State.success;
+                                    });
+                                  } else {
+                                    setState(() {
+                                      _state = _State.waiting;
+                                    });
+                                  }
+                                } catch (_) {
+                                  setState(() {
+                                    _state = _State.waiting;
+                                  });
+                                  // TODO 1656: Improve error handling!!
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: Text(t.common.unknownError),
+                                    ),
+                                  );
+                                  rethrow;
+                                }
                               }
-                            } catch (_) {
-                              setState(() {
-                                _state = _State.waiting;
-                              });
-                              // TODO 1656: Improve error handling!!
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(
-                                  content: Text(t.common.unknownError),
-                                ),
-                              );
-                              rethrow;
-                            }
-                          }
-                        : null,
+                            : null,
                     icon: _state != _State.waiting
                         ? Container(
                             width: 24,


### PR DESCRIPTION
### Short description

Currently the wrong card index is set after activating a card from deep link. That leads to the issue that an activated card can't be deleted.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Pass the `cardIndex` not the card amount to the route to initialize the identification page with the correct card index

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none
-

### Testing

1. Run koblenz production build
2. Switch to staging environment
3. Activate a koblenz pass ("Ausweisen" -> "Beantragen" use user information from `administration/resources/selfService
4. Go to "Weitere Aktionen" and delete the card
5. Dialog should open and card can be deleted

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1851
