### PR TITLE
1660: Handle apollo errors

### DIFF
--- a/administration/src/bp-modules/components/TextAreaDialog.tsx
+++ b/administration/src/bp-modules/components/TextAreaDialog.tsx
@@ -2,7 +2,7 @@ import { Button, Dialog, DialogFooter, TextArea, Tooltip } from '@blueprintjs/co
 import React, { ReactElement, useState } from 'react'
 import styled from 'styled-components'
 
-import defaultErrorMap from '../../errors/DefaultErrorMap'
+import graphQlErrorMap from '../../errors/GraphQlErrorMap'
 import { GraphQlExceptionCode } from '../../generated/graphql'
 
 const CharacterCounter = styled.div<{ $hasError: boolean }>`
@@ -37,7 +37,7 @@ const TextAreaDialog = ({
 }: NoteProps): ReactElement => {
   const [text, setText] = useState<string>(defaultText ?? '')
   const maxCharsExceeded = maxChars === undefined ? false : text.length > maxChars
-  const { title: errorMessage } = defaultErrorMap({
+  const { title: errorMessage } = graphQlErrorMap({
     code: GraphQlExceptionCode.InvalidNoteSize,
     maxSize: maxChars,
   })

--- a/administration/src/bp-modules/regions/data-privacy-policy/DataPrivacyOverview.tsx
+++ b/administration/src/bp-modules/regions/data-privacy-policy/DataPrivacyOverview.tsx
@@ -3,7 +3,7 @@ import React, { ReactElement, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
 
-import defaultErrorMap from '../../../errors/DefaultErrorMap'
+import graphQlErrorMap from '../../../errors/GraphQlErrorMap'
 import getMessageFromApolloError from '../../../errors/getMessageFromApolloError'
 import { GraphQlExceptionCode, useUpdateDataPolicyMutation } from '../../../generated/graphql'
 import { useAppToaster } from '../../AppToaster'
@@ -54,7 +54,7 @@ const DataPrivacyOverview = ({ dataPrivacyPolicy, regionId }: RegionOverviewProp
 
   const onSave = () => updateDataPrivacy({ variables: { regionId, text: dataPrivacyText } })
 
-  const { title: errorMessage } = defaultErrorMap({
+  const { title: errorMessage } = graphQlErrorMap({
     code: GraphQlExceptionCode.InvalidDataPolicySize,
     maxSize: MAX_CHARS,
   })

--- a/administration/src/errors/DefaultErrorMap.ts
+++ b/administration/src/errors/DefaultErrorMap.ts
@@ -1,0 +1,24 @@
+import { ApolloError } from '@apollo/client'
+
+import { GraphQLErrorMessage } from './getMessageFromApolloError'
+
+const defaultErrorMap = (error: ApolloError): GraphQLErrorMessage => {
+  if (error.message.includes('401')) {
+    return { title: 'Nicht autorisiert' }
+  }
+  if (error.message.includes('403')) {
+    return { title: 'Fehlende Berechtigung' }
+  }
+  if (error.message.includes('404')) {
+    return { title: 'Seite nicht gefunden' }
+  }
+  if (error.message.includes('500')) {
+    return { title: 'Interner Fehler aufgetreten' }
+  }
+  if (error.message.includes('501')) {
+    return { title: 'Funktion nicht verfügbar' }
+  }
+  return { title: 'Server nicht erreichbar' }
+}
+
+export default defaultErrorMap

--- a/administration/src/errors/GraphQlErrorMap.tsx
+++ b/administration/src/errors/GraphQlErrorMap.tsx
@@ -20,7 +20,7 @@ type ErrorExtensions = {
   [key: string]: unknown
 }
 
-const defaultErrorMap = (extensions?: ErrorExtensions): GraphQLErrorMessage => {
+const graphQlErrorMap = (extensions?: ErrorExtensions): GraphQLErrorMessage => {
   const defaultError = { title: 'Etwas ist schief gelaufen.' }
 
   if (!extensions || extensions.code === undefined) {
@@ -128,4 +128,4 @@ const defaultErrorMap = (extensions?: ErrorExtensions): GraphQLErrorMessage => {
   }
 }
 
-export default defaultErrorMap
+export default graphQlErrorMap

--- a/administration/src/errors/getMessageFromApolloError.tsx
+++ b/administration/src/errors/getMessageFromApolloError.tsx
@@ -2,27 +2,22 @@ import { ApolloError } from '@apollo/client'
 import { ReactElement } from 'react'
 
 import defaultErrorMap from './DefaultErrorMap'
+import graphQlErrorMap from './GraphQlErrorMap'
 
-type GraphQLErrorMessage = {
+export type GraphQLErrorMessage = {
   title: string
   description?: string | ReactElement
 }
 
 const getMessageFromApolloError = (error: ApolloError): GraphQLErrorMessage => {
-  const defaultMessage = 'Etwas ist schief gelaufen.'
-
-  if (error.networkError) {
-    return { title: 'Server nicht erreichbar.' }
-  }
-
   const codesEqual = error.graphQLErrors.every(
     (value, index, array) => value.extensions!.code === array[0].extensions!.code
   )
   if (error.graphQLErrors.length < 1 || (error.graphQLErrors.length > 1 && !codesEqual)) {
-    return { title: defaultMessage }
+    return defaultErrorMap(error)
   }
 
-  return defaultErrorMap(error.graphQLErrors[0].extensions)
+  return graphQlErrorMap(error.graphQLErrors[0].extensions)
 }
 
 export default getMessageFromApolloError


### PR DESCRIPTION
### Short description

We have the issue that all non `GraphlBaseExceptions` will result in the same message to the user and 403 exceptions will be handled as a network error and just result in `Server nicht erreichbar`
### Proposed changes

<!-- Describe this PR in more detail. -->

- remove the check for `networkError` but handle all errors which are not graphql errors in a `defaultErrorMap` and check for the particular error code and send the matching error message
- if non of these error codes were found just then return 'Server nicht erreichbar', because we didn't get any response from the backend (the most probably reason i guess)

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- some error messages may change or not be displayed

### Testing

I'm not pretty sure how to test this on staging because, most of the errors were handled before by not showing the function like `PepperSettings` or `ApiTokenSettings``
As a dev you can follow the instructions in the related issue to test the error messages

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1660 
