### PR TITLE
1843: Missing application labels

### DIFF
--- a/administration/src/bp-modules/applications/JsonFieldArray.tsx
+++ b/administration/src/bp-modules/applications/JsonFieldArray.tsx
@@ -60,7 +60,7 @@ const JsonFieldArray = ({
       'organizationContact',
       'organization',
       'volunteerServiceEntitlement',
-      'honoredByMinisterPresidentEntitlement',
+      'goldenCardHonoredByMinisterPresidentEntitlement',
     ].includes(jsonField.name)
       ? `${jsonField.name}.title`
       : jsonField.name
@@ -68,7 +68,16 @@ const JsonFieldArray = ({
   const children = jsonField.value.map((jsonFieldIt, index: number) => (
     <JsonFieldView
       jsonField={jsonFieldIt}
-      parentName={['organizationContact', 'organization'].includes(jsonField.name) ? jsonField.name : undefined}
+      parentName={
+        [
+          'organizationContact',
+          'organization',
+          'volunteerServiceEntitlement',
+          'goldenCardHonoredByMinisterPresidentEntitlement',
+        ].includes(jsonField.name)
+          ? jsonField.name
+          : undefined
+      }
       baseUrl={baseUrl}
       // This is the best key we have as jsonField.name is not unique
       // eslint-disable-next-line react/no-array-index-key

--- a/administration/src/bp-modules/applications/JsonFieldElemental.tsx
+++ b/administration/src/bp-modules/applications/JsonFieldElemental.tsx
@@ -26,7 +26,7 @@ const PrintOnlySpan = styled.span`
   }
 `
 
-// Some fields name are equals therefore the parents is needed for resolving the label
+// Some field names are equal therefore the parents are needed for resolving the label
 const getTranslationKey = (fieldName: string, parentName?: string) =>
   parentName ? `${parentName}.${fieldName}` : fieldName
 

--- a/administration/src/bp-modules/applications/JsonFieldElemental.tsx
+++ b/administration/src/bp-modules/applications/JsonFieldElemental.tsx
@@ -26,8 +26,12 @@ const PrintOnlySpan = styled.span`
   }
 `
 
+// Some fields name are equals therefore the parents is needed for resolving the label
+const getTranslationKey = (fieldName: string, parentName?: string) =>
+  parentName ? `${parentName}.${fieldName}` : fieldName
+
 const JsonFieldAttachment = memo(
-  ({ jsonField, baseUrl, attachmentAccessible }: JsonFieldViewProps<JsonField<'Attachment'>>) => {
+  ({ jsonField, baseUrl, attachmentAccessible, parentName }: JsonFieldViewProps<JsonField<'Attachment'>>) => {
     const appToaster = useAppToaster()
     const token = useContext(AuthContext).data?.token
     const { t } = useTranslation('application')
@@ -64,7 +68,7 @@ const JsonFieldAttachment = memo(
       }
       return (
         <p>
-          {t(jsonField.name)}:&nbsp;
+          {t(getTranslationKey(jsonField.name, parentName))}:&nbsp;
           <PrintAwareTag
             round
             rightIcon={<Icon icon='download' color={Colors.GRAY1} />}
@@ -77,7 +81,7 @@ const JsonFieldAttachment = memo(
     }
     return (
       <p>
-        {t(jsonField.name)}:&nbsp;
+        {t(getTranslationKey(jsonField.name, parentName))}:&nbsp;
         <span>eingereicht, nicht sichtbar</span>
       </p>
     )
@@ -90,31 +94,30 @@ const JsonFieldElemental = ({
   ...rest
 }: JsonFieldViewProps<Exclude<GeneralJsonField, JsonField<'Array'>>>) => {
   const { t } = useTranslation('application')
-  const getTranslationKey = () => (parentName ? `${parentName}.${jsonField.name}` : jsonField.name)
 
   switch (jsonField.type) {
     case 'String':
       return (
         <p>
-          {t(getTranslationKey())}: {jsonField.value}
+          {t(getTranslationKey(jsonField.name, parentName))}: {jsonField.value}
         </p>
       )
     case 'Date':
       return (
         <p>
-          {t(getTranslationKey())}: {new Date(jsonField.value).toLocaleDateString('de')}
+          {t(getTranslationKey(jsonField.name, parentName))}: {new Date(jsonField.value).toLocaleDateString('de')}
         </p>
       )
     case 'Number':
       return (
         <p>
-          {t(getTranslationKey())}: {jsonField.value}
+          {t(getTranslationKey(jsonField.name, parentName))}: {jsonField.value}
         </p>
       )
     case 'Boolean':
       return (
         <p>
-          {t(getTranslationKey())}:&nbsp;
+          {t(getTranslationKey(jsonField.name, parentName))}:&nbsp;
           {jsonField.value ? (
             <>
               <Icon icon='tick' intent='success' /> Ja
@@ -127,7 +130,7 @@ const JsonFieldElemental = ({
         </p>
       )
     case 'Attachment':
-      return <JsonFieldAttachment jsonField={jsonField} {...rest} />
+      return <JsonFieldAttachment jsonField={jsonField} parentName={parentName} {...rest} />
   }
 }
 

--- a/administration/src/bp-modules/applications/JsonFieldView.tsx
+++ b/administration/src/bp-modules/applications/JsonFieldView.tsx
@@ -16,7 +16,7 @@ export type JsonFieldValueByType = {
   String: string
   Number: number
   Boolean: boolean
-  Attachment: { fileIndex: number }
+  Attachment: { fileIndex: number; parentName?: string }
   Date: string
 }
 

--- a/administration/src/bp-modules/applications/JsonFieldView.tsx
+++ b/administration/src/bp-modules/applications/JsonFieldView.tsx
@@ -16,7 +16,7 @@ export type JsonFieldValueByType = {
   String: string
   Number: number
   Boolean: boolean
-  Attachment: { fileIndex: number; parentName?: string }
+  Attachment: { fileIndex: number }
   Date: string
 }
 

--- a/administration/src/mui-modules/application/forms/BlueCardEntitlementForm.tsx
+++ b/administration/src/mui-modules/application/forms/BlueCardEntitlementForm.tsx
@@ -21,11 +21,11 @@ import WorkAtOrganizationsEntitlementForm from './WorkAtOrganizationsEntitlement
 const EntitlementTypeRadioGroupForm = createRadioGroupForm<BlueCardEntitlementType>()
 const entitlementTypeOptions: { labelByValue: { [K in BlueCardEntitlementType]: string } } = {
   labelByValue: {
-    [BlueCardEntitlementType.WorkAtOrganizations]: i18next.t('application:blueCardEntitlementType.WorkAtOrganizations'),
-    [BlueCardEntitlementType.Juleica]: i18next.t('application:blueCardEntitlementType.Juleica'),
-    [BlueCardEntitlementType.WorkAtDepartment]: i18next.t('application:blueCardEntitlementType.WorkAtDepartment'),
-    [BlueCardEntitlementType.MilitaryReserve]: i18next.t('application:blueCardEntitlementType.MilitaryReserve'),
-    [BlueCardEntitlementType.VolunteerService]: i18next.t('application:blueCardEntitlementType.VolunteerService'),
+    [BlueCardEntitlementType.WorkAtOrganizations]: i18next.t('application:blueCardWorkAtOrganizationsEntitlement'),
+    [BlueCardEntitlementType.Juleica]: i18next.t('application:blueCardJuleicaEntitlement'),
+    [BlueCardEntitlementType.WorkAtDepartment]: i18next.t('application:blueCardWorkAtDepartmentEntitlement'),
+    [BlueCardEntitlementType.MilitaryReserve]: i18next.t('application:blueCardMilitaryReserveEntitlement'),
+    [BlueCardEntitlementType.VolunteerService]: i18next.t('application:volunteerServiceEntitlement:title'),
   },
 }
 

--- a/administration/src/mui-modules/application/forms/GoldenCardEntitlementForm.tsx
+++ b/administration/src/mui-modules/application/forms/GoldenCardEntitlementForm.tsx
@@ -19,14 +19,12 @@ import WorkAtOrganizationsEntitlementForm from './WorkAtOrganizationsEntitlement
 
 const entitlementTypeOptions: { labelByValue: { [K in GoldenCardEntitlementType]: string } } = {
   labelByValue: {
-    [GoldenCardEntitlementType.WorkAtOrganizations]: i18next.t(
-      'application:goldenCardEntitlementType.WorkAtOrganizations'
-    ),
+    [GoldenCardEntitlementType.WorkAtOrganizations]: i18next.t('application:goldenCardWorkAtOrganizationsEntitlement'),
     [GoldenCardEntitlementType.HonoredByMinisterPresident]: i18next.t(
-      'application:goldenCardEntitlementType.HonoredByMinisterPresident'
+      'application:goldenCardHonoredByMinisterPresidentEntitlement:title'
     ),
-    [GoldenCardEntitlementType.WorkAtDepartment]: i18next.t('application:goldenCardEntitlementType.WorkAtDepartment'),
-    [GoldenCardEntitlementType.MilitaryReserve]: i18next.t('application:goldenCardEntitlementType.MilitaryReserve'),
+    [GoldenCardEntitlementType.WorkAtDepartment]: i18next.t('application:goldenCardWorkAtDepartmentEntitlement'),
+    [GoldenCardEntitlementType.MilitaryReserve]: i18next.t('application:goldenCardMilitaryReserveEntitlement'),
   },
 }
 

--- a/administration/src/util/translations/de.json
+++ b/administration/src/util/translations/de.json
@@ -20,16 +20,25 @@
     "wantsDigitalCard": "Ich beantrage eine digitale Ehrenamtskarte",
     "wantsPhysicalCard": "Ich beantrage eine physische Ehrenamtskarte",
     "blueCardJuleicaEntitlement": "Ich bin Inhaber:in einer JuLeiCa (Jugendleiter:in-Card)",
-    "blueCardWorkAtDepartmentEntitlement": "Ich bin aktiv in der Freiwilligen Feuerwehr mit abgeschlossener Truppmannausbildung bzw. abgeschlossenem Basis-Modul der Modularen Truppausbildung (MTA), oder im Katastrophenschutz oder im Rettungsdienst mit abgeschlossener Grundausbildung",
-    "blueCardMilitaryReserveEntitlement": "Ich habe in den vergangenen zwei Kalenderjahren als Reservist regelmäßig aktiven Wehrdienst in der Bundeswehr geleistet, indem ich insgesamt mindestens 40 Tage Reservisten-Dienstleistung erbracht habe oder ständige:r Angehörige:r eines Bezirks- oder Kreisverbindungskommandos war",
-    "blueCardWorkAtOrganizationsEntitlement": "Ich engagiere mich ehrenamtlich seit mindestens zwei Jahren freiwillig mindestens fünf Stunden pro Woche oder bei Projektarbeiten mindestens 250 Stunden jährlich",
+    "blueCardWorkAtDepartmentEntitlement": "Ich bin aktiv in der Freiwilligen Feuerwehr mit abgeschlossener Truppmannausbildung bzw. abgeschlossenem Basis-Modul der Modularen Truppausbildung (MTA), oder im Katastrophenschutz oder im Rettungsdienst mit abgeschlossener Grundausbildung.",
+    "blueCardMilitaryReserveEntitlement": "Ich habe in den vergangenen zwei Kalenderjahren als Reservist regelmäßig aktiven Wehrdienst in der Bundeswehr geleistet, indem ich insgesamt mindestens 40 Tage Reservisten-Dienstleistung erbracht habe oder ständige:r Angehörige:r eines Bezirks- oder Kreisverbindungskommandos war.",
+    "blueCardWorkAtOrganizationsEntitlement": "Ich engagiere mich ehrenamtlich seit mindestens zwei Jahren freiwillig mindestens fünf Stunden pro Woche oder bei Projektarbeiten mindestens 250 Stunden jährlich.",
+    "volunteerServiceEntitlement": {
+      "title": "Ich leiste einen Freiwilligendienst ab in einem Freiwilligen Sozialen Jahr (FSJ), einem Freiwilligen Ökologischen Jahr (FÖJ) oder einem Bundesfreiwilligendienst (BFD).",
+      "programName": "Name des Programms",
+      "certificate": "Tätigkeitsnachweis"
+    },
     "juleicaNumber": "Kartennummer",
     "juleicaExpiration": "Karte gültig bis",
     "copyOfJuleicaFront": "Kopie der Karte (1)",
     "copyOfJuleicaBack": "Kopie der Karte (2)",
-    "goldenCardWorkAtOrganizationsEntitlement": "Ich bin seit mindestens 25 Jahren mindestens 5 Stunden pro Woche oder 250 Stunden pro Jahr bei einem Verein oder einer Organisation ehrenamtlich tätig",
-    "goldenCardWorkAtDepartmentEntitlement": "Ich bin Feuerwehrdienstleistende:r oder Einsatzkraft im Rettungsdienst oder in Einheiten des Katastrophenschutzes und habe eine Dienstzeitauszeichnung nach dem Feuerwehr- und Hilfsorganisationen-Ehrenzeichengesetz (FwHOEzG) erhalten",
+    "goldenCardWorkAtOrganizationsEntitlement": "Ich bin seit mindestens 25 Jahren mindestens 5 Stunden pro Woche oder 250 Stunden pro Jahr bei einem Verein oder einer Organisation ehrenamtlich tätig.",
+    "goldenCardWorkAtDepartmentEntitlement": "Ich bin Feuerwehrdienstleistende:r oder Einsatzkraft im Rettungsdienst oder in Einheiten des Katastrophenschutzes und habe eine Dienstzeitauszeichnung nach dem Feuerwehr- und Hilfsorganisationen-Ehrenzeichengesetz (FwHOEzG) erhalten.",
     "goldenCardMilitaryReserveEntitlement": "Ich leiste als Reservist:in seit mindestens 25 Jahren regelmäßig aktiven Wehrdienst in der Bundeswehr, indem ich in dieser Zeit entweder insgesamt mindestens 500 Tage Reservisten-Dienstleistung erbracht habe oder in dieser Zeit ständige:r Angehörige:r eines Bezirks- oder Kreisverbindungskommandos war.",
+    "goldenCardHonoredByMinisterPresidentEntitlement": {
+      "title": "Ich bin Inhaber:in des Ehrenzeichens für Verdienste im Ehrenamt des Bayerischen Ministerpräsidenten",
+      "certificate": "Kopie der Urkunde"
+    },
     "workAtOrganization": "Arbeit bei Organisation oder Verein",
     "organization": {
       "title": "Angaben zur Organisation",
@@ -54,28 +63,6 @@
     "givenInformationIsCorrectAndComplete": "Ich versichere, dass alle angegebenen Informationen korrekt und vollständig sind",
     "title": "Bayerische Ehrenamtskarte beantragen",
     "sentSuccessfully": "Erfolgreich gesendet",
-    "sentError": "Fehler beim Senden",
-    "blueCardEntitlementType": {
-      "WorkAtOrganizations": "Ich engagiere mich ehrenamtlich seit mindestens zwei Jahren freiwillig mindestens fünf Stunden pro Woche oder bei Projektarbeiten mindestens 250 Stunden jährlich.",
-      "Juleica": "Ich bin Inhaber:in einer JuLeiCa (Jugendleiter:in-Card).",
-      "WorkAtDepartment": "Ich bin aktiv in der Freiwilligen Feuerwehr mit abgeschlossener Truppmannausbildung bzw. abgeschlossenem Basis-Modul der Modularen Truppausbildung (MTA), oder im Katastrophenschutz oder im Rettungsdienst mit abgeschlossener Grundausbildung.",
-      "MilitaryReserve": "Ich habe in den vergangenen zwei Kalenderjahren als Reservist regelmäßig aktiven Wehrdienst in der Bundeswehr geleistet, indem ich insgesamt mindestens 40 Tage Reservisten-Dienstleistung erbracht habe oder ständige:r Angehörige:r eines Bezirks- oder Kreisverbindungskommandos war.",
-      "VolunteerService": "Ich leiste einen Freiwilligendienst ab in einem Freiwilligen Sozialen Jahr (FSJ), einem Freiwilligen Ökologischen Jahr (FÖJ) oder einem Bundesfreiwilligendienst (BFD)."
-    },
-    "goldenCardEntitlementType": {
-      "WorkAtOrganizations": "Ich bin seit mindestens 25 Jahren mindestens 5 Stunden pro Woche oder 250 Stunden pro Jahr bei einem Verein oder einer Organisation ehrenamtlich tätig.",
-      "HonoredByMinisterPresident": "Ich bin Inhaber:in des Ehrenzeichens für Verdienste im Ehrenamt des Bayerischen Ministerpräsidenten.",
-      "WorkAtDepartment": "Ich bin Feuerwehrdienstleistende:r oder Einsatzkraft im Rettungsdienst oder in Einheiten des Katastrophenschutzes und habe eine Dienstzeitauszeichnung nach dem Feuerwehr- und Hilfsorganisationen-Ehrenzeichengesetz (FwHOEzG) erhalten.",
-      "MilitaryReserve": "Ich leiste als Reservist:in seit mindestens 25 Jahren regelmäßig aktiven Wehrdienst in der Bundeswehr, indem ich in dieser Zeit entweder insgesamt mindestens 500 Tage Reservisten-Dienstleistung erbracht habe oder in dieser Zeit ständige:r Angehörige:r eines Bezirks- oder Kreisverbindungskommandos war."
-    },
-    "volunteerServiceEntitlement": {
-      "title": "Ich leiste einen Freiwilligendienst ab in einem Freiwilligen Sozialen Jahr (FSJ), einem Freiwilligen Ökologischen Jahr (FÖJ) oder einem Bundesfreiwilligendienst (BFD)",
-      "programName": "Name des Programms",
-      "certificate": "Tätigkeitsnachweis"
-    },
-    "goldenCardHonoredByMinisterPresidentEntitlement": {
-      "title": "Ich bin Inhaber:in des Ehrenzeichens für Verdienste im Ehrenamt des Bayerischen Ministerpräsidenten",
-      "certificate": "Kopie der Urkunde"
-    }
+    "sentError": "Fehler beim Senden"
   }
 }

--- a/administration/src/util/translations/de.json
+++ b/administration/src/util/translations/de.json
@@ -19,7 +19,7 @@
     "applicationType": "Art des Antrags",
     "wantsDigitalCard": "Ich beantrage eine digitale Ehrenamtskarte",
     "wantsPhysicalCard": "Ich beantrage eine physische Ehrenamtskarte",
-    "blueCardJuleicaEntitlement": "Ich bin Inhaber:in einer JuLeiCa (Jugendleiter:in-Card)",
+    "blueCardJuleicaEntitlement": "Ich bin Inhaber:in einer JuLeiCa (Jugendleiter:in-Card).",
     "blueCardWorkAtDepartmentEntitlement": "Ich bin aktiv in der Freiwilligen Feuerwehr mit abgeschlossener Truppmannausbildung bzw. abgeschlossenem Basis-Modul der Modularen Truppausbildung (MTA), oder im Katastrophenschutz oder im Rettungsdienst mit abgeschlossener Grundausbildung.",
     "blueCardMilitaryReserveEntitlement": "Ich habe in den vergangenen zwei Kalenderjahren als Reservist regelmäßig aktiven Wehrdienst in der Bundeswehr geleistet, indem ich insgesamt mindestens 40 Tage Reservisten-Dienstleistung erbracht habe oder ständige:r Angehörige:r eines Bezirks- oder Kreisverbindungskommandos war.",
     "blueCardWorkAtOrganizationsEntitlement": "Ich engagiere mich ehrenamtlich seit mindestens zwei Jahren freiwillig mindestens fünf Stunden pro Woche oder bei Projektarbeiten mindestens 250 Stunden jährlich.",
@@ -36,7 +36,7 @@
     "goldenCardWorkAtDepartmentEntitlement": "Ich bin Feuerwehrdienstleistende:r oder Einsatzkraft im Rettungsdienst oder in Einheiten des Katastrophenschutzes und habe eine Dienstzeitauszeichnung nach dem Feuerwehr- und Hilfsorganisationen-Ehrenzeichengesetz (FwHOEzG) erhalten.",
     "goldenCardMilitaryReserveEntitlement": "Ich leiste als Reservist:in seit mindestens 25 Jahren regelmäßig aktiven Wehrdienst in der Bundeswehr, indem ich in dieser Zeit entweder insgesamt mindestens 500 Tage Reservisten-Dienstleistung erbracht habe oder in dieser Zeit ständige:r Angehörige:r eines Bezirks- oder Kreisverbindungskommandos war.",
     "goldenCardHonoredByMinisterPresidentEntitlement": {
-      "title": "Ich bin Inhaber:in des Ehrenzeichens für Verdienste im Ehrenamt des Bayerischen Ministerpräsidenten",
+      "title": "Ich bin Inhaber:in des Ehrenzeichens für Verdienste im Ehrenamt des Bayerischen Ministerpräsidenten.",
       "certificate": "Kopie der Urkunde"
     },
     "workAtOrganization": "Arbeit bei Organisation oder Verein",

--- a/administration/src/util/translations/de.json
+++ b/administration/src/util/translations/de.json
@@ -20,11 +20,16 @@
     "wantsDigitalCard": "Ich beantrage eine digitale Ehrenamtskarte",
     "wantsPhysicalCard": "Ich beantrage eine physische Ehrenamtskarte",
     "blueCardJuleicaEntitlement": "Ich bin Inhaber:in einer JuLeiCa (Jugendleiter:in-Card)",
+    "blueCardWorkAtDepartmentEntitlement": "Ich bin aktiv in der Freiwilligen Feuerwehr mit abgeschlossener Truppmannausbildung bzw. abgeschlossenem Basis-Modul der Modularen Truppausbildung (MTA), oder im Katastrophenschutz oder im Rettungsdienst mit abgeschlossener Grundausbildung",
+    "blueCardMilitaryReserveEntitlement": "Ich habe in den vergangenen zwei Kalenderjahren als Reservist regelmäßig aktiven Wehrdienst in der Bundeswehr geleistet, indem ich insgesamt mindestens 40 Tage Reservisten-Dienstleistung erbracht habe oder ständige:r Angehörige:r eines Bezirks- oder Kreisverbindungskommandos war",
+    "blueCardWorkAtOrganizationsEntitlement": "Ich engagiere mich ehrenamtlich seit mindestens zwei Jahren freiwillig mindestens fünf Stunden pro Woche oder bei Projektarbeiten mindestens 250 Stunden jährlich",
     "juleicaNumber": "Kartennummer",
     "juleicaExpiration": "Karte gültig bis",
     "copyOfJuleicaFront": "Kopie der Karte (1)",
     "copyOfJuleicaBack": "Kopie der Karte (2)",
-    "blueCardWorkAtOrganizationsEntitlement": "Ich engagiere mich ehrenamtlich seit mindestens zwei Jahren freiwillig mindestens fünf Stunden pro Woche oder bei Projektarbeiten mindestens 250 Stunden jährlich",
+    "goldenCardWorkAtOrganizationsEntitlement": "Ich bin seit mindestens 25 Jahren mindestens 5 Stunden pro Woche oder 250 Stunden pro Jahr bei einem Verein oder einer Organisation ehrenamtlich tätig",
+    "goldenCardWorkAtDepartmentEntitlement": "Ich bin Feuerwehrdienstleistende:r oder Einsatzkraft im Rettungsdienst oder in Einheiten des Katastrophenschutzes und habe eine Dienstzeitauszeichnung nach dem Feuerwehr- und Hilfsorganisationen-Ehrenzeichengesetz (FwHOEzG) erhalten",
+    "goldenCardMilitaryReserveEntitlement": "Ich leiste als Reservist:in seit mindestens 25 Jahren regelmäßig aktiven Wehrdienst in der Bundeswehr, indem ich in dieser Zeit entweder insgesamt mindestens 500 Tage Reservisten-Dienstleistung erbracht habe oder in dieser Zeit ständige:r Angehörige:r eines Bezirks- oder Kreisverbindungskommandos war.",
     "workAtOrganization": "Arbeit bei Organisation oder Verein",
     "organization": {
       "title": "Angaben zur Organisation",
@@ -59,17 +64,17 @@
     },
     "goldenCardEntitlementType": {
       "WorkAtOrganizations": "Ich bin seit mindestens 25 Jahren mindestens 5 Stunden pro Woche oder 250 Stunden pro Jahr bei einem Verein oder einer Organisation ehrenamtlich tätig.",
-      "HonoredByMinisterPresident": "Ich bin Inhaber:in des Ehrenzeichens für Verdienstete im Ehrenamt des Bayerischen Ministerpräsidenten.",
+      "HonoredByMinisterPresident": "Ich bin Inhaber:in des Ehrenzeichens für Verdienste im Ehrenamt des Bayerischen Ministerpräsidenten.",
       "WorkAtDepartment": "Ich bin Feuerwehrdienstleistende:r oder Einsatzkraft im Rettungsdienst oder in Einheiten des Katastrophenschutzes und habe eine Dienstzeitauszeichnung nach dem Feuerwehr- und Hilfsorganisationen-Ehrenzeichengesetz (FwHOEzG) erhalten.",
       "MilitaryReserve": "Ich leiste als Reservist:in seit mindestens 25 Jahren regelmäßig aktiven Wehrdienst in der Bundeswehr, indem ich in dieser Zeit entweder insgesamt mindestens 500 Tage Reservisten-Dienstleistung erbracht habe oder in dieser Zeit ständige:r Angehörige:r eines Bezirks- oder Kreisverbindungskommandos war."
     },
     "volunteerServiceEntitlement": {
-      "title": "Freiwilligendienst",
+      "title": "Ich leiste einen Freiwilligendienst ab in einem Freiwilligen Sozialen Jahr (FSJ), einem Freiwilligen Ökologischen Jahr (FÖJ) oder einem Bundesfreiwilligendienst (BFD)",
       "programName": "Name des Programms",
       "certificate": "Tätigkeitsnachweis"
     },
-    "honoredByMinisterPresidentEntitlement": {
-      "title": "Ehrenzeichen des Ministerpräsidenten",
+    "goldenCardHonoredByMinisterPresidentEntitlement": {
+      "title": "Ich bin Inhaber:in des Ehrenzeichens für Verdienste im Ehrenamt des Bayerischen Ministerpräsidenten",
       "certificate": "Kopie der Urkunde"
     }
   }


### PR DESCRIPTION
### Short description

Some application labels were not resolved properly

### Proposed changes

<!-- Describe this PR in more detail. -->

- rename i18n keys according to how they will stored in the database to be able to resolve them properly,
- adjust these keys in the form states where they will be set
- fix key of `goldenCardHonoredByMinisterPresidentEntitlement`, 
- consider parents for resolving keys for attachments, 
- fix wrong label (#1852)

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Maybe some attachment labels may be affected so please check all labels of an application card properly

### Testing

1. Create applications with the different requirements, all possible for the blue card and all possible for the golden card
2. Open the application list and check if all application labels were resolved correctly, due to the `de.json`, there were some keys like `certificate` resolved wrong because the parents wasn't used

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1843 
Fixes: #1852
