### PR TITLE
1755: clickable email addresses

### DIFF
--- a/administration/src/bp-modules/EmailLink.tsx
+++ b/administration/src/bp-modules/EmailLink.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react'
 
-import { isEmailValid } from './applications/utils/verificationHelper'
+const EmailLink = ({ email }: { email: string }): ReactElement => <a href={`mailto:${email}`}>{email}</a>
 
-export const EmailLink = (email: string): ReactElement =>
-  isEmailValid(email) ? <a href={`mailto:${email}`}> {email}</a> : <span>{email}</span>
+export default EmailLink

--- a/administration/src/bp-modules/EmailLink.tsx
+++ b/administration/src/bp-modules/EmailLink.tsx
@@ -1,0 +1,6 @@
+import React, { ReactElement } from 'react'
+
+import { isEmailValid } from './applications/utils/verificationHelper'
+
+export const EmailLink = (email: string): ReactElement =>
+  isEmailValid(email) ? <a href={`mailto:${email}`}> {email}</a> : <span>{email}</span>

--- a/administration/src/bp-modules/applications/JsonFieldElemental.tsx
+++ b/administration/src/bp-modules/applications/JsonFieldElemental.tsx
@@ -8,6 +8,7 @@ import downloadDataUri from '../../util/downloadDataUri'
 import { useAppToaster } from '../AppToaster'
 import { printAwareCss } from './ApplicationCard'
 import { GeneralJsonField, JsonField, JsonFieldViewProps } from './JsonFieldView'
+import { isEmailValid } from './utils/verificationHelper'
 
 const extensionByContentType = new Map([
   ['application/pdf', 'pdf'],
@@ -96,7 +97,12 @@ const JsonFieldElemental = ({
     case 'String':
       return (
         <p>
-          {t(getTranslationKey())}: {jsonField.value}
+          {t(getTranslationKey())}:
+          {isEmailValid(jsonField.value) ? (
+            <a href={`mailto:${jsonField.value}`}>{jsonField.value}</a>
+          ) : (
+            jsonField.value
+          )}
         </p>
       )
     case 'Date':

--- a/administration/src/bp-modules/applications/JsonFieldElemental.tsx
+++ b/administration/src/bp-modules/applications/JsonFieldElemental.tsx
@@ -99,7 +99,7 @@ const JsonFieldElemental = ({
         <p>
           {t(getTranslationKey())}:
           {isEmailValid(jsonField.value) ? (
-            <a href={`mailto:${jsonField.value}`}>{jsonField.value}</a>
+            <a href={`mailto:${jsonField.value}`}> {jsonField.value}</a>
           ) : (
             jsonField.value
           )}

--- a/administration/src/bp-modules/applications/JsonFieldElemental.tsx
+++ b/administration/src/bp-modules/applications/JsonFieldElemental.tsx
@@ -6,9 +6,9 @@ import styled from 'styled-components'
 import { AuthContext } from '../../AuthProvider'
 import downloadDataUri from '../../util/downloadDataUri'
 import { useAppToaster } from '../AppToaster'
+import { EmailLink } from '../EmailLink'
 import { printAwareCss } from './ApplicationCard'
 import { GeneralJsonField, JsonField, JsonFieldViewProps } from './JsonFieldView'
-import { isEmailValid } from './utils/verificationHelper'
 
 const extensionByContentType = new Map([
   ['application/pdf', 'pdf'],
@@ -97,12 +97,7 @@ const JsonFieldElemental = ({
     case 'String':
       return (
         <p>
-          {t(getTranslationKey())}:
-          {isEmailValid(jsonField.value) ? (
-            <a href={`mailto:${jsonField.value}`}> {jsonField.value}</a>
-          ) : (
-            jsonField.value
-          )}
+          {t(getTranslationKey())}:{EmailLink(jsonField.value)}
         </p>
       )
     case 'Date':

--- a/administration/src/bp-modules/applications/JsonFieldElemental.tsx
+++ b/administration/src/bp-modules/applications/JsonFieldElemental.tsx
@@ -6,9 +6,10 @@ import styled from 'styled-components'
 import { AuthContext } from '../../AuthProvider'
 import downloadDataUri from '../../util/downloadDataUri'
 import { useAppToaster } from '../AppToaster'
-import { EmailLink } from '../EmailLink'
+import EmailLink from '../EmailLink'
 import { printAwareCss } from './ApplicationCard'
 import { GeneralJsonField, JsonField, JsonFieldViewProps } from './JsonFieldView'
+import { isEmailValid } from './utils/verificationHelper'
 
 const extensionByContentType = new Map([
   ['application/pdf', 'pdf'],
@@ -97,7 +98,8 @@ const JsonFieldElemental = ({
     case 'String':
       return (
         <p>
-          {t(getTranslationKey())}:{EmailLink(jsonField.value)}
+          {t(getTranslationKey())}:{' '}
+          {isEmailValid(jsonField.value) ? <EmailLink email={jsonField.value} /> : <span>{jsonField.value}</span>}
         </p>
       )
     case 'Date':

--- a/administration/src/bp-modules/applications/VerificationsView.tsx
+++ b/administration/src/bp-modules/applications/VerificationsView.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement } from 'react'
 import styled from 'styled-components'
 
 import { GetApplicationsQuery } from '../../generated/graphql'
+import { isEmailValid } from './utils/verificationHelper'
 
 const StyledIndicator = styled.span`
   display: inline-block;
@@ -99,7 +100,11 @@ const VerificationsView = ({ verifications }: { verifications: Application['veri
                 </tr>
                 <tr>
                   <td>Email:</td>
-                  <td>{verification.contactEmailAddress}</td>
+                  {isEmailValid(verification.contactEmailAddress) ? (
+                    <a href={`mailto:${verification.contactEmailAddress}`}>{verification.contactEmailAddress}</a>
+                  ) : (
+                    <td>{verification.contactEmailAddress}</td>
+                  )}
                 </tr>
                 <tr>
                   <td>Status:</td>

--- a/administration/src/bp-modules/applications/VerificationsView.tsx
+++ b/administration/src/bp-modules/applications/VerificationsView.tsx
@@ -3,7 +3,8 @@ import React, { ReactElement } from 'react'
 import styled from 'styled-components'
 
 import { GetApplicationsQuery } from '../../generated/graphql'
-import { EmailLink } from '../EmailLink'
+import EmailLink from '../EmailLink'
+import { isEmailValid } from './utils/verificationHelper'
 
 const StyledIndicator = styled.span`
   display: inline-block;
@@ -100,7 +101,13 @@ const VerificationsView = ({ verifications }: { verifications: Application['veri
                 </tr>
                 <tr>
                   <td>Email:</td>
-                  <td>{EmailLink(verification.contactEmailAddress)}</td>
+                  <td>
+                    {isEmailValid(verification.contactEmailAddress) ? (
+                      <EmailLink email={verification.contactEmailAddress} />
+                    ) : (
+                      <span>{verification.contactEmailAddress}</span>
+                    )}
+                  </td>
                 </tr>
                 <tr>
                   <td>Status:</td>

--- a/administration/src/bp-modules/applications/VerificationsView.tsx
+++ b/administration/src/bp-modules/applications/VerificationsView.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement } from 'react'
 import styled from 'styled-components'
 
 import { GetApplicationsQuery } from '../../generated/graphql'
-import { isEmailValid } from './utils/verificationHelper'
+import { EmailLink } from '../EmailLink'
 
 const StyledIndicator = styled.span`
   display: inline-block;
@@ -100,11 +100,7 @@ const VerificationsView = ({ verifications }: { verifications: Application['veri
                 </tr>
                 <tr>
                   <td>Email:</td>
-                  {isEmailValid(verification.contactEmailAddress) ? (
-                    <a href={`mailto:${verification.contactEmailAddress}`}>{verification.contactEmailAddress}</a>
-                  ) : (
-                    <td>{verification.contactEmailAddress}</td>
-                  )}
+                  <td>{EmailLink(verification.contactEmailAddress)}</td>
                 </tr>
                 <tr>
                   <td>Status:</td>

--- a/administration/src/bp-modules/applications/utils/verificationHelper.ts
+++ b/administration/src/bp-modules/applications/utils/verificationHelper.ts
@@ -1,0 +1,1 @@
+export const isEmailValid = (email: string): boolean => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)

--- a/administration/src/bp-modules/applications/utils/verificationHelper.tsx
+++ b/administration/src/bp-modules/applications/utils/verificationHelper.tsx
@@ -1,0 +1,4 @@
+export const isEmailValid = (email: string): boolean => {
+  const pattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  return pattern.test(email)
+}

--- a/administration/src/bp-modules/applications/utils/verificationHelper.tsx
+++ b/administration/src/bp-modules/applications/utils/verificationHelper.tsx
@@ -1,4 +1,0 @@
-export const isEmailValid = (email: string): boolean => {
-  const pattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-  return pattern.test(email)
-}


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
The e-mail addresses should be clickable so that they do not have to be copied and pasted.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Modifying `JsonFieldElemental` to check string if its a valid email address to show is as a `mail:to` link.
- `verificationHelper.tsx` having the regex for email verification function at `bp-modules/applications/utils`

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- `JsonFieldElemental.tsx` modified.

### Testing
- Create an application for a specific region
- Login with regionAdmin or regionManager of that specific region
- Check application if mail addresses are clickable


Fixes: #1755 
