### PR TITLE
1880: Adjust imprint for koblenzpass

### DIFF
--- a/frontend/build-configs/bayern/publisherText.ts
+++ b/frontend/build-configs/bayern/publisherText.ts
@@ -1,21 +1,20 @@
-export default `Bayerisches Staatsministerium für Familie, Arbeit und Soziales
-Winzererstraße 9
-80797 München
-
-Telefon: 089 1261-01
-Telefax: 089 1261-1122
-E-Mail: Poststelle@stmas.bayern.de
-
-USt-Identifikations-Nr. gemäß § 27 a Umsatzsteuergesetz: DE - 811335517
-
-Verantwortlich für den Inhalt
-
-Referat Öffentlichkeitsarbeit
-Telefon: 089 1261-01
-E-Mail: Poststelle@stmas.bayern.de
-
-E-Mail zur Ehrenamtskarte: Ehrenamtskarte@stmas.bayern.de
-
-Technische Umsetzung:
-Tür an Tür - Digitalfabrik gemeinnützige GmbH
-https://tuerantuer.de/digitalfabrik/`
+export default `<h4>Bayerisches Staatsministerium für Familie, Arbeit und Soziales</h4>
+<p>Winzererstraße 9<br>
+80797 München</p>
+<p>Telefon: 089 1261-01<br>
+Telefax: 089 1261-1122<br>
+E-Mail: <a href="mailto:poststelle@stmas.bayern.de">poststelle@stmas.bayern.de</a></p>
+<p>USt-Identifikations-Nr. gemäß § 27 a Umsatzsteuergesetz: DE - 811335517</p>
+<br>
+<br>
+<h4>Verantwortlich für den Inhalt:</h4>
+<p>Referat Öffentlichkeitsarbeit<br>
+Telefon: 089 1261-01<br>
+E-Mail: <a href="mailto:poststelle@stmas.bayern.de">poststelle@stmas.bayern.de</a></p>
+<p>E-Mail zur Ehrenamtskarte: <a href="mailto:ehrenamtskarte@stmas.bayern.de">ehrenamtskarte@stmas.bayern.de</a></p>
+<br>
+<br>
+<h4>Technische Umsetzung:</h4>
+<p>Tür an Tür - Digitalfabrik gemeinnützige GmbH<br>
+<a href="https://tuerantuer.de/digitalfabrik">https://tuerantuer.de/digitalfabrik</a></p>
+`

--- a/frontend/build-configs/koblenz/disclaimerText.ts
+++ b/frontend/build-configs/koblenz/disclaimerText.ts
@@ -1,5 +1,4 @@
-export default `
-Als Dienstanbieter der App „KoblenzPass“ ist die Stadt Koblenz gemäß § 7 Abs.1 DDG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 DDG ist sie als Dienstanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen.
+export default `Als Dienstanbieter der App „KoblenzPass“ ist die Stadt Koblenz gemäß § 7 Abs.1 DDG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 DDG ist sie als Dienstanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen.
 
 Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden von entsprechenden Rechtsverletzungen wird die Stadt Koblenz diese Inhalte umgehend entfernen.
 

--- a/frontend/build-configs/koblenz/publisherText.ts
+++ b/frontend/build-configs/koblenz/publisherText.ts
@@ -3,6 +3,8 @@ export default `<p>Die App „KoblenzPass“ ist eine Kooperation zwischen der S
 <li>Inhalte: Amt für Jugend, Familie, Senioren und Soziales der Stadt Koblenz</li>
 <li>Applikation und Betrieb: Tür an Tür - Digitalfabrik gemeinnützige GmbH</li>
 </ul>
+<br>
+<br>
 <h4>Stadt Koblenz, Amt für Jugend, Familie, Senioren und Soziales</h4>
 <p>Die Stadt Koblenz ist eine Körperschaft des Öffentlichen Rechts. Sie wird vertreten durch den Oberbürgermeister.</p>
 <p>Rathauspassage 2<br>
@@ -12,6 +14,8 @@ E-Mail: <a href="mailto:koblenzpass@stadt.koblenz.de">koblenzpass@stadt.koblenz.
 <a href="https://koblenz.de/koblenzpass">https://koblenz.de/koblenzpass</a></p>
 <p>Tel.: +49 (0)261 129-0 (Telefonservice)<br>
 Ust.-ID: DE148721830</p>
+<br>
+<br>
 <h4>Tür an Tür - Digitalfabrik gemeinnützige GmbH</h4>
 <p>Vertreten durch die Geschäftsführer Clara Bracklo und Daniel Kehne.</p>
 <p>Wertachstraße 29<br>

--- a/frontend/build-configs/koblenz/publisherText.ts
+++ b/frontend/build-configs/koblenz/publisherText.ts
@@ -1,31 +1,24 @@
-export default `Herausgegeben von:
-
-Stadt Koblenz
-
-Willi-Hörter-Platz 1
-56068 Koblenz
-Tel.: +49 (0)261 129-0 (Telefonservice)
-Fax: +49 (0)261 129-1300
-
-E-Mail für rechtsverbindliche elektronische Kommunikation:
-stadt-koblenz@poststelle.rlp.de
-E-Mail für unverbindliche Anfragen und Auskünfte:
-poststelle@stadt.koblenz.de
-Die Stadt Koblenz ist eine Körperschaft des Öffentlichen Rechts. Sie wird vertreten durch den Oberbürgermeister.
-UST-Ident.-Nummer der Stadt Koblenz: DE148721830
-
-Verantwortlich für den Inhalt:
-Stadt Koblenz
-Amt für Jugend, Familie, Senioren und Soziales
-Rathauspassage 2
-56068 Koblenz
-sozialamt@stadt.koblenz.de
-Tel: +49 (0)261 129-0 (Telefonservice)
-Aus Koblenz unter der Telefonnummer 115 zu erreichen
-
-Technische Umsetzung:
-Tür an Tür – Digitalfabrik gemeinnützige GmbH
-Wertachstr. 29
-86153 Augsburg
-https://tuerantuer.de/digitalfabrik
+export default `<p>Die App „KoblenzPass“ ist eine Kooperation zwischen der Stadt Koblenz und der Tür an Tür - Digitalfabrik gGmbH. Die Bereiche teilen sich wie folgt auf:</p>
+<ul>
+<li>Inhalte: Amt für Jugend, Familie, Senioren und Soziales der Stadt Koblenz</li>
+<li>Applikation und Betrieb: Tür an Tür - Digitalfabrik gemeinnützige GmbH</li>
+</ul>
+<h4>Stadt Koblenz, Amt für Jugend, Familie, Senioren und Soziales</h4>
+<p>Die Stadt Koblenz ist eine Körperschaft des Öffentlichen Rechts. Sie wird vertreten durch den Oberbürgermeister.</p>
+<p>Rathauspassage 2<br>
+56068 Koblenz</p>
+<p>E-Mail für elektronische Kommunikation die App betreffend:<br>
+E-Mail: <a href="mailto:koblenzpass@stadt.koblenz.de">koblenzpass@stadt.koblenz.de</a><br>
+<a href="https://koblenz.de/koblenzpass">https://koblenz.de/koblenzpass</a></p>
+<p>Tel.: +49 (0)261 129-0 (Telefonservice)<br>
+Ust.-ID: DE148721830</p>
+<h4>Tür an Tür - Digitalfabrik gemeinnützige GmbH</h4>
+<p>Vertreten durch die Geschäftsführer Clara Bracklo und Daniel Kehne.</p>
+<p>Wertachstraße 29<br>
+86153 Augsburg</p>
+<p>E-Mail: <a href="mailto:berechtigungskarte+koblenz@tuerantuer.org">berechtigungskarte+koblenz@tuerantuer.org</a><br>
+<a href="https://tuerantuer.de/digitalfabrik">https://tuerantuer.de/digitalfabrik</a></p>
+<p>Handelsregister-Gericht: Amtsgericht Augsburg<br>
+Handelsregisternummer: HRB30759<br>
+Ust.-ID: DE307491397</p>
 `

--- a/frontend/lib/about/texts.dart
+++ b/frontend/lib/about/texts.dart
@@ -53,12 +53,10 @@ List<Widget> getPublisherText(BuildContext context) {
     Html(
       data: buildConfig.publisherText,
       style: {
-        'li': Style(
-          padding: HtmlPaddings.only(left: 10),
-        ),
-        'ul': Style(
-          padding: HtmlPaddings.only(left: 20),
-        ),
+        'p': Style(margin: Margins.only(bottom: 10)),
+        'h4': Style(margin: Margins.only(bottom: 10)),
+        'li': Style(padding: HtmlPaddings.only(left: 10)),
+        'ul': Style(padding: HtmlPaddings.only(left: 20)),
       },
       onLinkTap: (url, attributes, element) {
         if (url != null) {

--- a/frontend/lib/about/texts.dart
+++ b/frontend/lib/about/texts.dart
@@ -1,5 +1,7 @@
 import 'package:ehrenamtskarte/build_config/build_config.dart' show buildConfig;
 import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 @immutable
 class Paragraph {
@@ -47,9 +49,22 @@ List<Widget> getDisclaimerText(BuildContext context) {
 }
 
 List<Widget> getPublisherText(BuildContext context) {
-  return toWidgets(Theme.of(context), [
-    Paragraph(
-      content: buildConfig.publisherText,
-    )
-  ]);
+  return [
+    Html(
+      data: buildConfig.publisherText,
+      style: {
+        'li': Style(
+          padding: HtmlPaddings.only(left: 10),
+        ),
+        'ul': Style(
+          padding: HtmlPaddings.only(left: 20),
+        ),
+      },
+      onLinkTap: (url, attributes, element) {
+        if (url != null) {
+          launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+        }
+      },
+    ),
+  ];
 }

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -209,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      sha256: "831883fb353c8bdc1d71979e5b342c7d88acfbc643113c14ae51e2442ea0f20f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.17.3"
   csv:
     dependency: transitive
     description:
@@ -325,6 +333,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.18.6"
+  flutter_html:
+    dependency: "direct main"
+    description:
+      name: flutter_html
+      sha256: "02ad69e813ecfc0728a455e4bf892b9379983e050722b1dce00192ee2e41d1ee"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0-beta.2"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -588,6 +604,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      sha256: "3a7812d5bcd2894edf53dfaf8cd640876cf6cef50a8f238745c8b8120ea74d3a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.15.4"
   http:
     dependency: "direct main"
     description:
@@ -716,6 +740,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  list_counter:
+    dependency: transitive
+    description:
+      name: list_counter
+      sha256: c447ae3dfcd1c55f0152867090e67e219d42fe6d4f2807db4bbe8b8d69912237
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   logging:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   carousel_slider: ^5.0.0
   slang: ^4.2.1
   slang_flutter: ^4.2.0
+  flutter_html: ^3.0.0-beta.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
### Short description
Adjust publisher text for Koblenz in accordance with https://nextcloud.tuerantuer.org/index.php/f/6531153

### Proposed changes
- adjusted publisher text for Koblenz
- updated getPublisherText() function to use flutter_html library
- added formatting for all publisher texts (bayern, koblenz, nürnberg) and made all links and emails clickable

### Side effects
Only tested on Android, please check for iOs

### Testing
Check the publisher text in the app:
Über -> Mehr Informationen

### Resolved issues
Fixes: #1880
