### PR TITLE
Fix Application Form: Do not allow jumping to next step if a previous…

### DIFF
--- a/administration/src/mui-modules/application/SteppedSubForms.tsx
+++ b/administration/src/mui-modules/application/SteppedSubForms.tsx
@@ -115,7 +115,7 @@ const SteppedSubForms = ({
     for (let i = 0; i < index; i++) {
       if (subForms[i].validate().type === 'error') {
         setActiveStep(() => i)
-        break
+        return
       }
     }
     setActiveStep(() => index)


### PR DESCRIPTION
… step contains invalid data

### Short description

Fix Application Form: Do not allow jumping to next step if a previous…

### Proposed changes

Fix the bug that was introduced by a huge refactor :D

### Side effects

None

### Testing

Navigating to a step in the application form should no longer be possible if there is invalid data.

### Resolved issues

Fixes: #1859
