### PR TITLE
1880: Use flutter_html for all legal texts

### DIFF
--- a/frontend/build-configs/bayern/disclaimerText.ts
+++ b/frontend/build-configs/bayern/disclaimerText.ts
@@ -1,20 +1,14 @@
-export default `Verantwortlich im Sinne § 7 TMG:
-Referat Öffentlichkeitsarbeit
-Telefon: 089 1261-01
-E-Mail: Poststelle@stmas.bayern.de
-Haftung im Sinne §§ 7 - 10 TMG
-
-Das Bayerische Staatsministerium für Arbeit und Soziales, Familie und Integration stellt sein App-Angebot unter folgenden Nutzungsbedingungen zur Verfügung:
-
-• Die App "Ehrenamtskarte" ist nach § 7 Abs. 1 TMG für die eigenen Inhalte, die es zur Nutzung bereithält, nach den allgemeinen Vorschriften verantwortlich. Die Haftung für Schäden materieller oder ideeller Art, die durch die Nutzung der Inhalte verursacht wurden, ist ausgeschlossen, sofern nicht Vorsatz oder grobe Fahrlässigkeit vorliegt.
-Bei der Zusammenstellung und Abgabe der Informationen von Vergünstigungen wird alle Sorgfalt walten gelassen. Eine Gewähr für die inhaltliche Vollständigkeit und Richtigkeit der Daten kann dennoch nicht übernommen werden. Insbesondere wird jede Haftung für solche Schäden ausgeschlossen, die bei Anwendern direkt oder indirekt daraus entstehen, dass die Daten genutzt werden.
-
-• Soweit ein Text von dritter Seite erstellt ist, wird die jeweilige Verfasserin oder der jeweilige Verfasser oder die verantwortliche Einrichtung namentlich benannt. In diesen Fällen ist die Verfasserin oder der Verfasser bzw. die genannte Einrichtung des jeweiligen Dokuments für den Inhalt verantwortlich.
-
-• Die App "Ehrenamtskarte" bewertet den Inhalt der verzeichneten Web-Sites zum Zeitpunkt ihrer Aufnahme in das Verzeichnis sorgfältig, und es werden nur solche Verweise aufgenommen, deren Inhalt nach Prüfung zum Zeitpunkt der Aufnahme nicht gegen geltendes Recht verstößt.
-
-• Die App "Ehrenamtskarte" macht sich den Inhalt der zugänglich gemachten fremden Websites jedoch ausdrücklich nicht zu Eigen. Die Inhalte der Sites, auf die verwiesen wird, können sich ständig ändern - das macht gerade das Wesen eines WWW-Angebots aus. Aus diesem Grund übernimmt die App "Ehrenamtskarte" trotz Prüfung keine Gewähr für die Korrektheit, Vollständigkeit und Verfügbarkeit der jeweiligen fremden Website.
-
-• Die App "Ehrenamtskarte" hat keinen Einfluss auf die aktuelle und zukünftige Gestaltung und Inhalte der Seiten.
-
-• Die App "Ehrenamtskarte" übernimmt keine Haftung für Schäden, die aus der Benutzung der Links entstehen könnten.`
+export default `<p>Verantwortlich im Sinne § 7 TMG:</p>
+<p>Referat Öffentlichkeitsarbeit<br>
+Telefon: 089 1261-01<br>
+E-Mail: <a href="mailto:poststelle@stmas.bayern.de">poststelle@stmas.bayern.de</a><br>
+Haftung im Sinne §§ 7 - 10 TMG</p>
+<p>Das Bayerische Staatsministerium für Arbeit und Soziales, Familie und Integration stellt sein App-Angebot unter folgenden Nutzungsbedingungen zur Verfügung:</p>
+<p>• Die App "Ehrenamtskarte" ist nach § 7 Abs. 1 TMG für die eigenen Inhalte, die es zur Nutzung bereithält, nach den allgemeinen Vorschriften verantwortlich. Die Haftung für Schäden materieller oder ideeller Art, die durch die Nutzung der Inhalte verursacht wurden, ist ausgeschlossen, sofern nicht Vorsatz oder grobe Fahrlässigkeit vorliegt.
+Bei der Zusammenstellung und Abgabe der Informationen von Vergünstigungen wird alle Sorgfalt walten gelassen. Eine Gewähr für die inhaltliche Vollständigkeit und Richtigkeit der Daten kann dennoch nicht übernommen werden. Insbesondere wird jede Haftung für solche Schäden ausgeschlossen, die bei Anwendern direkt oder indirekt daraus entstehen, dass die Daten genutzt werden.</p>
+<p>• Soweit ein Text von dritter Seite erstellt ist, wird die jeweilige Verfasserin oder der jeweilige Verfasser oder die verantwortliche Einrichtung namentlich benannt. In diesen Fällen ist die Verfasserin oder der Verfasser bzw. die genannte Einrichtung des jeweiligen Dokuments für den Inhalt verantwortlich.</p>
+<p>• Die App "Ehrenamtskarte" bewertet den Inhalt der verzeichneten Web-Sites zum Zeitpunkt ihrer Aufnahme in das Verzeichnis sorgfältig, und es werden nur solche Verweise aufgenommen, deren Inhalt nach Prüfung zum Zeitpunkt der Aufnahme nicht gegen geltendes Recht verstößt.</p>
+<p>• Die App "Ehrenamtskarte" macht sich den Inhalt der zugänglich gemachten fremden Websites jedoch ausdrücklich nicht zu Eigen. Die Inhalte der Sites, auf die verwiesen wird, können sich ständig ändern - das macht gerade das Wesen eines WWW-Angebots aus. Aus diesem Grund übernimmt die App "Ehrenamtskarte" trotz Prüfung keine Gewähr für die Korrektheit, Vollständigkeit und Verfügbarkeit der jeweiligen fremden Website.</p>
+<p>• Die App "Ehrenamtskarte" hat keinen Einfluss auf die aktuelle und zukünftige Gestaltung und Inhalte der Seiten.</p>
+<p>• Die App "Ehrenamtskarte" übernimmt keine Haftung für Schäden, die aus der Benutzung der Links entstehen könnten.</p>
+`

--- a/frontend/build-configs/koblenz/disclaimerText.ts
+++ b/frontend/build-configs/koblenz/disclaimerText.ts
@@ -1,10 +1,12 @@
-export default `Als Dienstanbieter der App „KoblenzPass“ ist die Stadt Koblenz gemäß § 7 Abs.1 DDG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 DDG ist sie als Dienstanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen.
-
-Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden von entsprechenden Rechtsverletzungen wird die Stadt Koblenz diese Inhalte umgehend entfernen.
-
-Soweit die App „KoblenzPass“ Links zu externen Websites Dritter enthält wird darauf hingewiesen, dass die Stadt Koblenz auf deren Inhalt keinen Einfluss hat. Für diese fremden Inhalte wird daher keine Gewähr übernommen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten wurden zum Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar.
-
-Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht möglich. Bei Bekanntwerden von Rechtsverletzungen wird die Stadt Koblenz derartige Links umgehend entfernen.
-
-Die Stadt Koblenz übernimmt keine Haftung für Schäden, die aus der Benutzung der Links entstehen könnten.
+export default `<p>Als Dienstanbieter der App „KoblenzPass“ ist die Stadt Koblenz gemäß § 7 Abs.1 DDG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. 
+Nach §§ 8 bis 10 DDG ist sie als Dienstanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen.</p>
+<p>Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. 
+Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich. 
+Bei Bekanntwerden von entsprechenden Rechtsverletzungen wird die Stadt Koblenz diese Inhalte umgehend entfernen.</p>
+<p>Soweit die App „KoblenzPass“ Links zu externen Websites Dritter enthält wird darauf hingewiesen, dass die Stadt Koblenz auf deren Inhalt keinen Einfluss hat. 
+Für diese fremden Inhalte wird daher keine Gewähr übernommen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. 
+Die verlinkten Seiten wurden zum Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar.</p>
+<p>Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht möglich. 
+Bei Bekanntwerden von Rechtsverletzungen wird die Stadt Koblenz derartige Links umgehend entfernen.</p>
+<p>Die Stadt Koblenz übernimmt keine Haftung für Schäden, die aus der Benutzung der Links entstehen könnten.</p>
 `

--- a/frontend/build-configs/nuernberg/disclaimerText.ts
+++ b/frontend/build-configs/nuernberg/disclaimerText.ts
@@ -1,22 +1,18 @@
-export default `Verantwortlich im Sinne § 7 TMG:
-Volker Wolfrum
-Leiter Amt für Existenzsicherung und soziale Integration – Sozialamt
-Telefon: 0911 231-2315
-Telefax: 0911 231 4644
-E-Mail: SHA@stadt.nuernberg.de
-Haftung im Sinne §§ 7 - 10 TMG
-
-Das Amt für Existenzsicherung und soziale Integration – Sozialamt der Stadt Nürnberg stellt sein App-Angebot unter folgenden Nutzungsbedingungen zur Verfügung:
-
-• Die App "Nürnberg-Pass" ist nach § 7 Abs. 1 TMG für die eigenen Inhalte, die es zur Nutzung bereithält, nach den allgemeinen Vorschriften verantwortlich. Die Haftung für Schäden materieller oder ideeller Art, die durch die Nutzung der Inhalte verursacht wurden, ist ausgeschlossen, sofern nicht Vorsatz oder grobe Fahrlässigkeit vorliegt.
-Bei der Zusammenstellung und Abgabe der Informationen von Vergünstigungen wird alle Sorgfalt walten gelassen. Eine Gewähr für die inhaltliche Vollständigkeit und Richtigkeit der Daten kann dennoch nicht übernommen werden. Insbesondere wird jede Haftung für solche Schäden ausgeschlossen, die bei Anwendern direkt oder indirekt daraus entstehen, dass die Daten genutzt werden.
-
-• Soweit ein Text von dritter Seite erstellt ist, wird die jeweilige Verfasserin oder der jeweilige Verfasser oder die verantwortliche Einrichtung namentlich benannt. In diesen Fällen ist die Verfasserin oder der Verfasser bzw. die genannte Einrichtung des jeweiligen Dokuments für den Inhalt verantwortlich.
-
-• Die App "Nürnberg-Pass" bewertet den Inhalt der verzeichneten Web-Sites zum Zeitpunkt ihrer Aufnahme in das Verzeichnis sorgfältig, und es werden nur solche Verweise aufgenommen, deren Inhalt nach Prüfung zum Zeitpunkt der Aufnahme nicht gegen geltendes Recht verstößt.
-
-• Die App "Nürnberg-Pass" macht sich den Inhalt der zugänglich gemachten fremden Websites jedoch ausdrücklich nicht zu Eigen. Die Inhalte der Sites, auf die verwiesen wird, können sich ständig ändern - das macht gerade das Wesen eines WWW-Angebots aus. Aus diesem Grund übernimmt die App "Nürnberg-Pass" trotz Prüfung keine Gewähr für die Korrektheit, Vollständigkeit und Verfügbarkeit der jeweiligen fremden Website.
-
-• Die App "Nürnberg-Pass" hat keinen Einfluss auf die aktuelle und zukünftige Gestaltung und Inhalte der Seiten.
-
-• Die App "Nürnberg-Pass" übernimmt keine Haftung für Schäden, die aus der Benutzung der Links entstehen könnten.`
+export default `<p>Verantwortlich im Sinne § 7 TMG:</p>
+</p>Volker Wolfrum<br>
+Leiter Amt für Existenzsicherung und soziale Integration – Sozialamt<br>
+Telefon: 0911 231-2315<br>
+Telefax: 0911 231 4644<br>
+E-Mail: <a href="mailto:SHA@stadt.nuernberg.de">SHA@stadt.nuernberg.de</a><br>
+Haftung im Sinne §§ 7 - 10 TMG</p>
+<br>
+<br>
+<p>Das Amt für Existenzsicherung und soziale Integration – Sozialamt der Stadt Nürnberg stellt sein App-Angebot unter folgenden Nutzungsbedingungen zur Verfügung:</p>
+<p>• Die App "Nürnberg-Pass" ist nach § 7 Abs. 1 TMG für die eigenen Inhalte, die es zur Nutzung bereithält, nach den allgemeinen Vorschriften verantwortlich. Die Haftung für Schäden materieller oder ideeller Art, die durch die Nutzung der Inhalte verursacht wurden, ist ausgeschlossen, sofern nicht Vorsatz oder grobe Fahrlässigkeit vorliegt.
+Bei der Zusammenstellung und Abgabe der Informationen von Vergünstigungen wird alle Sorgfalt walten gelassen. Eine Gewähr für die inhaltliche Vollständigkeit und Richtigkeit der Daten kann dennoch nicht übernommen werden. Insbesondere wird jede Haftung für solche Schäden ausgeschlossen, die bei Anwendern direkt oder indirekt daraus entstehen, dass die Daten genutzt werden.</p>
+<p>• Soweit ein Text von dritter Seite erstellt ist, wird die jeweilige Verfasserin oder der jeweilige Verfasser oder die verantwortliche Einrichtung namentlich benannt. In diesen Fällen ist die Verfasserin oder der Verfasser bzw. die genannte Einrichtung des jeweiligen Dokuments für den Inhalt verantwortlich.</p>
+<p>• Die App "Nürnberg-Pass" bewertet den Inhalt der verzeichneten Web-Sites zum Zeitpunkt ihrer Aufnahme in das Verzeichnis sorgfältig, und es werden nur solche Verweise aufgenommen, deren Inhalt nach Prüfung zum Zeitpunkt der Aufnahme nicht gegen geltendes Recht verstößt.</p>
+<p>• Die App "Nürnberg-Pass" macht sich den Inhalt der zugänglich gemachten fremden Websites jedoch ausdrücklich nicht zu Eigen. Die Inhalte der Sites, auf die verwiesen wird, können sich ständig ändern - das macht gerade das Wesen eines WWW-Angebots aus. Aus diesem Grund übernimmt die App "Nürnberg-Pass" trotz Prüfung keine Gewähr für die Korrektheit, Vollständigkeit und Verfügbarkeit der jeweiligen fremden Website.</p>
+<p>• Die App "Nürnberg-Pass" hat keinen Einfluss auf die aktuelle und zukünftige Gestaltung und Inhalte der Seiten.</p>
+<p>• Die App "Nürnberg-Pass" übernimmt keine Haftung für Schäden, die aus der Benutzung der Links entstehen könnten.</p>
+`

--- a/frontend/lib/about/texts.dart
+++ b/frontend/lib/about/texts.dart
@@ -3,67 +3,55 @@ import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-@immutable
-class Paragraph {
-  const Paragraph({this.title, this.content});
-
-  final String? content;
-  final String? title;
-}
-
-List<Widget> toWidgets(ThemeData theme, List<Paragraph> paragraphs) {
-  return paragraphs
-      .map((e) {
-        final title = e.title;
-        final content = e.content;
-        return [
-          if (title != null) Text(title, style: theme.textTheme.titleLarge),
-          if (content != null) Text(content, style: theme.textTheme.bodyLarge)
-        ];
-      })
-      .expand((i) => i)
-      .toList();
-}
-
 List<Widget> getCopyrightText(BuildContext context) {
-  return toWidgets(Theme.of(context), [
-    const Paragraph(
-      content: '''
-Der Quelltext dieser App ist unter der MIT Lizenz veröffentlicht und kann unter https://github.com/digitalfabrik/entitlementcard eingesehen werden.
-
-MIT License
-
-Copyright (c) 2021 The Entitlementcard Contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.''',
-    )
-  ]);
+  const content = '''
+  <p>Der Quelltext dieser App ist unter der MIT Lizenz veröffentlicht und kann unter https://github.com/digitalfabrik/entitlementcard eingesehen werden.</p>
+  <p>MIT License</p>
+  <p>Copyright (c) 2021 The Entitlementcard Contributors</p>
+  <p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+  <p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
+  <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
+  ''';
+  return [
+    Html(
+      data: content,
+      style: _getHtmlStyle(),
+    ),
+  ];
 }
 
 List<Widget> getDisclaimerText(BuildContext context) {
-  return toWidgets(Theme.of(context), [Paragraph(content: buildConfig.disclaimerText)]);
+  return [
+    Html(
+      data: buildConfig.disclaimerText,
+      style: _getHtmlStyle(),
+      onLinkTap: (url, attributes, element) => _onLinkTap(url),
+    ),
+  ];
 }
 
 List<Widget> getPublisherText(BuildContext context) {
   return [
     Html(
       data: buildConfig.publisherText,
-      style: {
-        '*': Style(fontSize: FontSize(15), letterSpacing: 0.1),
-        'p': Style(margin: Margins.only(bottom: 10)),
-        'h4': Style(margin: Margins.only(bottom: 10)),
-        'li': Style(padding: HtmlPaddings.only(left: 10)),
-        'ul': Style(padding: HtmlPaddings.only(left: 20)),
-      },
-      onLinkTap: (url, attributes, element) {
-        if (url != null) {
-          launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
-        }
-      },
+      style: _getHtmlStyle(),
+      onLinkTap: (url, attributes, element) => _onLinkTap(url),
     ),
   ];
+}
+
+Map<String, Style> _getHtmlStyle() {
+  return {
+    '*': Style(fontSize: FontSize(15), letterSpacing: 0.1),
+    'p': Style(margin: Margins.only(bottom: 10)),
+    'h4': Style(margin: Margins.only(bottom: 10)),
+    'li': Style(padding: HtmlPaddings.only(left: 10)),
+    'ul': Style(padding: HtmlPaddings.only(left: 20)),
+  };
+}
+
+void _onLinkTap(String? url) {
+  if (url != null) {
+    launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+  }
 }


### PR DESCRIPTION
### Short description
Follow-up for https://github.com/digitalfabrik/entitlementcard/pull/1881
I have changed other legal texts (copyright text, disclaimer text) to html to unify the approach.

### Side effects
Not tested on iOS, but I believe it will look the same as the publisher text.

### Testing
Check the copyright and disclaimer texts in the apps:
Über -> Lizenz
Über -> Haftung, Haftungsausschluss und Impressum

### Resolved issues
N/a
