### PR TITLE
1850: Fix multi card activation

### DIFF
--- a/frontend/lib/identification/user_code_model.dart
+++ b/frontend/lib/identification/user_code_model.dart
@@ -95,7 +95,7 @@ void _updateUserCode(List<DynamicUserCode> userCodes, DynamicUserCode userCode) 
 }
 
 bool isAlreadyInList(List<DynamicUserCode> userCodes, CardInfo info, List<int> pepper) {
-  return userCodes.any((userCode) => userCode.info == info && userCode.pepper == pepper);
+  return userCodes.any((userCode) => userCode.info == info && listEquals(userCode.pepper, pepper));
 }
 
 bool hasReachedCardLimit(List<DynamicUserCode> userCodes) {


### PR DESCRIPTION
### Short description

This pr fixes the issue that the same card could be activated twice on the same device, even the first card is changing to an invalid state. Basically if the same card is already activated on this device, the user shouldn't be able to activate it again.

### Proposed changes

<!-- Describe this PR in more detail. -->

- add a deep equality check for the peppers lists ton ensure same cards are correctly identified

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. Create a card for nuernberg or koblenz (where multiple cards can be activated)
2. Activate the card once. Then use the same qr code and try to activate the same card
3. There should be a message, that the card is already activated on your device

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1850
