### PR TITLE
1882: Fix translations override

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -31,7 +31,9 @@ Future<void> main() async {
   // Use override locales for whitelabels (e.g. nuernberg)
   // ignore: unnecessary_null_comparison
   if (buildConfig.localeOverridePath != null) {
-    AppLocale.values.forEach(overrideLocale);
+    await Future.forEach(AppLocale.values, (locale) async {
+      await overrideLocale(locale);
+    });
   }
 
   debugPrint('Environment: $appEnvironment');


### PR DESCRIPTION
### Short description
There is an error in the log when launching the Nürnberg app
```
TypeError: Null check operator used on a null value
  File "singleton.dart", line 504, in LocaleSettingsExt.overrideTranslations
  File "translations.g.dart", line 174, in LocaleSettings.overrideTranslations
  File "main.dart", line 66, in overrideLocale
```
This also means that one of the languages was not loaded correctly and the default translation was used.

### Proposed changes
I guess it’s related to asynchronous processing.
I have added ‘await’ to the overrideLocale() call and it seems to help.

### Side effects
Hopefully none

### Testing
- Check that the translations for each application are loaded properly (overrides are applied in the app)
- Check the language change for Nürnberg (About -> Settings -> Change language)

### Resolved issues
Fixes: #1882
