### PR TITLE
1909: Fix circular dependency to use of project config in extensions

### DIFF
--- a/administration/src/App.tsx
+++ b/administration/src/App.tsx
@@ -9,6 +9,7 @@ import { AppToasterProvider } from './bp-modules/AppToaster'
 import useMetaTags from './hooks/useMetaTags'
 import './i18n'
 import { ProjectConfigProvider } from './project-configs/ProjectConfigContext'
+import getProjectConfig from './project-configs/getProjectConfig'
 
 if (!process.env.REACT_APP_API_BASE_URL) {
   throw new Error('REACT_APP_API_BASE_URL is not set!')
@@ -17,7 +18,7 @@ if (!process.env.REACT_APP_API_BASE_URL) {
 const App = (): ReactElement => {
   useMetaTags()
   return (
-    <ProjectConfigProvider>
+    <ProjectConfigProvider projectConfig={getProjectConfig(window.location.hostname)}>
       <AppToasterProvider>
         <AuthProvider>
           <AppApolloProvider>

--- a/administration/src/bp-modules/AppToaster.tsx
+++ b/administration/src/bp-modules/AppToaster.tsx
@@ -1,11 +1,11 @@
 import { OverlayToaster, Position, Toaster } from '@blueprintjs/core'
-import React, { ReactElement, createContext, useContext, useState } from 'react'
+import React, { ReactElement, ReactNode, createContext, useContext, useState } from 'react'
 
 const ToasterContext = createContext<Toaster | null>(null)
 
 export const useAppToaster = (): Toaster | null => useContext(ToasterContext)
 
-export const AppToasterProvider = ({ children }: { children: ReactElement }): ReactElement => {
+export const AppToasterProvider = ({ children }: { children: ReactNode }): ReactElement => {
   const [toaster, setToaster] = useState<OverlayToaster | null>(null)
   return (
     <ToasterContext.Provider value={toaster}>

--- a/administration/src/bp-modules/cards/CreateCardsButtonBar.test.tsx
+++ b/administration/src/bp-modules/cards/CreateCardsButtonBar.test.tsx
@@ -1,16 +1,13 @@
 import { act, fireEvent, render } from '@testing-library/react'
-import React, { ReactNode } from 'react'
+import React from 'react'
 
 import { initializeCard } from '../../cards/Card'
 import { Region } from '../../generated/graphql'
-import { ProjectConfigProvider } from '../../project-configs/ProjectConfigContext'
 import bayernConfig from '../../project-configs/bayern/config'
 import { renderWithTranslation } from '../../testing/render'
 import CreateCardsButtonBar from './CreateCardsButtonBar'
 
 jest.useFakeTimers()
-
-const wrapper = ({ children }: { children: ReactNode }) => <ProjectConfigProvider>{children}</ProjectConfigProvider>
 
 describe('CreateCardsButtonBar', () => {
   const region: Region = {
@@ -29,8 +26,7 @@ describe('CreateCardsButtonBar', () => {
         cards={[]}
         generateCardsPdf={() => Promise.resolve()}
         generateCardsCsv={() => Promise.resolve()}
-      />,
-      { wrapper }
+      />
     )
 
     const backButton = getByText('Zurück zur Auswahl')
@@ -51,8 +47,7 @@ describe('CreateCardsButtonBar', () => {
         cards={[]}
         generateCardsPdf={generateCardsPdf}
         generateCardsCsv={generateCardsCsv}
-      />,
-      { wrapper }
+      />
     )
 
     const generateButton = getByText('QR-Codes drucken').closest('button') as HTMLButtonElement
@@ -79,8 +74,7 @@ describe('CreateCardsButtonBar', () => {
         cards={cards}
         generateCardsPdf={generateCardsPdf}
         generateCardsCsv={generateCardsCsv}
-      />,
-      { wrapper }
+      />
     )
 
     const generateButton = getByText('QR-Codes drucken').closest('button') as HTMLButtonElement
@@ -108,8 +102,7 @@ describe('CreateCardsButtonBar', () => {
         cards={cards}
         generateCardsPdf={generateCardsPdf}
         generateCardsCsv={generateCardsCsv}
-      />,
-      { wrapper }
+      />
     )
 
     const generateButton = getByText('QR-Codes drucken').closest('button') as HTMLButtonElement

--- a/administration/src/bp-modules/cards/ImportCardsInput.test.tsx
+++ b/administration/src/bp-modules/cards/ImportCardsInput.test.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { Region } from '../../generated/graphql'
 import { ProjectConfigProvider } from '../../project-configs/ProjectConfigContext'
 import bayernConfig from '../../project-configs/bayern/config'
-import { ProjectConfig, setProjectConfigOverride } from '../../project-configs/getProjectConfig'
+import { ProjectConfig } from '../../project-configs/getProjectConfig'
 import koblenzConfig from '../../project-configs/koblenz/config'
 import nuernbergConfig from '../../project-configs/nuernberg/config'
 import { renderWithRouter } from '../../testing/render'
@@ -38,11 +38,10 @@ describe('ImportCardsInput', () => {
     } as unknown as FileReader
     jest.spyOn(global, 'FileReader').mockReturnValue(fileReaderMock)
     const file = new File([csv], `${projectConfig.name}.csv`, { type: 'text/csv' })
-    setProjectConfigOverride(projectConfig.projectId)
 
     const { getByTestId } = renderWithRouter(
       <AppToasterProvider>
-        <ProjectConfigProvider>
+        <ProjectConfigProvider projectConfig={projectConfig}>
           <ImportCardsInput setCards={setCards} region={region} />
         </ProjectConfigProvider>
       </AppToasterProvider>

--- a/administration/src/bp-modules/cards/hooks/useCardGenerator.test.tsx
+++ b/administration/src/bp-modules/cards/hooks/useCardGenerator.test.tsx
@@ -10,7 +10,6 @@ import createCards, { CreateCardsError, CreateCardsResult } from '../../../cards
 import deleteCards from '../../../cards/deleteCards'
 import { DynamicActivationCode, StaticVerificationCode } from '../../../generated/card_pb'
 import { Region } from '../../../generated/graphql'
-import { ProjectConfigProvider } from '../../../project-configs/ProjectConfigContext'
 import bayernConfig from '../../../project-configs/bayern/config'
 import downloadDataUri from '../../../util/downloadDataUri'
 import { AppToasterProvider } from '../../AppToaster'
@@ -18,9 +17,7 @@ import useCardGenerator, { CardActivationState } from './useCardGenerator'
 
 const wrapper = ({ children }: { children: ReactNode }) => (
   <AppToasterProvider>
-    <ApolloProvider>
-      <ProjectConfigProvider>{children}</ProjectConfigProvider>
-    </ApolloProvider>
+    <ApolloProvider>{children}</ApolloProvider>
   </AppToasterProvider>
 )
 

--- a/administration/src/bp-modules/self-service/__tests__/CardSelfServiceActivation.test.tsx
+++ b/administration/src/bp-modules/self-service/__tests__/CardSelfServiceActivation.test.tsx
@@ -1,13 +1,10 @@
 import { fireEvent } from '@testing-library/react'
-import React, { ReactNode } from 'react'
+import React from 'react'
 
-import { ProjectConfigProvider } from '../../../project-configs/ProjectConfigContext'
 import { LOCAL_STORAGE_PROJECT_KEY } from '../../../project-configs/constants'
 import koblenzConfig from '../../../project-configs/koblenz/config'
 import { renderWithTranslation } from '../../../testing/render'
 import CardSelfServiceActivation from '../CardSelfServiceActivation'
-
-const wrapper = ({ children }: { children: ReactNode }) => <ProjectConfigProvider>{children}</ProjectConfigProvider>
 
 const downloadPdf = jest.fn()
 const exampleDeepLink = 'example:deeplink'
@@ -16,8 +13,7 @@ describe('CardSelfServiceActivation', () => {
     localStorage.setItem(LOCAL_STORAGE_PROJECT_KEY, koblenzConfig.projectId)
 
     const { getByText } = renderWithTranslation(
-      <CardSelfServiceActivation downloadPdf={downloadPdf} deepLink={exampleDeepLink} />,
-      { wrapper }
+      <CardSelfServiceActivation downloadPdf={downloadPdf} deepLink={exampleDeepLink} />
     )
     expect(getByText('KoblenzPass jetzt aktivieren').getAttribute('href')).toBe(exampleDeepLink)
   })
@@ -26,8 +22,7 @@ describe('CardSelfServiceActivation', () => {
     localStorage.setItem(LOCAL_STORAGE_PROJECT_KEY, koblenzConfig.projectId)
 
     const { getByText } = renderWithTranslation(
-      <CardSelfServiceActivation downloadPdf={downloadPdf} deepLink={exampleDeepLink} />,
-      { wrapper }
+      <CardSelfServiceActivation downloadPdf={downloadPdf} deepLink={exampleDeepLink} />
     )
 
     const downloadPDFButton = getByText('KoblenzPass PDF')

--- a/administration/src/bp-modules/self-service/__tests__/CardSelfServiceForm.test.tsx
+++ b/administration/src/bp-modules/self-service/__tests__/CardSelfServiceForm.test.tsx
@@ -6,7 +6,6 @@ import React, { ReactNode, act } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 
 import { initializeCardFromCSV } from '../../../cards/Card'
-import { ProjectConfigProvider } from '../../../project-configs/ProjectConfigContext'
 import { LOCAL_STORAGE_PROJECT_KEY } from '../../../project-configs/constants'
 import koblenzConfig from '../../../project-configs/koblenz/config'
 import { renderWithTranslation } from '../../../testing/render'
@@ -19,9 +18,7 @@ import FormErrorMessage from '../components/FormErrorMessage'
 const wrapper = ({ children }: { children: ReactNode }) => (
   <LocalizationProvider dateAdapter={AdapterDateFns}>
     <MemoryRouter>
-      <AppToasterProvider>
-        <ProjectConfigProvider>{children}</ProjectConfigProvider>
-      </AppToasterProvider>
+      <AppToasterProvider>{children}</AppToasterProvider>
     </MemoryRouter>
   </LocalizationProvider>
 )

--- a/administration/src/bp-modules/self-service/__tests__/CardSelfServiceInformation.test.tsx
+++ b/administration/src/bp-modules/self-service/__tests__/CardSelfServiceInformation.test.tsx
@@ -1,13 +1,10 @@
 import { fireEvent } from '@testing-library/react'
-import React, { ReactNode } from 'react'
+import React from 'react'
 
-import { ProjectConfigProvider } from '../../../project-configs/ProjectConfigContext'
 import { LOCAL_STORAGE_PROJECT_KEY } from '../../../project-configs/constants'
 import koblenzConfig from '../../../project-configs/koblenz/config'
 import { renderWithTranslation } from '../../../testing/render'
 import CardSelfServiceInformation from '../CardSelfServiceInformation'
-
-const wrapper = ({ children }: { children: ReactNode }) => <ProjectConfigProvider>{children}</ProjectConfigProvider>
 
 const goToActivation = jest.fn()
 
@@ -15,9 +12,7 @@ describe('CardSelfServiceInformation', () => {
   it('should provide a go to activation button', async () => {
     localStorage.setItem(LOCAL_STORAGE_PROJECT_KEY, koblenzConfig.projectId)
 
-    const { getByText } = renderWithTranslation(<CardSelfServiceInformation goToActivation={goToActivation} />, {
-      wrapper,
-    })
+    const { getByText } = renderWithTranslation(<CardSelfServiceInformation goToActivation={goToActivation} />)
 
     const goNextButton = getByText('Weiter zur Aktivierung')
     fireEvent.click(goNextButton)
@@ -27,9 +22,7 @@ describe('CardSelfServiceInformation', () => {
   it('should provide some information texts', async () => {
     localStorage.setItem(LOCAL_STORAGE_PROJECT_KEY, koblenzConfig.projectId)
 
-    const { getByText } = renderWithTranslation(<CardSelfServiceInformation goToActivation={goToActivation} />, {
-      wrapper,
-    })
+    const { getByText } = renderWithTranslation(<CardSelfServiceInformation goToActivation={goToActivation} />)
 
     expect(getByText('Haben sie die App noch nicht?')).toBeTruthy()
     expect(getByText('Laden Sie sie jetzt herunter, um fortzufahren.')).toBeTruthy()

--- a/administration/src/bp-modules/self-service/hooks/__tests__/useCardGeneratorSelfService.test.tsx
+++ b/administration/src/bp-modules/self-service/hooks/__tests__/useCardGeneratorSelfService.test.tsx
@@ -5,7 +5,6 @@ import React, { ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 
 import { ProjectConfigProvider } from '../../../../project-configs/ProjectConfigContext'
-import { LOCAL_STORAGE_PROJECT_KEY } from '../../../../project-configs/constants'
 import koblenzConfig from '../../../../project-configs/koblenz/config'
 import downloadDataUri from '../../../../util/downloadDataUri'
 import { AppToasterProvider } from '../../../AppToaster'
@@ -18,7 +17,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
   <MemoryRouter>
     <AppToasterProvider>
       <MockedProvider mocks={mocks} addTypename={false}>
-        <ProjectConfigProvider>{children}</ProjectConfigProvider>
+        <ProjectConfigProvider projectConfig={koblenzConfig}>{children}</ProjectConfigProvider>
       </MockedProvider>
     </AppToasterProvider>
   </MemoryRouter>
@@ -44,7 +43,6 @@ jest.mock('../../../../util/downloadDataUri')
 describe('useCardGeneratorSelfService', () => {
   it('should successfully create a card', async () => {
     const toasterSpy = jest.spyOn(OverlayToaster.prototype, 'show')
-    localStorage.setItem(LOCAL_STORAGE_PROJECT_KEY, koblenzConfig.projectId)
     mocks.push(mockedCardMutation)
 
     const { result } = renderHook(() => useCardGeneratorSelfService(), { wrapper })

--- a/administration/src/bp-modules/self-service/hooks/useCardGeneratorSelfService.tsx
+++ b/administration/src/bp-modules/self-service/hooks/useCardGeneratorSelfService.tsx
@@ -113,7 +113,7 @@ const useCardGeneratorSelfService = (): UseCardGeneratorSelfServiceReturn => {
       }
       setCode(code)
       setDeepLink(
-        getCustomDeepLinkFromQrCode({
+        getCustomDeepLinkFromQrCode(projectConfig, {
           case: 'dynamicActivationCode',
           value: code.dynamicActivationCode,
         })

--- a/administration/src/bp-modules/stores/__tests__/StoreImportResult.test.tsx
+++ b/administration/src/bp-modules/stores/__tests__/StoreImportResult.test.tsx
@@ -1,18 +1,12 @@
-import React, { ReactNode } from 'react'
+import React from 'react'
 
-import { ProjectConfigProvider } from '../../../project-configs/ProjectConfigContext'
 import { renderWithTranslation } from '../../../testing/render'
 import StoresImportResult from '../StoresImportResult'
-
-const wrapper = ({ children }: { children: ReactNode }) => <ProjectConfigProvider>{children}</ProjectConfigProvider>
 
 describe('StoresImportResult', () => {
   it('should show the correct amount of stores that were affected', () => {
     const { getByTestId } = renderWithTranslation(
-      <StoresImportResult dryRun={false} storesUntouched={5} storesCreated={15} storesDeleted={20} />,
-      {
-        wrapper,
-      }
+      <StoresImportResult dryRun={false} storesUntouched={5} storesCreated={15} storesDeleted={20} />
     )
     expect(getByTestId('storesUntouched').textContent).toBe('5')
     expect(getByTestId('storesCreated').textContent).toBe('15')
@@ -21,20 +15,14 @@ describe('StoresImportResult', () => {
 
   it('should show the correct headline for test import', () => {
     const { getByTestId } = renderWithTranslation(
-      <StoresImportResult dryRun={false} storesUntouched={5} storesCreated={15} storesDeleted={20} />,
-      {
-        wrapper,
-      }
+      <StoresImportResult dryRun={false} storesUntouched={5} storesCreated={15} storesDeleted={20} />
     )
     expect(getByTestId('import-result-headline').textContent).toBe('Der Import der Akzeptanzpartner war erfolgreich!')
   })
 
   it('should show the correct headline for production import', () => {
     const { getByTestId } = renderWithTranslation(
-      <StoresImportResult dryRun storesUntouched={5} storesCreated={15} storesDeleted={20} />,
-      {
-        wrapper,
-      }
+      <StoresImportResult dryRun storesUntouched={5} storesCreated={15} storesDeleted={20} />
     )
     expect(getByTestId('import-result-headline').textContent).toBe(
       'Der Testimport der Akzeptanzpartner war erfolgreich!'

--- a/administration/src/bp-modules/stores/__tests__/StoresButtonBar.test.tsx
+++ b/administration/src/bp-modules/stores/__tests__/StoresButtonBar.test.tsx
@@ -1,7 +1,6 @@
 import { act, fireEvent } from '@testing-library/react'
-import React, { ReactNode } from 'react'
+import React from 'react'
 
-import { ProjectConfigProvider } from '../../../project-configs/ProjectConfigContext'
 import { LOCAL_STORAGE_PROJECT_KEY } from '../../../project-configs/constants'
 import koblenzConfig from '../../../project-configs/koblenz/config'
 import nuernbergConfig from '../../../project-configs/nuernberg/config'
@@ -16,7 +15,6 @@ const setDryRun = jest.fn()
 
 const goBack = jest.fn()
 const importStores = jest.fn()
-const wrapper = ({ children }: { children: ReactNode }) => <ProjectConfigProvider>{children}</ProjectConfigProvider>
 
 describe('StoresButtonBar', () => {
   const projectConfigsWithStoreUpload = [{ projectConfig: nuernbergConfig }, { projectConfig: koblenzConfig }]
@@ -31,10 +29,7 @@ describe('StoresButtonBar', () => {
           goBack={goBack}
           acceptingStores={[]}
           importStores={importStores}
-        />,
-        {
-          wrapper,
-        }
+        />
       )
 
       const backButton = getByText('Zurück zur Auswahl')
@@ -58,10 +53,7 @@ describe('StoresButtonBar', () => {
           goBack={goBack}
           acceptingStores={[]}
           importStores={importStores}
-        />,
-        {
-          wrapper,
-        }
+        />
       )
 
       const importButton = getByText('Importiere Akzeptanzpartner').closest('button') as HTMLButtonElement
@@ -91,8 +83,7 @@ describe('StoresButtonBar', () => {
           goBack={goBack}
           acceptingStores={stores}
           importStores={importStores}
-        />,
-        { wrapper }
+        />
       )
 
       const importButton = getByText('Importiere Akzeptanzpartner').closest('button') as HTMLButtonElement
@@ -123,8 +114,7 @@ describe('StoresButtonBar', () => {
           goBack={goBack}
           acceptingStores={stores}
           importStores={importStores}
-        />,
-        { wrapper }
+        />
       )
 
       const importButton = getAllByText('Importiere Akzeptanzpartner')[0].closest('button') as HTMLButtonElement

--- a/administration/src/bp-modules/stores/__tests__/StoresCSVInput.test.tsx
+++ b/administration/src/bp-modules/stores/__tests__/StoresCSVInput.test.tsx
@@ -4,7 +4,6 @@ import { parse } from 'csv-parse/browser/esm/sync'
 import { mocked } from 'jest-mock'
 import React, { ReactNode } from 'react'
 
-import { ProjectConfigProvider } from '../../../project-configs/ProjectConfigContext'
 import nuernbergConfig from '../../../project-configs/nuernberg/config'
 import { renderWithTranslation } from '../../../testing/render'
 import { AppToasterProvider } from '../../AppToaster'
@@ -19,11 +18,7 @@ const fieldNames = nuernbergConfig.storesManagement.enabled
 jest.mock('csv-parse/browser/esm/sync', () => ({
   parse: jest.fn(),
 }))
-const wrapper = ({ children }: { children: ReactNode }) => (
-  <AppToasterProvider>
-    <ProjectConfigProvider>{children}</ProjectConfigProvider>
-  </AppToasterProvider>
-)
+const wrapper = ({ children }: { children: ReactNode }) => <AppToasterProvider>{children}</AppToasterProvider>
 const setAcceptingStores = jest.fn()
 const setIsLoadingCoordinates = jest.fn()
 

--- a/administration/src/bp-modules/stores/__tests__/StoresImportAlert.test.tsx
+++ b/administration/src/bp-modules/stores/__tests__/StoresImportAlert.test.tsx
@@ -1,19 +1,13 @@
-import React, { ReactNode } from 'react'
+import React from 'react'
 
-import { ProjectConfigProvider } from '../../../project-configs/ProjectConfigContext'
 import { renderWithTranslation } from '../../../testing/render'
 import StoresImportAlert from '../StoresImportAlert'
-
-const wrapper = ({ children }: { children: ReactNode }) => <ProjectConfigProvider>{children}</ProjectConfigProvider>
 
 const setDryRun = jest.fn()
 describe('StoresImportAlert', () => {
   it('should show the correct alert information for dry run', () => {
     const { getByTestId, queryByTestId, getByText } = renderWithTranslation(
-      <StoresImportAlert dryRun setDryRun={setDryRun} storesCount={100} />,
-      {
-        wrapper,
-      }
+      <StoresImportAlert dryRun setDryRun={setDryRun} storesCount={100} />
     )
     const infoSpanElement = getByTestId('dry-run-alert')
     expect(infoSpanElement).toBeTruthy()
@@ -32,10 +26,7 @@ describe('StoresImportAlert', () => {
 
   it('should show the correct alert information for production run', () => {
     const { getByTestId, queryByTestId } = renderWithTranslation(
-      <StoresImportAlert dryRun={false} setDryRun={setDryRun} storesCount={100} />,
-      {
-        wrapper,
-      }
+      <StoresImportAlert dryRun={false} setDryRun={setDryRun} storesCount={100} />
     )
     const infoSpanElement = getByTestId('prod-run-alert')
     expect(infoSpanElement).toBeTruthy()
@@ -48,10 +39,7 @@ describe('StoresImportAlert', () => {
 
   it('should show the correct alert information including approximate duration for production run', () => {
     const { getByTestId } = renderWithTranslation(
-      <StoresImportAlert dryRun={false} setDryRun={setDryRun} storesCount={10000} />,
-      {
-        wrapper,
-      }
+      <StoresImportAlert dryRun={false} setDryRun={setDryRun} storesCount={10000} />
     )
     const infoSpanElement = getByTestId('prod-run-alert')
     expect(infoSpanElement).toBeTruthy()

--- a/administration/src/bp-modules/util/ProjectSwitcher.tsx
+++ b/administration/src/bp-modules/util/ProjectSwitcher.tsx
@@ -2,12 +2,12 @@ import { Button } from '@blueprintjs/core'
 import React, { ReactElement } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { setProjectConfigOverride } from '../../project-configs/getProjectConfig'
+import { LOCAL_STORAGE_PROJECT_KEY } from '../../project-configs/constants'
 
 const ProjectSwitcher = (): ReactElement | null => {
   const navigate = useNavigate()
   const switchProject = (project: string) => {
-    setProjectConfigOverride(project)
+    window.localStorage.setItem(LOCAL_STORAGE_PROJECT_KEY, project)
     navigate(0)
   }
 

--- a/administration/src/project-configs/ProjectConfigContext.tsx
+++ b/administration/src/project-configs/ProjectConfigContext.tsx
@@ -1,12 +1,16 @@
 import React, { ReactElement, ReactNode, createContext } from 'react'
 
-import getProjectConfig, { ProjectConfig } from './getProjectConfig'
+import { ProjectConfig } from './getProjectConfig'
+import showcaseConfig from './showcase/config'
 
-const projectConfig = getProjectConfig(window.location.hostname)
+export const ProjectConfigContext = createContext<ProjectConfig>(showcaseConfig)
 
-export const ProjectConfigContext = createContext<ProjectConfig>(projectConfig)
+type ProjectConfigProviderProps = {
+  children: ReactNode
+  projectConfig: ProjectConfig
+}
 
-export const ProjectConfigProvider = ({ children }: { children: ReactNode }): ReactElement => {
+export const ProjectConfigProvider = ({ children, projectConfig }: ProjectConfigProviderProps): ReactElement => {
   const Provider = ProjectConfigContext.Provider
-  return <Provider value={getProjectConfig(window.location.hostname)}>{children}</Provider>
+  return <Provider value={projectConfig}>{children}</Provider>
 }

--- a/administration/src/project-configs/getProjectConfig.ts
+++ b/administration/src/project-configs/getProjectConfig.ts
@@ -121,10 +121,6 @@ export type ProjectConfig = {
   userImportApiEnabled: boolean
 }
 
-export const setProjectConfigOverride = (hostname: string): void => {
-  window.localStorage.setItem(LOCAL_STORAGE_PROJECT_KEY, hostname)
-}
-
 const getProjectConfig = (hostname: string): ProjectConfig => {
   switch (window.localStorage.getItem(LOCAL_STORAGE_PROJECT_KEY) ?? hostname) {
     case BAYERN_PRODUCTION_ID:

--- a/administration/src/testing/render.tsx
+++ b/administration/src/testing/render.tsx
@@ -1,9 +1,12 @@
-import { RenderOptions, RenderResult, render } from '@testing-library/react'
+import { RenderOptions, RenderResult, render as rawRender } from '@testing-library/react'
 import React, { ReactElement, ReactNode } from 'react'
 import { I18nextProvider } from 'react-i18next'
 import { MemoryRouter } from 'react-router-dom'
 
 import i18n from '../i18n'
+import { ProjectConfigProvider } from '../project-configs/ProjectConfigContext'
+import { ProjectConfig } from '../project-configs/getProjectConfig'
+import showcaseConfig from '../project-configs/showcase/config'
 
 export const renderWithRouter = (ui: ReactElement, options?: RenderOptions): RenderResult => {
   const CustomWrapper = options?.wrapper
@@ -14,15 +17,25 @@ export const renderWithRouter = (ui: ReactElement, options?: RenderOptions): Ren
         </MemoryRouter>
       )
     : MemoryRouter
-  return render(ui, { wrapper })
+  return rawRender(ui, { wrapper })
 }
 
-export const renderWithTranslation = (ui: ReactElement, options?: RenderOptions): RenderResult => {
+type CustomRenderOptions = {
+  projectConfig?: ProjectConfig
+}
+
+export const renderWithTranslation = (
+  ui: ReactElement,
+  options?: RenderOptions & CustomRenderOptions
+): RenderResult => {
   const CustomWrapper = options?.wrapper
+  const projectConfig = options?.projectConfig ?? showcaseConfig
 
   const wrapper = (props: { children: ReactNode }) => (
-    <I18nextProvider i18n={i18n}>{CustomWrapper ? <CustomWrapper {...props} /> : props.children}</I18nextProvider>
+    <ProjectConfigProvider projectConfig={projectConfig}>
+      <I18nextProvider i18n={i18n}>{CustomWrapper ? <CustomWrapper {...props} /> : props.children}</I18nextProvider>
+    </ProjectConfigProvider>
   )
 
-  return render(ui, { wrapper })
+  return rawRender(ui, { wrapper })
 }

--- a/administration/src/util/getCustomDeepLinkFromQrCode.ts
+++ b/administration/src/util/getCustomDeepLinkFromQrCode.ts
@@ -2,12 +2,13 @@ import { ACTIVATION_FRAGMENT, ACTIVATION_PATH } from 'build-configs/constants'
 
 import { PdfQrCode } from '../cards/pdf/PdfQrCodeElement'
 import { QrCode } from '../generated/card_pb'
+import { ProjectConfig } from '../project-configs/getProjectConfig'
 import { uint8ArrayToBase64 } from './base64'
 import { getBuildConfig } from './getBuildConfig'
 
-const getCustomDeepLinkFromQrCode = (qrCode: PdfQrCode): string => {
+const getCustomDeepLinkFromQrCode = (projectConfig: ProjectConfig, qrCode: PdfQrCode): string => {
   const qrCodeContent = new QrCode({ qrCode }).toBinary()
-  const { deepLinking, projectId } = getBuildConfig(window.location.hostname).common
+  const { deepLinking, projectId } = getBuildConfig(projectConfig.projectId).common
   const { production: host } = projectId
   const { customScheme } = deepLinking
   return `${customScheme}://${host}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodeURIComponent(


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Fix circular dependency to allow for use of project config in extensions (including for testing).

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Pass a project config to ProjectContextProvider instead of using getProjectConfig directly
- Adjust the tests to easily set a project config

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

The `setOverrideProject` has been removed as it is unsafe and should be avoided (e.g. for tests).

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Everything should still work for the different projects.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1909 
