### PR TITLE
1610: Optimize cards creation performance

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/cards/service/CardActivator.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/cards/service/CardActivator.kt
@@ -6,7 +6,7 @@ import com.eatthepath.otp.TimeBasedOneTimePasswordGenerator
 import javax.crypto.KeyGenerator
 
 object CardActivator {
-    private const val cost = 11
+    private const val cost = 10
 
     @Synchronized
     fun generateTotpSecret(): ByteArray {


### PR DESCRIPTION
### Short Description
We have a performance issue in the staging environment.
When creating cards in bulk (Karten erstellen --> Mehrere Karten importieren), if a csv file contains 300 entries, the request processing time takes almost a minute.
If a user imports multiple large files in parallel, processing may take more than a minute, resulting in a timeout error.

### Proposed Changes
97% of the processing time during the card creation is spent hashing the activation code.
I suggest reducing the hash cost to 10 (this is the default value), this will cut the query processing time in half.

Pls check out the discussion in the issue comments for more details.
The discussion there is still open, so I'm not sure if everyone agrees, but I'm opening this PR as a suggestion to move the task forward anyway.

### Side Effects
The hashing complexity is reduced, but since we're hashing a randomly generated array of bytes, I tend to think it's not a problem.

### Testing
The initial issue from the ticket description can only be reproduced in the staging env.
Locally we can test the following:

1. Login as region admin to bayern 
2. Go to Karten erstellen --> Mehrere Karten importieren
3. Try uploading a large csv file (300 records), see if the processing time is reduced compared to the main branch.

Also can be checked:
- Old cards (created on the previous release version or main branch) can be activated and verified in the app.
- New cards can be created, activated and verified in the app.

### Resolved Issues
Fixes: #1610
