### PR TITLE
1865: Custom application created confirmation mail

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/EakApplicationMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/EakApplicationMutationService.kt
@@ -41,6 +41,7 @@ class EakApplicationMutationService {
 
         if (isPreVerified) {
             applicationHandler.setApplicationVerificationToPreVerifiedNow(verificationEntities)
+            applicationHandler.sendPreVerifiedApplicationMails(applicationEntity, verificationEntities, dataFetcherResultBuilder)
         } else {
             applicationHandler.sendApplicationMails(applicationEntity, verificationEntities, dataFetcherResultBuilder)
         }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/utils/ApplicationHandler.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/utils/ApplicationHandler.kt
@@ -62,6 +62,30 @@ class ApplicationHandler(
         Mailer.sendNotificationForApplicationMails(project, backendConfig, projectConfig, regionId)
     }
 
+    fun sendPreVerifiedApplicationMails(
+        applicationEntity: ApplicationEntity,
+        verificationEntities: List<ApplicationVerificationEntity>,
+        dataFetcherResultBuilder: DataFetcherResult.Builder<Boolean>
+    ) {
+        val backendConfig = context.backendConfiguration
+        val projectConfig = backendConfig.projects.first { it.id == project }
+
+        for (applicationVerification in verificationEntities) {
+            try {
+                Mailer.sendApplicationMailToContactPerson(
+                    backendConfig,
+                    projectConfig,
+                    applicationVerification.contactName,
+                    application.personalData,
+                    applicationEntity.accessKey
+                )
+            } catch (exception: MailNotSentException) {
+                dataFetcherResultBuilder.error(exception.toError())
+            }
+        }
+        Mailer.sendNotificationForApplicationMails(project, backendConfig, projectConfig, regionId)
+    }
+
     fun validateAttachmentTypes() {
         val allowedContentTypes = setOf("application/pdf", "image/png", "image/jpeg")
         val maxFileSizeBytes = 5 * 1000 * 1000

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/mail/Mailer.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/mail/Mailer.kt
@@ -19,7 +19,7 @@ import java.nio.charset.StandardCharsets
 
 object Mailer {
     private const val DO_NOT_ANSWER_MESSAGE =
-        "Dies ist eine automatisierte Nachricht. Bitte antworten Sie nicht auf diese Email."
+        "Bitte beachten Sie, dass dies eine automatisierte Nachricht ist. Antworten auf diese E-Mail werden nicht gelesen."
 
     private fun EmailBody.adjustNotificationsParagraph(projectConfig: ProjectConfig) {
         p {
@@ -199,6 +199,36 @@ object Mailer {
                 link(URL("${projectConfig.administrationBaseUrl}/antrag-einsehen/${urlEncode(accessKey)}"))
             }
             p { +"Bei Rückfragen zum Bearbeitungsstand wenden Sie sich bitte an Ihr örtliches Landratsamt bzw. die Verwaltung Ihrer kreisfreien Stadt." }
+            p { +DO_NOT_ANSWER_MESSAGE }
+            p { +"- ${projectConfig.administrationName}" }
+        }
+        sendMail(
+            backendConfig,
+            projectConfig.smtp,
+            projectConfig.administrationName,
+            personalData.emailAddress.email,
+            subject,
+            message
+        )
+    }
+
+    fun sendApplicationMailToContactPerson(
+        backendConfig: BackendConfiguration,
+        projectConfig: ProjectConfig,
+        contactPerson: String,
+        personalData: PersonalData,
+        accessKey: String
+    ) {
+        val subject = "Antrag erfolgreich eingereicht"
+        val message = emailBody {
+            p { +"Sehr geehrte/r $contactPerson," }
+            p { +"Ihr Antrag auf die Bayerische Ehrenamtskarte für ${personalData.forenames.shortText} ${personalData.surname.shortText} wurde erfolgreich eingereicht." }
+            p {
+                +"Den aktuellen Status Ihres Antrags können sie jederzeit unter folgendem Link einsehen. Dort haben Sie auch die Möglichkeit, Ihren Antrag bei Bedarf zurückzuziehen:"
+                br()
+                link(URL("${projectConfig.administrationBaseUrl}/antrag-einsehen/${urlEncode(accessKey)}"))
+            }
+            p { +"Bei Rückfragen wenden Sie sich bitte direkt an Ihr zuständiges Landratsamt oder die Verwaltung Ihrer kreisfreien Stadt." }
             p { +DO_NOT_ANSWER_MESSAGE }
             p { +"- ${projectConfig.administrationName}" }
         }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/mail/Mailer.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/mail/Mailer.kt
@@ -18,8 +18,16 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 object Mailer {
-    private const val DO_NOT_ANSWER_MESSAGE =
-        "Bitte beachten Sie, dass dies eine automatisierte Nachricht ist. Antworten auf diese E-Mail werden nicht gelesen."
+    private fun EmailBody.finalInformationParagraph(projectConfig: ProjectConfig) {
+        p {
+            +"Bitte beachten Sie, dass dies eine automatisierte Nachricht ist. Antworten auf diese E-Mail werden nicht gelesen."
+            br()
+            br()
+            +"Mit freundlichen Grüßen"
+            br()
+            +"- ${projectConfig.administrationName}"
+        }
+    }
 
     private fun EmailBody.adjustNotificationsParagraph(projectConfig: ProjectConfig) {
         p {
@@ -98,8 +106,7 @@ object Mailer {
             p { +"ein neuer Antrag liegt in ${projectConfig.administrationName} vor." }
             viewApplicationsParagraph(projectConfig)
             adjustNotificationsParagraph(projectConfig)
-            p { +DO_NOT_ANSWER_MESSAGE }
-            p { +"- ${projectConfig.administrationName}" }
+            finalInformationParagraph(projectConfig)
         }
 
         for (recipient: AdministratorEntity in recipients) {
@@ -129,8 +136,7 @@ object Mailer {
             p { +"ein Antrag wurde verifiziert." }
             viewApplicationsParagraph(projectConfig)
             adjustNotificationsParagraph(projectConfig)
-            p { +DO_NOT_ANSWER_MESSAGE }
-            p { +"- ${projectConfig.administrationName}" }
+            finalInformationParagraph(projectConfig)
         }
 
         for (recipient: AdministratorEntity in recipients) {
@@ -169,8 +175,7 @@ object Mailer {
                 br()
                 link(verificationLink)
             }
-            p { +DO_NOT_ANSWER_MESSAGE }
-            p { +"- ${projectConfig.administrationName}" }
+            finalInformationParagraph(projectConfig)
         }
 
         sendMail(
@@ -199,8 +204,7 @@ object Mailer {
                 link(URL("${projectConfig.administrationBaseUrl}/antrag-einsehen/${urlEncode(accessKey)}"))
             }
             p { +"Bei Rückfragen zum Bearbeitungsstand wenden Sie sich bitte an Ihr örtliches Landratsamt bzw. die Verwaltung Ihrer kreisfreien Stadt." }
-            p { +DO_NOT_ANSWER_MESSAGE }
-            p { +"- ${projectConfig.administrationName}" }
+            finalInformationParagraph(projectConfig)
         }
         sendMail(
             backendConfig,
@@ -229,8 +233,7 @@ object Mailer {
                 link(URL("${projectConfig.administrationBaseUrl}/antrag-einsehen/${urlEncode(accessKey)}"))
             }
             p { +"Bei Rückfragen wenden Sie sich bitte direkt an Ihr zuständiges Landratsamt oder die Verwaltung Ihrer kreisfreien Stadt." }
-            p { +DO_NOT_ANSWER_MESSAGE }
-            p { +"- ${projectConfig.administrationName}" }
+            finalInformationParagraph(projectConfig)
         }
         sendMail(
             backendConfig,
@@ -260,8 +263,7 @@ object Mailer {
                 link(URL("${projectConfig.administrationBaseUrl}/reset-password?email=$encodedRecipient&token=$encodedResetKey"))
             }
             p { +"Dieser Link ist 24 Stunden gültig." }
-            p { +DO_NOT_ANSWER_MESSAGE }
-            p { +"- ${projectConfig.administrationName}" }
+            finalInformationParagraph(projectConfig)
         }
 
         sendMail(
@@ -296,8 +298,7 @@ object Mailer {
                 link(URL(passwordResetLink))
             }
             p { +"Dieser Link ist 24 Stunden gültig." }
-            p { +DO_NOT_ANSWER_MESSAGE }
-            p { +"- ${projectConfig.administrationName}" }
+            finalInformationParagraph(projectConfig)
         }
 
         sendMail(
@@ -334,8 +335,7 @@ object Mailer {
                 +"Hinweis: Die Vorab-Aktivierung wird nicht von allen Endgeräten unterstützt. "
                 +"Falls der Vorgang fehlschlägt, warten Sie bitte auf das offizielle Schreiben."
             }
-            p { +DO_NOT_ANSWER_MESSAGE }
-            p { +"- ${projectConfig.administrationName}" }
+            finalInformationParagraph(projectConfig)
         }
 
         sendMail(


### PR DESCRIPTION
### Short description

As a trainer from verein360, i want to receive a confirmation mail for my application i sent for an applicatant.
Background: For verein360 not the applicant him/herself creates application but the trainer for him/her.
So the confirmation mail should not be send to the applicant but to the creator of the application in this case the trainer.

### Proposed changes

<!-- Describe this PR in more detail. -->

- if the application was send by verein360 and is pre verified send an e mail to the contact person/trainer of the organization.

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

- send an application request (graphiql or postman) using a mail address as contact person that you own (to check that you receive the mail)
- Example for an graphql mutation you can find here: https://github.com/digitalfabrik/entitlementcard/pull/1863

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1865 
