### PR TITLE
1799: Refactor useCardGenerator and useCardGeneratorSelfService

### DIFF
--- a/administration/src/bp-modules/cards/AddCardsController.tsx
+++ b/administration/src/bp-modules/cards/AddCardsController.tsx
@@ -9,27 +9,28 @@ import useBlockNavigation from '../../util/useBlockNavigation'
 import AddCardsForm from './AddCardsForm'
 import GenerationFinished from './CardsCreatedMessage'
 import CreateCardsButtonBar from './CreateCardsButtonBar'
-import useCardGenerator, { CardActivationState } from './hooks/useCardGenerator'
+import useCardGenerator from './hooks/useCardGenerator'
 
 const InnerAddCardsController = ({ region }: { region: Region }) => {
   const navigate = useNavigate()
   const { t } = useTranslation('cards')
-  const { state, setState, generateCardsPdf, generateCardsCsv, setCards, updateCard, cards } = useCardGenerator(region)
+  const { cardGenerationStep, setCardGenerationStep, generateCardsPdf, generateCardsCsv, setCards, updateCard, cards } =
+    useCardGenerator({ region })
 
   useBlockNavigation({
     when: cards.length > 0,
     message: t('dataWillBeLostWarning'),
   })
 
-  if (state === CardActivationState.loading) {
+  if (cardGenerationStep === 'loading') {
     return <Spinner />
   }
-  if (state === CardActivationState.finished) {
+  if (cardGenerationStep === 'finished') {
     return (
       <GenerationFinished
         reset={() => {
           setCards([])
-          setState(CardActivationState.input)
+          setCardGenerationStep('input')
         }}
       />
     )

--- a/administration/src/bp-modules/cards/AddCardsController.tsx
+++ b/administration/src/bp-modules/cards/AddCardsController.tsx
@@ -22,7 +22,6 @@ const InnerAddCardsController = ({ region }: { region: Region }) => {
     setCards,
     updateCard,
     cards,
-    applicationIdToMarkAsProcessed,
     setApplicationIdToMarkAsProcessed,
   } = useCardGenerator(region)
 
@@ -57,8 +56,8 @@ const InnerAddCardsController = ({ region }: { region: Region }) => {
       <CreateCardsButtonBar
         cards={cards}
         goBack={() => navigate('/cards')}
-        generateCardsPdf={() => generateCardsPdf(applicationIdToMarkAsProcessed)}
-        generateCardsCsv={() => generateCardsCsv(applicationIdToMarkAsProcessed)}
+        generateCardsPdf={() => generateCardsPdf()}
+        generateCardsCsv={() => generateCardsCsv()}
       />
     </>
   )

--- a/administration/src/bp-modules/cards/AddCardsController.tsx
+++ b/administration/src/bp-modules/cards/AddCardsController.tsx
@@ -14,16 +14,7 @@ import useCardGenerator, { CardActivationState } from './hooks/useCardGenerator'
 const InnerAddCardsController = ({ region }: { region: Region }) => {
   const navigate = useNavigate()
   const { t } = useTranslation('cards')
-  const {
-    state,
-    setState,
-    generateCardsPdf,
-    generateCardsCsv,
-    setCards,
-    updateCard,
-    cards,
-    setApplicationIdToMarkAsProcessed,
-  } = useCardGenerator(region)
+  const { state, setState, generateCardsPdf, generateCardsCsv, setCards, updateCard, cards } = useCardGenerator(region)
 
   useBlockNavigation({
     when: cards.length > 0,
@@ -46,13 +37,7 @@ const InnerAddCardsController = ({ region }: { region: Region }) => {
 
   return (
     <>
-      <AddCardsForm
-        region={region}
-        cards={cards}
-        setCards={setCards}
-        updateCard={updateCard}
-        setApplicationIdToMarkAsProcessed={setApplicationIdToMarkAsProcessed}
-      />
+      <AddCardsForm region={region} cards={cards} setCards={setCards} updateCard={updateCard} />
       <CreateCardsButtonBar
         cards={cards}
         goBack={() => navigate('/cards')}

--- a/administration/src/bp-modules/cards/AddCardsForm.tsx
+++ b/administration/src/bp-modules/cards/AddCardsForm.tsx
@@ -62,10 +62,7 @@ const AddCardsForm = ({
       setCards([initializeCardFromCSV(projectConfig.card, values, headers, region, true)])
 
       const applicationIdToMarkAsProcessed = searchParams.get('applicationIdToMarkAsProcessed')
-      setApplicationIdToMarkAsProcessed(
-        applicationIdToMarkAsProcessed == null ? undefined : +applicationIdToMarkAsProcessed
-      )
-
+      setApplicationIdToMarkAsProcessed(applicationIdToMarkAsProcessed ? +applicationIdToMarkAsProcessed : undefined)
       setSearchParams(undefined, { replace: true })
     }
   }, [cards.length, projectConfig, region, searchParams, setCards, setSearchParams, setApplicationIdToMarkAsProcessed])

--- a/administration/src/bp-modules/cards/AddCardsForm.tsx
+++ b/administration/src/bp-modules/cards/AddCardsForm.tsx
@@ -1,13 +1,11 @@
-import React, { ReactElement, useCallback, useContext, useEffect, useRef } from 'react'
+import React, { ReactElement, useCallback, useContext, useRef } from 'react'
 import FlipMove from 'react-flip-move'
 import { useTranslation } from 'react-i18next'
-import { useSearchParams } from 'react-router-dom'
 import styled from 'styled-components'
 
-import { Card, initializeCard, initializeCardFromCSV } from '../../cards/Card'
+import { Card, initializeCard } from '../../cards/Card'
 import { Region } from '../../generated/graphql'
 import { ProjectConfigContext } from '../../project-configs/ProjectConfigContext'
-import { getCsvHeaders } from '../../project-configs/helper'
 import AddCardForm from './AddCardForm'
 import CardFormButton from './CardFormButton'
 
@@ -41,31 +39,11 @@ type CreateCardsFormProps = {
   cards: Card[]
   setCards: (cards: Card[]) => void
   updateCard: (updatedCard: Partial<Card>, index: number) => void
-  setApplicationIdToMarkAsProcessed: (applicationIdToMarkAsProcessed: number | undefined) => void
 }
 
-const AddCardsForm = ({
-  region,
-  cards,
-  setCards,
-  updateCard,
-  setApplicationIdToMarkAsProcessed,
-}: CreateCardsFormProps): ReactElement => {
+const AddCardsForm = ({ region, cards, setCards, updateCard }: CreateCardsFormProps): ReactElement => {
   const projectConfig = useContext(ProjectConfigContext)
   const { t } = useTranslation('cards')
-  const [searchParams, setSearchParams] = useSearchParams()
-
-  useEffect(() => {
-    if (cards.length === 0) {
-      const headers = getCsvHeaders(projectConfig)
-      const values = headers.map(header => searchParams.get(header))
-      setCards([initializeCardFromCSV(projectConfig.card, values, headers, region, true)])
-
-      const applicationIdToMarkAsProcessed = searchParams.get('applicationIdToMarkAsProcessed')
-      setApplicationIdToMarkAsProcessed(applicationIdToMarkAsProcessed ? +applicationIdToMarkAsProcessed : undefined)
-      setSearchParams(undefined, { replace: true })
-    }
-  }, [cards.length, projectConfig, region, searchParams, setCards, setSearchParams, setApplicationIdToMarkAsProcessed])
   const bottomRef = useRef<HTMLDivElement>(null)
 
   const scrollToBottom = () => {

--- a/administration/src/bp-modules/cards/ImportCardsController.tsx
+++ b/administration/src/bp-modules/cards/ImportCardsController.tsx
@@ -10,10 +10,11 @@ import GenerationFinished from './CardsCreatedMessage'
 import CreateCardsButtonBar from './CreateCardsButtonBar'
 import ImportCardsInput from './ImportCardsInput'
 import CardImportTable from './ImportCardsTable'
-import useCardGenerator, { CardActivationState } from './hooks/useCardGenerator'
+import useCardGenerator from './hooks/useCardGenerator'
 
 const InnerImportCardsController = ({ region }: { region: Region }): ReactElement => {
-  const { state, setState, generateCardsPdf, generateCardsCsv, setCards, cards } = useCardGenerator(region)
+  const { cardGenerationStep, setCardGenerationStep, generateCardsPdf, generateCardsCsv, setCards, cards } =
+    useCardGenerator({ region, initializeCards: false })
   const navigate = useNavigate()
   const { t } = useTranslation('cards')
 
@@ -30,16 +31,16 @@ const InnerImportCardsController = ({ region }: { region: Region }): ReactElemen
     }
   }
 
-  if (state === CardActivationState.loading) {
+  if (cardGenerationStep === 'loading') {
     return <Spinner />
   }
 
-  if (state === CardActivationState.finished) {
+  if (cardGenerationStep === 'finished') {
     return (
       <GenerationFinished
         reset={() => {
           setCards([])
-          setState(CardActivationState.input)
+          setCardGenerationStep('input')
         }}
       />
     )

--- a/administration/src/bp-modules/cards/hooks/useCardGenerator.test.tsx
+++ b/administration/src/bp-modules/cards/hooks/useCardGenerator.test.tsx
@@ -14,7 +14,7 @@ import { Region } from '../../../generated/graphql'
 import bayernConfig from '../../../project-configs/bayern/config'
 import downloadDataUri from '../../../util/downloadDataUri'
 import { AppToasterProvider } from '../../AppToaster'
-import useCardGenerator, { CardActivationState } from './useCardGenerator'
+import useCardGenerator from './useCardGenerator'
 
 const wrapper = ({ children }: { children: ReactNode }) => (
   <MemoryRouter>
@@ -67,7 +67,7 @@ describe('useCardGenerator', () => {
   it('should successfully create multiple cards', async () => {
     const toasterSpy = jest.spyOn(OverlayToaster.prototype, 'show')
     mocked(createCards).mockReturnValueOnce(Promise.resolve(codes))
-    const { result } = renderHook(() => useCardGenerator(region), { wrapper })
+    const { result } = renderHook(() => useCardGenerator({ region }), { wrapper })
     act(() => result.current.setCards(cards))
 
     expect(result.current.cards).toEqual(cards)
@@ -78,7 +78,7 @@ describe('useCardGenerator', () => {
     expect(toasterSpy).not.toHaveBeenCalled()
     expect(createCards).toHaveBeenCalled()
     expect(downloadDataUri).toHaveBeenCalled()
-    expect(result.current.state).toBe(CardActivationState.finished)
+    expect(result.current.cardGenerationStep).toBe('finished')
     expect(result.current.cards).toEqual([])
   })
 
@@ -88,7 +88,7 @@ describe('useCardGenerator', () => {
       throw new CreateCardsError('error')
     })
 
-    const { result } = renderHook(() => useCardGenerator(region), { wrapper })
+    const { result } = renderHook(() => useCardGenerator({ region }), { wrapper })
 
     act(() => result.current.setCards(cards))
 
@@ -99,7 +99,7 @@ describe('useCardGenerator', () => {
 
     expect(toasterSpy).toHaveBeenCalledWith({ message: 'error', intent: 'danger' })
     expect(downloadDataUri).not.toHaveBeenCalled()
-    expect(result.current.state).toBe(CardActivationState.input)
+    expect(result.current.cardGenerationStep).toBe('input')
     expect(result.current.cards).toEqual([])
   })
 
@@ -111,7 +111,7 @@ describe('useCardGenerator', () => {
     })
     const toasterSpy = jest.spyOn(OverlayToaster.prototype, 'show')
 
-    const { result } = renderHook(() => useCardGenerator(region), { wrapper })
+    const { result } = renderHook(() => useCardGenerator({ region }), { wrapper })
 
     act(() => result.current.setCards(cards))
 
@@ -131,7 +131,7 @@ describe('useCardGenerator', () => {
     // TODO 1869 Finalize translations - fix test to call delete cards with parameters
     // expect(deleteCards).toHaveBeenCalledWith(expect.anything(), region.id, codesToDelete)
     expect(downloadDataUri).not.toHaveBeenCalled()
-    expect(result.current.state).toBe(CardActivationState.input)
+    expect(result.current.cardGenerationStep).toBe('input')
     expect(result.current.cards).toEqual([])
   })
 })

--- a/administration/src/bp-modules/cards/hooks/useCardGenerator.test.tsx
+++ b/administration/src/bp-modules/cards/hooks/useCardGenerator.test.tsx
@@ -3,6 +3,7 @@ import { OverlayToaster } from '@blueprintjs/core'
 import { act, renderHook } from '@testing-library/react'
 import { mocked } from 'jest-mock'
 import React, { ReactNode } from 'react'
+import { MemoryRouter } from 'react-router-dom'
 
 import { generateCardInfo, initializeCard } from '../../../cards/Card'
 import { PdfError, generatePdf } from '../../../cards/PdfFactory'
@@ -16,9 +17,11 @@ import { AppToasterProvider } from '../../AppToaster'
 import useCardGenerator, { CardActivationState } from './useCardGenerator'
 
 const wrapper = ({ children }: { children: ReactNode }) => (
-  <AppToasterProvider>
-    <ApolloProvider>{children}</ApolloProvider>
-  </AppToasterProvider>
+  <MemoryRouter>
+    <AppToasterProvider>
+      <ApolloProvider>{children}</ApolloProvider>
+    </AppToasterProvider>
+  </MemoryRouter>
 )
 
 jest.mock('../../../cards/PdfFactory', () => ({

--- a/administration/src/bp-modules/cards/hooks/useCardGenerator.ts
+++ b/administration/src/bp-modules/cards/hooks/useCardGenerator.ts
@@ -46,10 +46,10 @@ const useCardGenerator = (region: Region): UseCardGeneratorReturn => {
   const projectConfig = useContext(ProjectConfigContext)
   const [searchParams] = useSearchParams()
   const [state, setState] = useState(CardActivationState.input)
-  const [createCardsService] = useCreateCardsMutation()
-  const [deleteCardsService] = useDeleteCardsMutation()
+  const [createCardsMutation] = useCreateCardsMutation()
+  const [deleteCardsMutation] = useDeleteCardsMutation()
   const appToaster = useAppToaster()
-  const sendCardConfirmationMails = useSendCardConfirmationMails()
+  const sendConfirmationMails = useSendCardConfirmationMails()
   const { t } = useTranslation('errors')
   const [cards, setCards] = useState<Card[]>(() => {
     const headers = getCsvHeaders(projectConfig)
@@ -71,20 +71,20 @@ const useCardGenerator = (region: Region): UseCardGeneratorReturn => {
       setState(CardActivationState.loading)
 
       try {
-        codes = await createCards(createCardsService, projectConfig, cards, t, applicationId)
+        codes = await createCards(createCardsMutation, projectConfig, cards, t, applicationId)
         const dataUri = await generateFunction(codes, cards, projectConfig, region)
         downloadDataUri(dataUri, filename)
         cards.forEach(saveActivityLog)
 
         if (region.activatedForCardConfirmationMail) {
-          await sendCardConfirmationMails(codes, cards)
+          await sendConfirmationMails(codes, cards)
         }
 
         setState(CardActivationState.finished)
       } catch (error) {
         if (codes) {
           // Rollback
-          await deleteCards(deleteCardsService, region.id, codes, t).catch(reportErrorToSentry)
+          await deleteCards(deleteCardsMutation, region.id, codes, t).catch(reportErrorToSentry)
         }
         if (appToaster) {
           showCardGenerationError(appToaster, error, t)
@@ -96,11 +96,11 @@ const useCardGenerator = (region: Region): UseCardGeneratorReturn => {
     },
     [
       cards,
-      createCardsService,
-      deleteCardsService,
+      createCardsMutation,
+      deleteCardsMutation,
       projectConfig,
       appToaster,
-      sendCardConfirmationMails,
+      sendConfirmationMails,
       region,
       applicationId,
       t,

--- a/administration/src/bp-modules/cards/hooks/useCardGenerator.ts
+++ b/administration/src/bp-modules/cards/hooks/useCardGenerator.ts
@@ -1,23 +1,21 @@
-import { useApolloClient } from '@apollo/client'
 import { useCallback, useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { Card, generateCardInfo, updateCard as updateCardObject } from '../../../cards/Card'
-import { CsvError, generateCsv, getCSVFilename } from '../../../cards/CsvFactory'
-import { PdfError, generatePdf } from '../../../cards/PdfFactory'
-import createCards, { CreateCardsError, CreateCardsResult } from '../../../cards/createCards'
+import { Card, updateCard as updateCardObject } from '../../../cards/Card'
+import { generateCsv, getCSVFilename } from '../../../cards/CsvFactory'
+import { generatePdf, getPdfFilename } from '../../../cards/PdfFactory'
+import createCards, { CreateCardsResult } from '../../../cards/createCards'
 import deleteCards from '../../../cards/deleteCards'
-import { EMAIL_NOTIFICATION_EXTENSION_NAME } from '../../../cards/extensions/EMailNotificationExtension'
-import getMessageFromApolloError from '../../../errors/getMessageFromApolloError'
-import { Region, useSendCardCreationConfirmationMailMutation } from '../../../generated/graphql'
+import { Region, useCreateCardsMutation, useDeleteCardsMutation } from '../../../generated/graphql'
 import { ProjectConfigContext } from '../../../project-configs/ProjectConfigContext'
+import { ProjectConfig } from '../../../project-configs/getProjectConfig'
 import downloadDataUri from '../../../util/downloadDataUri'
-import getDeepLinkFromQrCode from '../../../util/getDeepLinkFromQrCode'
 import { updateArrayItem } from '../../../util/helper'
-import normalizeString from '../../../util/normalizeString'
 import { reportErrorToSentry } from '../../../util/sentry'
 import { useAppToaster } from '../../AppToaster'
 import { saveActivityLog } from '../../user-settings/ActivityLog'
+import { showCardGenerationError } from '../../util/cardGenerationError'
+import useSendCardConfirmationMails from './useSendCardConfirmationMails'
 
 export enum CardActivationState {
   input,
@@ -25,19 +23,18 @@ export enum CardActivationState {
   finished,
 }
 
-const extractCardInfoHashes = (codes: CreateCardsResult[]) =>
-  codes.flatMap(code => {
-    if (code.staticCardInfoHashBase64) {
-      return [code.dynamicCardInfoHashBase64, code.staticCardInfoHashBase64]
-    }
-    return code.dynamicCardInfoHashBase64
-  })
+type GenerateCardFunction = (
+  codes: CreateCardsResult[],
+  cards: Card[],
+  projectConfig: ProjectConfig,
+  region?: Region
+) => Promise<Blob> | Blob
 
 type UseCardGeneratorReturn = {
   state: CardActivationState
   setState: (state: CardActivationState) => void
-  generateCardsPdf: (applicationId?: number) => Promise<void>
-  generateCardsCsv: (applicationId?: number) => Promise<void>
+  generateCardsPdf: () => Promise<void>
+  generateCardsCsv: () => Promise<void>
   setCards: (cards: Card[]) => void
   updateCard: (updatedCard: Partial<Card>, index: number) => void
   cards: Card[]
@@ -51,21 +48,10 @@ const useCardGenerator = (region: Region): UseCardGeneratorReturn => {
   const [cards, setCards] = useState<Card[]>([])
   const [state, setState] = useState(CardActivationState.input)
   const [applicationIdToMarkAsProcessed, setApplicationIdToMarkAsProcessed] = useState<number>()
-  const client = useApolloClient()
+  const [createCardsService] = useCreateCardsMutation()
+  const [deleteCardsService] = useDeleteCardsMutation()
   const appToaster = useAppToaster()
-  const [sendMail] = useSendCardCreationConfirmationMailMutation({
-    onCompleted: () => {
-      appToaster?.show({ intent: 'success', message: t('cards:cardCreationConfirmationMessage') })
-    },
-    onError: error => {
-      const { title } = getMessageFromApolloError(error, t)
-      appToaster?.show({
-        intent: 'danger',
-        message: title,
-        timeout: 0,
-      })
-    },
-  })
+  const sendCardConfirmationMails = useSendCardConfirmationMails()
 
   const updateCard = useCallback(
     (updatedCard: Partial<Card>, index: number) =>
@@ -73,132 +59,56 @@ const useCardGenerator = (region: Region): UseCardGeneratorReturn => {
     [cards]
   )
 
-  const sendCardConfirmationMails = useCallback(
-    async (codes: CreateCardsResult[], cards: Card[], projectId: string): Promise<void> => {
-      for (let k = 0; k < codes.length; k++) {
-        const card = cards[k]
-        const mailNotificationExtensionState = card.extensions[EMAIL_NOTIFICATION_EXTENSION_NAME]
-        const dynamicCode = codes[k].dynamicActivationCode
-        if (!mailNotificationExtensionState || dynamicCode.info?.extensions?.extensionRegion?.regionId === undefined) {
-          return
-        }
-        const deepLink = getDeepLinkFromQrCode({
-          case: 'dynamicActivationCode',
-          value: dynamicCode,
-        })
-        // eslint-disable-next-line no-await-in-loop
-        await sendMail({
-          variables: {
-            project: projectId,
-            regionId: dynamicCode.info.extensions.extensionRegion.regionId,
-            recipientAddress: mailNotificationExtensionState,
-            recipientName: card.fullName,
-            deepLink,
-          },
-        })
-      }
-    },
-    [sendMail]
-  )
-
-  const handleError = useCallback(
-    async (error: unknown, codes: CreateCardsResult[] | undefined) => {
-      if (codes !== undefined) {
-        // try rollback
-        try {
-          await deleteCards(client, region.id, extractCardInfoHashes(codes), t)
-        } catch (e) {
-          reportErrorToSentry(e)
-        }
-      }
-      if (error instanceof CreateCardsError) {
-        appToaster?.show({
-          message: error.message,
-          intent: 'danger',
-        })
-      } else if (error instanceof PdfError) {
-        appToaster?.show({
-          message: t('pdfCreationError'),
-          intent: 'danger',
-        })
-      } else if (error instanceof CsvError) {
-        appToaster?.show({
-          message: t('csvCreationError'),
-          intent: 'danger',
-        })
-      } else {
-        appToaster?.show({
-          message: t('unknownError'),
-          intent: 'danger',
-        })
-        reportErrorToSentry(error)
-      }
-      setState(CardActivationState.input)
-    },
-    [appToaster, client, region, t]
-  )
-
   const generateCards = useCallback(
-    async (
-      generateFunction: (codes: CreateCardsResult[], cards: Card[]) => Promise<Blob> | Blob,
-      filename: string,
-      applicationIdToMarkAsProcessed?: number
-    ): Promise<void> => {
+    async (generateFunction: GenerateCardFunction, filename: string): Promise<void> => {
       let codes: CreateCardsResult[] | undefined
       setState(CardActivationState.loading)
 
       try {
-        const cardInfos = cards.map(generateCardInfo)
-        codes = await createCards(
-          client,
-          projectConfig.projectId,
-          cardInfos,
-          projectConfig.staticQrCodesEnabled,
-          t,
-          applicationIdToMarkAsProcessed
-        )
-
-        const dataUri = await generateFunction(codes, cards)
-
+        codes = await createCards(createCardsService, projectConfig, cards, t, applicationIdToMarkAsProcessed)
+        const dataUri = await generateFunction(codes, cards, projectConfig, region)
+        downloadDataUri(dataUri, filename)
         cards.forEach(saveActivityLog)
 
-        downloadDataUri(dataUri, filename)
         if (region.activatedForCardConfirmationMail) {
-          await sendCardConfirmationMails(codes, cards, projectConfig.projectId)
+          await sendCardConfirmationMails(codes, cards)
         }
+
         setState(CardActivationState.finished)
       } catch (error) {
-        await handleError(error, codes)
+        if (codes) {
+          // Rollback
+          await deleteCards(deleteCardsService, region.id, codes, t).catch(reportErrorToSentry)
+        }
+        if (appToaster) {
+          showCardGenerationError(appToaster, error, t)
+        }
+        setState(CardActivationState.input)
       } finally {
         setCards([])
       }
     },
-    [cards, client, projectConfig, handleError, sendCardConfirmationMails, region.activatedForCardConfirmationMail, t]
+    [
+      cards,
+      createCardsService,
+      deleteCardsService,
+      projectConfig,
+      appToaster,
+      sendCardConfirmationMails,
+      region,
+      applicationIdToMarkAsProcessed,
+      t,
+    ]
   )
 
   const generateCardsPdf = useCallback(
-    async (applicationIdToMarkAsProcessed?: number) => {
-      // "Berechtigungskarte_" prefix needs to always be in the filename to ensure Nuernberg automation will not break
-      await generateCards(
-        (codes: CreateCardsResult[], cards: Card[]) => generatePdf(codes, cards, projectConfig.pdf, region),
-        cards.length === 1
-          ? `Berechtigungskarte_${normalizeString(cards[0].fullName)}-${new Date().getFullYear()}.pdf`
-          : 'berechtigungskarten.pdf',
-        applicationIdToMarkAsProcessed
-      )
-    },
-    [projectConfig, region, generateCards, cards]
+    async () => generateCards(generatePdf, getPdfFilename(cards)),
+    [generateCards, cards]
   )
 
   const generateCardsCsv = useCallback(
-    async (applicationIdToMarkAsProcessed?: number) => {
-      await generateCards(
-        (codes: CreateCardsResult[], cards: Card[]) => generateCsv(codes, cards, projectConfig.csvExport),
-        getCSVFilename(cards),
-        applicationIdToMarkAsProcessed
-      )
-    },
-    [cards, generateCards, projectConfig.csvExport]
+    async () => generateCards(generateCsv, getCSVFilename(cards)),
+    [cards, generateCards]
   )
 
   return {

--- a/administration/src/bp-modules/cards/hooks/useSendCardConfirmationMails.ts
+++ b/administration/src/bp-modules/cards/hooks/useSendCardConfirmationMails.ts
@@ -1,0 +1,60 @@
+import { useCallback, useContext } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { Card } from '../../../cards/Card'
+import { CreateCardsResult } from '../../../cards/createCards'
+import { EMAIL_NOTIFICATION_EXTENSION_NAME } from '../../../cards/extensions/EMailNotificationExtension'
+import getMessageFromApolloError from '../../../errors/getMessageFromApolloError'
+import { useSendCardCreationConfirmationMailMutation } from '../../../generated/graphql'
+import { ProjectConfigContext } from '../../../project-configs/ProjectConfigContext'
+import getDeepLinkFromQrCode from '../../../util/getDeepLinkFromQrCode'
+import { useAppToaster } from '../../AppToaster'
+
+type SendCardConfirmationMail = (codes: CreateCardsResult[], cards: Card[]) => Promise<void>
+
+const useSendCardConfirmationMails = (): SendCardConfirmationMail => {
+  const { projectId } = useContext(ProjectConfigContext)
+  const { t } = useTranslation('cards')
+  const appToaster = useAppToaster()
+  const [sendMail] = useSendCardCreationConfirmationMailMutation({
+    onCompleted: () => {
+      appToaster?.show({ intent: 'success', message: t('cards:cardCreationConfirmationMessage') })
+    },
+    onError: error => {
+      const { title } = getMessageFromApolloError(error, t)
+      appToaster?.show({
+        intent: 'danger',
+        message: title,
+        timeout: 0,
+      })
+    },
+  })
+
+  return useCallback(
+    async (codes: CreateCardsResult[], cards: Card[]): Promise<void> => {
+      await Promise.all(
+        codes.map(async (code, index) => {
+          const card = cards[index]
+          const mailNotificationExtensionState = card.extensions[EMAIL_NOTIFICATION_EXTENSION_NAME]
+          const regionId = code.dynamicActivationCode.info?.extensions?.extensionRegion?.regionId
+          if (!mailNotificationExtensionState || regionId === undefined) {
+            return
+          }
+          const deepLink = getDeepLinkFromQrCode({ case: 'dynamicActivationCode', value: code.dynamicActivationCode })
+          await sendMail({
+            variables: {
+              project: projectId,
+              regionId,
+              recipientAddress: mailNotificationExtensionState,
+              recipientName: card.fullName,
+              deepLink,
+            },
+          })
+        })
+      )
+    },
+    [sendMail, projectId]
+  )
+}
+
+export default useSendCardConfirmationMails

--- a/administration/src/bp-modules/self-service/CardSelfServiceActivation.tsx
+++ b/administration/src/bp-modules/self-service/CardSelfServiceActivation.tsx
@@ -1,8 +1,11 @@
 import FileDownloadOutlinedIcon from '@mui/icons-material/FileDownloadOutlined'
 import { styled } from '@mui/material'
-import React, { ReactElement } from 'react'
+import React, { ReactElement, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { CreateCardsResult } from '../../cards/createCards'
+import { ProjectConfigContext } from '../../project-configs/ProjectConfigContext'
+import getCustomDeepLinkFromQrCode from '../../util/getCustomDeepLinkFromQrCode'
 import { ActionButton } from './components/ActionButton'
 import { IconTextButton } from './components/IconTextButton'
 import { InfoText } from './components/InfoText'
@@ -17,15 +20,21 @@ const StyledIconTextButton = styled(IconTextButton)`
 `
 
 type CardSelfServiceActivationProps = {
-  deepLink: string
-  downloadPdf: () => Promise<void>
+  code: CreateCardsResult
+  downloadPdf: (code: CreateCardsResult, fileName: string) => Promise<void>
 }
 
-const CardSelfServiceActivation = ({ deepLink, downloadPdf }: CardSelfServiceActivationProps): ReactElement => {
+const CardSelfServiceActivation = ({ code, downloadPdf }: CardSelfServiceActivationProps): ReactElement => {
+  const projectConfig = useContext(ProjectConfigContext)
   const { t } = useTranslation('selfService')
+  const deepLink = getCustomDeepLinkFromQrCode(projectConfig, {
+    case: 'dynamicActivationCode',
+    value: code.dynamicActivationCode,
+  })
+
   return (
     <Container>
-      <StyledIconTextButton onClick={downloadPdf}>
+      <StyledIconTextButton onClick={() => downloadPdf(code, `${projectConfig.name}.pdf`)}>
         <FileDownloadOutlinedIcon />
         {t('koblenzPassPdf')}
       </StyledIconTextButton>

--- a/administration/src/bp-modules/self-service/CardSelfServiceView.tsx
+++ b/administration/src/bp-modules/self-service/CardSelfServiceView.tsx
@@ -15,7 +15,7 @@ import { IconTextButton } from './components/IconTextButton'
 import { InfoText } from './components/InfoText'
 import { DataPrivacyAcceptingStatus } from './constants'
 import selfServiceStepInfo from './constants/selfServiceStepInfo'
-import useCardGeneratorSelfService, { CardSelfServiceStep } from './hooks/useCardGeneratorSelfService'
+import useCardGeneratorSelfService from './hooks/useCardGeneratorSelfService'
 
 const CenteredSpinner = styled(Spinner)`
   position: absolute;
@@ -85,8 +85,8 @@ const CardSelfServiceView = (): ReactElement => {
   const [dataPrivacyCheckbox, setDataPrivacyCheckbox] = useState(DataPrivacyAcceptingStatus.untouched)
   const [openHelpDialog, setOpenHelpDialog] = useState(false)
   const {
-    selfServiceState,
-    setSelfServiceState,
+    cardGenerationStep,
+    setCardGenerationStep,
     generateCards,
     setSelfServiceCard,
     selfServiceCard,
@@ -94,9 +94,11 @@ const CardSelfServiceView = (): ReactElement => {
     downloadPdf,
   } = useCardGeneratorSelfService()
 
-  if (selfServiceState === CardSelfServiceStep.loading) {
+  if (cardGenerationStep === 'loading') {
     return <CenteredSpinner />
   }
+
+  const totalSteps = Object.keys(selfServiceStepInfo).length
 
   return (
     <Container>
@@ -108,11 +110,11 @@ const CardSelfServiceView = (): ReactElement => {
         </StyledInfoTextButton>
       </Header>
       <Body>
-        <Step>{`${t('step')} ${selfServiceStepInfo[selfServiceState].stepNr}/${selfServiceStepInfo.length}`}</Step>
-        <Headline>{selfServiceStepInfo[selfServiceState].headline}</Headline>
-        <SubHeadline>{selfServiceStepInfo[selfServiceState].subHeadline}</SubHeadline>
-        <Text>{selfServiceStepInfo[selfServiceState].text}</Text>
-        {selfServiceState === CardSelfServiceStep.form && (
+        <Step>{`${t('step')} ${selfServiceStepInfo[cardGenerationStep].stepNr}/${totalSteps}`}</Step>
+        <Headline>{selfServiceStepInfo[cardGenerationStep].headline}</Headline>
+        <SubHeadline>{selfServiceStepInfo[cardGenerationStep].subHeadline}</SubHeadline>
+        <Text>{selfServiceStepInfo[cardGenerationStep].text}</Text>
+        {cardGenerationStep === 'input' && (
           <CardSelfServiceForm
             card={selfServiceCard}
             dataPrivacyAccepted={dataPrivacyCheckbox}
@@ -121,10 +123,10 @@ const CardSelfServiceView = (): ReactElement => {
             generateCards={generateCards}
           />
         )}
-        {selfServiceState === CardSelfServiceStep.information && (
-          <CardSelfServiceInformation goToActivation={() => setSelfServiceState(CardSelfServiceStep.activation)} />
+        {cardGenerationStep === 'information' && (
+          <CardSelfServiceInformation goToActivation={() => setCardGenerationStep('activation')} />
         )}
-        {selfServiceState === CardSelfServiceStep.activation && code && (
+        {cardGenerationStep === 'activation' && code && (
           <CardSelfServiceActivation downloadPdf={downloadPdf} code={code} />
         )}
       </Body>

--- a/administration/src/bp-modules/self-service/CardSelfServiceView.tsx
+++ b/administration/src/bp-modules/self-service/CardSelfServiceView.tsx
@@ -1,13 +1,12 @@
 import { Spinner } from '@blueprintjs/core'
 import HelpOutlineOutlinedIcon from '@mui/icons-material/HelpOutlineOutlined'
-import React, { ReactElement, useContext, useState } from 'react'
+import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import KoblenzLogo from '../../assets/koblenz_logo.svg'
 import { updateCard } from '../../cards/Card'
 import BasicDialog from '../../mui-modules/application/BasicDialog'
-import { ProjectConfigContext } from '../../project-configs/ProjectConfigContext'
 import CardSelfServiceActivation from './CardSelfServiceActivation'
 import CardSelfServiceForm from './CardSelfServiceForm'
 import CardSelfServiceInformation from './CardSelfServiceInformation'
@@ -83,35 +82,20 @@ const StyledInfoTextButton = styled(IconTextButton)`
 
 // TODO 1646 Add tests for CardSelfService
 const CardSelfServiceView = (): ReactElement => {
-  const projectConfig = useContext(ProjectConfigContext)
   const { t } = useTranslation('selfService')
-  const [dataPrivacyCheckbox, setDataPrivacyCheckbox] = useState<DataPrivacyAcceptingStatus>(
-    DataPrivacyAcceptingStatus.untouched
-  )
+  const [dataPrivacyCheckbox, setDataPrivacyCheckbox] = useState(DataPrivacyAcceptingStatus.untouched)
+  const [openHelpDialog, setOpenHelpDialog] = useState(false)
   const {
     selfServiceState,
     setSelfServiceState,
-    isLoading,
     generateCards,
     setSelfServiceCard,
     selfServiceCard,
-    deepLink,
     code,
     downloadPdf,
   } = useCardGeneratorSelfService()
-  const [openHelpDialog, setOpenHelpDialog] = useState(false)
 
-  const onDownloadPdf = async () => {
-    if (code) {
-      await downloadPdf(code, projectConfig.name)
-    }
-  }
-
-  const goToActivation = () => {
-    setSelfServiceState(CardSelfServiceStep.activation)
-  }
-
-  if (isLoading) {
+  if (selfServiceState === CardSelfServiceStep.loading) {
     return <CenteredSpinner />
   }
 
@@ -139,10 +123,10 @@ const CardSelfServiceView = (): ReactElement => {
           />
         )}
         {selfServiceState === CardSelfServiceStep.information && (
-          <CardSelfServiceInformation goToActivation={goToActivation} />
+          <CardSelfServiceInformation goToActivation={() => setSelfServiceState(CardSelfServiceStep.activation)} />
         )}
-        {selfServiceState === CardSelfServiceStep.activation && (
-          <CardSelfServiceActivation downloadPdf={onDownloadPdf} deepLink={deepLink} />
+        {selfServiceState === CardSelfServiceStep.activation && code && (
+          <CardSelfServiceActivation downloadPdf={downloadPdf} code={code} />
         )}
       </Body>
       <BasicDialog

--- a/administration/src/bp-modules/self-service/CardSelfServiceView.tsx
+++ b/administration/src/bp-modules/self-service/CardSelfServiceView.tsx
@@ -80,7 +80,6 @@ const StyledInfoTextButton = styled(IconTextButton)`
   margin: 0;
 `
 
-// TODO 1646 Add tests for CardSelfService
 const CardSelfServiceView = (): ReactElement => {
   const { t } = useTranslation('selfService')
   const [dataPrivacyCheckbox, setDataPrivacyCheckbox] = useState(DataPrivacyAcceptingStatus.untouched)

--- a/administration/src/bp-modules/self-service/__tests__/CardSelfServiceActivation.test.tsx
+++ b/administration/src/bp-modules/self-service/__tests__/CardSelfServiceActivation.test.tsx
@@ -1,32 +1,41 @@
 import { fireEvent } from '@testing-library/react'
 import React from 'react'
 
-import { LOCAL_STORAGE_PROJECT_KEY } from '../../../project-configs/constants'
+import { generateCardInfo, initializeCard } from '../../../cards/Card'
+import { CreateCardsResult } from '../../../cards/createCards'
+import { DynamicActivationCode } from '../../../generated/card_pb'
 import koblenzConfig from '../../../project-configs/koblenz/config'
 import { renderWithTranslation } from '../../../testing/render'
+import getCustomDeepLinkFromQrCode from '../../../util/getCustomDeepLinkFromQrCode'
 import CardSelfServiceActivation from '../CardSelfServiceActivation'
 
 const downloadPdf = jest.fn()
-const exampleDeepLink = 'example:deeplink'
-describe('CardSelfServiceActivation', () => {
-  it('should have the correct deeplink', async () => {
-    localStorage.setItem(LOCAL_STORAGE_PROJECT_KEY, koblenzConfig.projectId)
 
-    const { getByText } = renderWithTranslation(
-      <CardSelfServiceActivation downloadPdf={downloadPdf} deepLink={exampleDeepLink} />
-    )
-    expect(getByText('KoblenzPass jetzt aktivieren').getAttribute('href')).toBe(exampleDeepLink)
+describe('CardSelfServiceActivation', () => {
+  const card = initializeCard(koblenzConfig.card, undefined, { fullName: 'Thea Test' })
+  const code: CreateCardsResult = {
+    dynamicCardInfoHashBase64: 'rS8nukf7S9j8V1j+PZEkBQWlAeM2WUKkmxBHi1k9hRo=',
+    dynamicActivationCode: new DynamicActivationCode({ info: generateCardInfo(card) }),
+  }
+  const deepLink = getCustomDeepLinkFromQrCode(koblenzConfig, {
+    case: 'dynamicActivationCode',
+    value: code.dynamicActivationCode,
+  })
+
+  it('should have the correct deeplink', async () => {
+    const { getByText } = renderWithTranslation(<CardSelfServiceActivation downloadPdf={downloadPdf} code={code} />, {
+      projectConfig: koblenzConfig,
+    })
+    expect(getByText('KoblenzPass jetzt aktivieren').getAttribute('href')).toBe(deepLink)
   })
 
   it('should provide a pdf download button', async () => {
-    localStorage.setItem(LOCAL_STORAGE_PROJECT_KEY, koblenzConfig.projectId)
-
-    const { getByText } = renderWithTranslation(
-      <CardSelfServiceActivation downloadPdf={downloadPdf} deepLink={exampleDeepLink} />
-    )
+    const { getByText } = renderWithTranslation(<CardSelfServiceActivation downloadPdf={downloadPdf} code={code} />, {
+      projectConfig: koblenzConfig,
+    })
 
     const downloadPDFButton = getByText('KoblenzPass PDF')
     fireEvent.click(downloadPDFButton)
-    expect(downloadPdf).toHaveBeenCalled()
+    expect(downloadPdf).toHaveBeenCalledWith(code, 'KoblenzPass.pdf')
   })
 })

--- a/administration/src/bp-modules/self-service/constants/selfServiceStepInfo.tsx
+++ b/administration/src/bp-modules/self-service/constants/selfServiceStepInfo.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react'
 
 import i18next from '../../../i18n'
+import { SelfServiceCardGenerationStep } from '../hooks/useCardGeneratorSelfService'
 
 type SelfServiceStepInfo = {
   stepNr: number
@@ -9,14 +10,14 @@ type SelfServiceStepInfo = {
   text: ReactElement
 }
 
-const selfServiceStepInfo: SelfServiceStepInfo[] = [
-  {
+const selfServiceStepInfo: { [step in Exclude<SelfServiceCardGenerationStep, 'loading'>]: SelfServiceStepInfo } = {
+  input: {
     stepNr: 1,
     headline: i18next.t('selfService:welcome'),
     subHeadline: i18next.t('selfService:fewStepsNeeded'),
     text: <span>{i18next.t('selfService:explanation')}</span>,
   },
-  {
+  information: {
     stepNr: 2,
     headline: i18next.t('selfService:createdPassSuccessfully'),
     subHeadline: i18next.t('selfService:fewMoreStepsNeeded'),
@@ -27,7 +28,7 @@ const selfServiceStepInfo: SelfServiceStepInfo[] = [
       </span>
     ),
   },
-  {
+  activation: {
     stepNr: 3,
     headline: i18next.t('selfService:almostThere'),
     subHeadline: i18next.t('selfService:activateAndDownloadPrompt'),
@@ -39,6 +40,6 @@ const selfServiceStepInfo: SelfServiceStepInfo[] = [
       </span>
     ),
   },
-]
+}
 
 export default selfServiceStepInfo

--- a/administration/src/bp-modules/self-service/hooks/__tests__/useCardGeneratorSelfService.test.tsx
+++ b/administration/src/bp-modules/self-service/hooks/__tests__/useCardGeneratorSelfService.test.tsx
@@ -51,9 +51,6 @@ describe('useCardGeneratorSelfService', () => {
     await act(async () => result.current.generateCards())
     expect(toasterSpy).not.toHaveBeenCalled()
     expect(result.current.selfServiceState).toBe(CardSelfServiceStep.information)
-    expect(result.current.deepLink).toBe(
-      'koblenzpass://koblenz.sozialpass.app/activation/code#ClcKLQoNS2FybGEgS29ibGVuehDmnwEaGAoCCF8SBAjqvgEqBAiLmgEyBgoEMTIzSxIQL%2Fle3xYGNIKS50god4ITmxoUOUYGq%2FjAE99bK4edMPo2I3ojr78%3D/'
-    )
     await act(async () => result.current.downloadPdf(result.current.code!, 'koblenzpass.pdf'))
     expect(downloadDataUri).toHaveBeenCalled()
   })

--- a/administration/src/bp-modules/self-service/hooks/__tests__/useCardGeneratorSelfService.test.tsx
+++ b/administration/src/bp-modules/self-service/hooks/__tests__/useCardGeneratorSelfService.test.tsx
@@ -9,7 +9,7 @@ import koblenzConfig from '../../../../project-configs/koblenz/config'
 import downloadDataUri from '../../../../util/downloadDataUri'
 import { AppToasterProvider } from '../../../AppToaster'
 import { exampleCard, mockedCardMutation } from '../../__mock__/mockSelfServiceCard'
-import useCardGeneratorSelfService, { CardSelfServiceStep } from '../useCardGeneratorSelfService'
+import useCardGeneratorSelfService from '../useCardGeneratorSelfService'
 
 const mocks: MockedResponse[] = []
 
@@ -50,7 +50,7 @@ describe('useCardGeneratorSelfService', () => {
     expect(result.current.selfServiceCard).toEqual(exampleCard)
     await act(async () => result.current.generateCards())
     expect(toasterSpy).not.toHaveBeenCalled()
-    expect(result.current.selfServiceState).toBe(CardSelfServiceStep.information)
+    expect(result.current.cardGenerationStep).toBe('information')
     await act(async () => result.current.downloadPdf(result.current.code!, 'koblenzpass.pdf'))
     expect(downloadDataUri).toHaveBeenCalled()
   })

--- a/administration/src/bp-modules/self-service/hooks/useCardGeneratorSelfService.tsx
+++ b/administration/src/bp-modules/self-service/hooks/useCardGeneratorSelfService.tsx
@@ -12,16 +12,11 @@ import downloadDataUri from '../../../util/downloadDataUri'
 import { useAppToaster } from '../../AppToaster'
 import { showCardGenerationError } from '../../util/cardGenerationError'
 
-export enum CardSelfServiceStep {
-  form,
-  loading,
-  information,
-  activation,
-}
+export type SelfServiceCardGenerationStep = 'input' | 'loading' | 'information' | 'activation'
 
 type UseCardGeneratorSelfServiceReturn = {
-  selfServiceState: CardSelfServiceStep
-  setSelfServiceState: (step: CardSelfServiceStep) => void
+  cardGenerationStep: SelfServiceCardGenerationStep
+  setCardGenerationStep: (step: SelfServiceCardGenerationStep) => void
   code: CreateCardsResult | null
   selfServiceCard: Card
   setSelfServiceCard: (card: Card) => void
@@ -34,7 +29,7 @@ const useCardGeneratorSelfService = (): UseCardGeneratorSelfServiceReturn => {
   const appToaster = useAppToaster()
   const { t } = useTranslation('errors')
   const [searchParams] = useSearchParams()
-  const [selfServiceState, setSelfServiceState] = useState(CardSelfServiceStep.form)
+  const [cardGenerationStep, setCardGenerationStep] = useState<SelfServiceCardGenerationStep>('input')
   const [code, setCode] = useState<CreateCardsResult | null>(null)
   const [createCardsSelfService] = useCreateCardsFromSelfServiceMutation()
   const [selfServiceCard, setSelfServiceCard] = useState(() => {
@@ -44,16 +39,16 @@ const useCardGeneratorSelfService = (): UseCardGeneratorSelfServiceReturn => {
   })
 
   const generateCards = useCallback(async (): Promise<void> => {
-    setSelfServiceState(CardSelfServiceStep.loading)
+    setCardGenerationStep('loading')
     try {
       const code = await createSelfServiceCard(createCardsSelfService, projectConfig, selfServiceCard, t)
       setCode(code)
-      setSelfServiceState(CardSelfServiceStep.information)
+      setCardGenerationStep('information')
     } catch (error) {
       if (appToaster) {
         showCardGenerationError(appToaster, error, t)
       }
-      setSelfServiceState(CardSelfServiceStep.form)
+      setCardGenerationStep('input')
     }
   }, [projectConfig, setCode, createCardsSelfService, appToaster, selfServiceCard, t])
 
@@ -63,8 +58,8 @@ const useCardGeneratorSelfService = (): UseCardGeneratorSelfServiceReturn => {
   }
 
   return {
-    selfServiceState,
-    setSelfServiceState,
+    cardGenerationStep,
+    setCardGenerationStep,
     code,
     selfServiceCard,
     setSelfServiceCard,

--- a/administration/src/bp-modules/self-service/hooks/useCardGeneratorSelfService.tsx
+++ b/administration/src/bp-modules/self-service/hooks/useCardGeneratorSelfService.tsx
@@ -1,25 +1,20 @@
-import { ApolloError } from '@apollo/client'
-import React, { useCallback, useContext, useState } from 'react'
+import { useCallback, useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
 
-import { Card, generateCardInfo, initializeCardFromCSV } from '../../../cards/Card'
+import { Card, initializeCardFromCSV } from '../../../cards/Card'
 import { generatePdf } from '../../../cards/PdfFactory'
-import { CreateCardsError, CreateCardsResult } from '../../../cards/createCards'
-import getMessageFromApolloError from '../../../errors/getMessageFromApolloError'
-import { DynamicActivationCode, StaticVerificationCode } from '../../../generated/card_pb'
+import { CreateCardsResult, createSelfServiceCard } from '../../../cards/createCards'
 import { useCreateCardsFromSelfServiceMutation } from '../../../generated/graphql'
 import { ProjectConfigContext } from '../../../project-configs/ProjectConfigContext'
 import { getCsvHeaders } from '../../../project-configs/helper'
-import { base64ToUint8Array, uint8ArrayToBase64 } from '../../../util/base64'
 import downloadDataUri from '../../../util/downloadDataUri'
-import getCustomDeepLinkFromQrCode from '../../../util/getCustomDeepLinkFromQrCode'
-import { reportErrorToSentry } from '../../../util/sentry'
 import { useAppToaster } from '../../AppToaster'
-import FormAlert from '../components/FormAlert'
+import { showCardGenerationError } from '../../util/cardGenerationError'
 
 export enum CardSelfServiceStep {
   form,
+  loading,
   information,
   activation,
 }
@@ -27,8 +22,6 @@ export enum CardSelfServiceStep {
 type UseCardGeneratorSelfServiceReturn = {
   selfServiceState: CardSelfServiceStep
   setSelfServiceState: (step: CardSelfServiceStep) => void
-  isLoading: boolean
-  deepLink: string
   code: CreateCardsResult | null
   selfServiceCard: Card
   setSelfServiceCard: (card: Card) => void
@@ -41,103 +34,37 @@ const useCardGeneratorSelfService = (): UseCardGeneratorSelfServiceReturn => {
   const appToaster = useAppToaster()
   const { t } = useTranslation('errors')
   const [searchParams] = useSearchParams()
+  const [selfServiceState, setSelfServiceState] = useState(CardSelfServiceStep.form)
+  const [code, setCode] = useState<CreateCardsResult | null>(null)
+  const [createCardsSelfService] = useCreateCardsFromSelfServiceMutation()
   const [selfServiceCard, setSelfServiceCard] = useState(() => {
     const headers = getCsvHeaders(projectConfig)
     const values = headers.map(header => searchParams.get(header))
     return initializeCardFromCSV(projectConfig.card, values, headers, undefined, true)
   })
-  const [isLoading, setIsLoading] = useState<boolean>(false)
-  const [selfServiceState, setSelfServiceState] = useState<CardSelfServiceStep>(CardSelfServiceStep.form)
-  const [deepLink, setDeepLink] = useState<string>('')
-  const [code, setCode] = useState<CreateCardsResult | null>(null)
-  const [createCardsSelfService] = useCreateCardsFromSelfServiceMutation()
-
-  const handleErrors = useCallback(
-    (error: unknown) => {
-      if (error instanceof CreateCardsError) {
-        appToaster?.show({
-          message: error.message,
-          intent: 'danger',
-        })
-      }
-      if (error instanceof ApolloError) {
-        const { title } = getMessageFromApolloError(error, t)
-        appToaster?.show({
-          message: <FormAlert isToast errorMessage={title} />,
-          timeout: 0,
-          intent: 'danger',
-        })
-      } else {
-        appToaster?.show({
-          message: t('unknown'),
-          intent: 'danger',
-        })
-        reportErrorToSentry(error)
-      }
-      setSelfServiceState(CardSelfServiceStep.form)
-      setIsLoading(false)
-    },
-    [appToaster, setSelfServiceState, t]
-  )
 
   const generateCards = useCallback(async (): Promise<void> => {
-    setIsLoading(true)
-
+    setSelfServiceState(CardSelfServiceStep.loading)
     try {
-      const cardInfo = generateCardInfo(selfServiceCard)
-      const result = await createCardsSelfService({
-        variables: {
-          project: projectConfig.projectId,
-          generateStaticCodes: true,
-          encodedCardInfo: uint8ArrayToBase64(cardInfo.toBinary()),
-        },
-      })
-
-      if (result.errors) {
-        const { title } = getMessageFromApolloError(new ApolloError({ graphQLErrors: result.errors }), t)
-        return Promise.reject(new CreateCardsError(title))
-      }
-      if (!result.data) {
-        return Promise.reject(new CreateCardsError(t('cardCreationFailed')))
-      }
-      const cardResult = result.data.card
-      const dynamicActivationCode = DynamicActivationCode.fromBinary(
-        base64ToUint8Array(cardResult.dynamicActivationCode.codeBase64)
-      )
-      const staticVerificationCode = cardResult.staticVerificationCode
-        ? StaticVerificationCode.fromBinary(base64ToUint8Array(cardResult.staticVerificationCode.codeBase64))
-        : undefined
-      const code = {
-        dynamicActivationCode,
-        staticVerificationCode,
-        staticCardInfoHashBase64: cardResult.staticVerificationCode?.cardInfoHashBase64,
-        dynamicCardInfoHashBase64: cardResult.dynamicActivationCode.cardInfoHashBase64,
-      }
+      const code = await createSelfServiceCard(createCardsSelfService, projectConfig, selfServiceCard, t)
       setCode(code)
-      setDeepLink(
-        getCustomDeepLinkFromQrCode(projectConfig, {
-          case: 'dynamicActivationCode',
-          value: code.dynamicActivationCode,
-        })
-      )
-
-      setIsLoading(false)
       setSelfServiceState(CardSelfServiceStep.information)
     } catch (error) {
-      handleErrors(error)
+      if (appToaster) {
+        showCardGenerationError(appToaster, error, t)
+      }
+      setSelfServiceState(CardSelfServiceStep.form)
     }
-  }, [projectConfig, setIsLoading, setDeepLink, setCode, createCardsSelfService, handleErrors, selfServiceCard, t])
+  }, [projectConfig, setCode, createCardsSelfService, appToaster, selfServiceCard, t])
 
   const downloadPdf = async (code: CreateCardsResult, fileName: string): Promise<void> => {
-    const blob = await generatePdf([code], [selfServiceCard], projectConfig.pdf)
+    const blob = await generatePdf([code], [selfServiceCard], projectConfig)
     downloadDataUri(blob, fileName)
   }
 
   return {
     selfServiceState,
     setSelfServiceState,
-    isLoading,
-    deepLink,
     code,
     selfServiceCard,
     setSelfServiceCard,

--- a/administration/src/bp-modules/util/cardGenerationError.tsx
+++ b/administration/src/bp-modules/util/cardGenerationError.tsx
@@ -1,0 +1,43 @@
+import { ApolloError } from '@apollo/client'
+import { Toaster } from '@blueprintjs/core'
+import { TFunction } from 'i18next'
+import React from 'react'
+
+import { CsvError } from '../../cards/CsvFactory'
+import { PdfError } from '../../cards/PdfFactory'
+import { CreateCardsError } from '../../cards/createCards'
+import getMessageFromApolloError from '../../errors/getMessageFromApolloError'
+import { reportErrorToSentry } from '../../util/sentry'
+import FormAlert from '../self-service/components/FormAlert'
+
+export const showCardGenerationError = (appToaster: Toaster, error: unknown, t: TFunction<'errors'>): void => {
+  if (error instanceof CreateCardsError) {
+    appToaster.show({
+      message: error.message,
+      intent: 'danger',
+    })
+  } else if (error instanceof ApolloError) {
+    const { title } = getMessageFromApolloError(error, t)
+    appToaster.show({
+      message: <FormAlert isToast errorMessage={title} />,
+      timeout: 0,
+      intent: 'danger',
+    })
+  } else if (error instanceof PdfError) {
+    appToaster.show({
+      message: t('pdfCreationError'),
+      intent: 'danger',
+    })
+  } else if (error instanceof CsvError) {
+    appToaster.show({
+      message: t('csvCreationError'),
+      intent: 'danger',
+    })
+  } else {
+    appToaster.show({
+      message: t('unknownError'),
+      intent: 'danger',
+    })
+    reportErrorToSentry(error)
+  }
+}

--- a/administration/src/cards/CsvFactory.ts
+++ b/administration/src/cards/CsvFactory.ts
@@ -1,6 +1,6 @@
 import { stringify } from 'csv-stringify/browser/esm/sync'
 
-import { CsvExport } from '../project-configs/getProjectConfig'
+import { ProjectConfig } from '../project-configs/getProjectConfig'
 import { Card } from './Card'
 import { CreateCardsResult } from './createCards'
 import { NUERNBERG_PASS_ID_EXTENSION_NAME } from './extensions/NuernbergPassIdExtension'
@@ -12,14 +12,15 @@ export class CsvError extends Error {
   }
 }
 
-export const generateCsv = (codes: CreateCardsResult[], cards: Card[], csvProjectConfig: CsvExport): Blob => {
-  if (!csvProjectConfig.enabled) {
+export const generateCsv = (codes: CreateCardsResult[], cards: Card[], projectConfig: ProjectConfig): Blob => {
+  const csvConfig = projectConfig.csvExport
+  if (!csvConfig.enabled) {
     throw new CsvError('CSV Export is disabled for this project')
   }
   try {
-    let csvContent = stringify([csvProjectConfig.csvHeader])
+    let csvContent = stringify([csvConfig.csvHeader])
     for (let k = 0; k < codes.length; k++) {
-      csvContent += csvProjectConfig.buildCsvLine(codes[k], cards[k])
+      csvContent += csvConfig.buildCsvLine(codes[k], cards[k])
     }
     return new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
   } catch (error) {

--- a/administration/src/cards/PdfFactory.ts
+++ b/administration/src/cards/PdfFactory.ts
@@ -114,10 +114,10 @@ export const generatePdf = async (
   try {
     const doc = await PDFDocument.create()
     const templateDocument = await PDFDocument.load(await fetch(pdfConfig.templatePath).then(res => res.arrayBuffer()))
-    const [templatePage] = await doc.copyPages(templateDocument, [0])
 
     await Promise.all(
       codes.map(async (code, index) => {
+        const [templatePage] = await doc.copyPages(templateDocument, [0])
         const page = doc.addPage(templatePage)
         await fillContentAreas(doc, page, code, cards[index], pdfConfig, region)
       })

--- a/administration/src/cards/PdfFactory.ts
+++ b/administration/src/cards/PdfFactory.ts
@@ -115,13 +115,13 @@ export const generatePdf = async (
     const doc = await PDFDocument.create()
     const templateDocument = await PDFDocument.load(await fetch(pdfConfig.templatePath).then(res => res.arrayBuffer()))
 
-    await Promise.all(
-      codes.map(async (code, index) => {
-        const [templatePage] = await doc.copyPages(templateDocument, [0])
-        const page = doc.addPage(templatePage)
-        await fillContentAreas(doc, page, code, cards[index], pdfConfig, region)
-      })
-    )
+    for (let index = 0; index < codes.length; index++) {
+      // eslint-disable-next-line no-await-in-loop
+      const [templatePage] = await doc.copyPages(templateDocument, [0])
+      const page = doc.addPage(templatePage)
+      // eslint-disable-next-line no-await-in-loop
+      await fillContentAreas(doc, page, codes[index], cards[index], pdfConfig, region)
+    }
 
     doc.setTitle(pdfConfig.title)
     doc.setAuthor(pdfConfig.issuer)

--- a/administration/src/cards/__tests__/CsvFactory.test.ts
+++ b/administration/src/cards/__tests__/CsvFactory.test.ts
@@ -57,7 +57,7 @@ describe('CsvFactory', () => {
       },
     ]
 
-    expect(() => generateCsv(codes, cards, bayernConfig.csvExport)).toThrow(
+    expect(() => generateCsv(codes, cards, bayernConfig)).toThrow(
       new CsvError('CSV Export is disabled for this project')
     )
   })
@@ -73,7 +73,7 @@ describe('CsvFactory', () => {
     if (!nuernbergConfig.csvExport.enabled) {
       throw Error('test failed')
     }
-    generateCsv([], [], nuernbergConfig.csvExport)
+    generateCsv([], [], nuernbergConfig)
     expect(TEST_BLOB_CONSTRUCTOR).toHaveBeenCalledWith([nuernbergConfig.csvExport.csvHeader.join(',')], {
       type: 'text/csv;charset=utf-8;',
     })

--- a/administration/src/cards/createCards.ts
+++ b/administration/src/cards/createCards.ts
@@ -2,7 +2,7 @@ import { TFunction } from 'i18next'
 
 import { DynamicActivationCode, StaticVerificationCode } from '../generated/card_pb'
 import { CreateCardsFromSelfServiceMutationFn, CreateCardsMutation, CreateCardsMutationFn } from '../generated/graphql'
-import { ProjectConfig } from '../project-configs/getProjectConfig'
+import type { ProjectConfig } from '../project-configs/getProjectConfig'
 import { base64ToUint8Array, uint8ArrayToBase64 } from '../util/base64'
 import { mapGraphqlRequestResult } from '../util/helper'
 import { Card, generateCardInfo } from './Card'

--- a/administration/src/cards/createCards.ts
+++ b/administration/src/cards/createCards.ts
@@ -1,10 +1,11 @@
-import { ApolloClient, ApolloError } from '@apollo/client'
 import { TFunction } from 'i18next'
 
-import getMessageFromApolloError from '../errors/getMessageFromApolloError'
-import { CardInfo, DynamicActivationCode, StaticVerificationCode } from '../generated/card_pb'
-import { CreateCardsDocument, CreateCardsMutation, CreateCardsMutationVariables } from '../generated/graphql'
+import { DynamicActivationCode, StaticVerificationCode } from '../generated/card_pb'
+import { CreateCardsFromSelfServiceMutationFn, CreateCardsMutation, CreateCardsMutationFn } from '../generated/graphql'
+import { ProjectConfig } from '../project-configs/getProjectConfig'
 import { base64ToUint8Array, uint8ArrayToBase64 } from '../util/base64'
+import { mapGraphqlRequestResult } from '../util/helper'
+import { Card, generateCardInfo } from './Card'
 
 export class CreateCardsError extends Error {
   constructor(message: string) {
@@ -13,6 +14,8 @@ export class CreateCardsError extends Error {
   }
 }
 
+type RawCreateCardsResult = CreateCardsMutation['cards'][number]
+
 export type CreateCardsResult = {
   dynamicCardInfoHashBase64: string
   dynamicActivationCode: DynamicActivationCode
@@ -20,42 +23,49 @@ export type CreateCardsResult = {
   staticVerificationCode?: StaticVerificationCode
 }
 
+const mapCardCreationResult = (card: RawCreateCardsResult): CreateCardsResult => {
+  const dynamicActivationCode = DynamicActivationCode.fromBinary(
+    base64ToUint8Array(card.dynamicActivationCode.codeBase64)
+  )
+  const staticVerificationCode = card.staticVerificationCode
+    ? StaticVerificationCode.fromBinary(base64ToUint8Array(card.staticVerificationCode.codeBase64))
+    : undefined
+  return {
+    dynamicActivationCode,
+    staticVerificationCode,
+    staticCardInfoHashBase64: card.staticVerificationCode?.cardInfoHashBase64,
+    dynamicCardInfoHashBase64: card.dynamicActivationCode.cardInfoHashBase64,
+  }
+}
+
+export const createSelfServiceCard = async (
+  createCardsSelfService: CreateCardsFromSelfServiceMutationFn,
+  projectConfig: ProjectConfig,
+  selfServiceCard: Card,
+  t: TFunction
+): Promise<CreateCardsResult> => {
+  const cardInfo = uint8ArrayToBase64(generateCardInfo(selfServiceCard).toBinary())
+  const result = await createCardsSelfService({
+    variables: { project: projectConfig.projectId, generateStaticCodes: true, encodedCardInfo: cardInfo },
+  })
+  const data = mapGraphqlRequestResult(result, message => new CreateCardsError(message), t)
+  return mapCardCreationResult(data.card)
+}
+
 const createCards = async (
-  client: ApolloClient<object>,
-  projectId: string,
-  cardInfos: CardInfo[],
-  generateStaticCodes: boolean,
+  createCardsService: CreateCardsMutationFn,
+  projectConfig: ProjectConfig,
+  cards: Card[],
   t: TFunction,
   applicationIdToMarkAsProcessed?: number
 ): Promise<CreateCardsResult[]> => {
-  const encodedCardInfos = cardInfos.map(cardInfo => uint8ArrayToBase64(cardInfo.toBinary()))
-  const result = await client.mutate<CreateCardsMutation, CreateCardsMutationVariables>({
-    mutation: CreateCardsDocument,
+  const { projectId, staticQrCodesEnabled: generateStaticCodes } = projectConfig
+  const encodedCardInfos = cards.map(generateCardInfo).map(cardInfo => uint8ArrayToBase64(cardInfo.toBinary()))
+  const result = await createCardsService({
     variables: { project: projectId, encodedCardInfos, generateStaticCodes, applicationIdToMarkAsProcessed },
   })
-
-  if (result.errors) {
-    const { title } = getMessageFromApolloError(new ApolloError({ graphQLErrors: result.errors }), t)
-    throw new CreateCardsError(title)
-  }
-  if (!result.data) {
-    throw new CreateCardsError('Beim erstellen der Karte(n) ist ein Fehler aufgetreten.')
-  }
-
-  return result.data.cards.map(card => {
-    const dynamicActivationCode = DynamicActivationCode.fromBinary(
-      base64ToUint8Array(card.dynamicActivationCode.codeBase64)
-    )
-    const staticVerificationCode = card.staticVerificationCode
-      ? StaticVerificationCode.fromBinary(base64ToUint8Array(card.staticVerificationCode.codeBase64))
-      : undefined
-    return {
-      dynamicActivationCode,
-      staticVerificationCode,
-      staticCardInfoHashBase64: card.staticVerificationCode?.cardInfoHashBase64,
-      dynamicCardInfoHashBase64: card.dynamicActivationCode.cardInfoHashBase64,
-    }
-  })
+  const data = mapGraphqlRequestResult(result, message => new CreateCardsError(message), t)
+  return data.cards.map(mapCardCreationResult)
 }
 
 export default createCards

--- a/administration/src/cards/createCards.ts
+++ b/administration/src/cards/createCards.ts
@@ -53,7 +53,7 @@ export const createSelfServiceCard = async (
 }
 
 const createCards = async (
-  createCardsService: CreateCardsMutationFn,
+  createCardsMutation: CreateCardsMutationFn,
   projectConfig: ProjectConfig,
   cards: Card[],
   t: TFunction,
@@ -61,7 +61,7 @@ const createCards = async (
 ): Promise<CreateCardsResult[]> => {
   const { projectId, staticQrCodesEnabled: generateStaticCodes } = projectConfig
   const encodedCardInfos = cards.map(generateCardInfo).map(cardInfo => uint8ArrayToBase64(cardInfo.toBinary()))
-  const result = await createCardsService({
+  const result = await createCardsMutation({
     variables: { project: projectId, encodedCardInfos, generateStaticCodes, applicationIdToMarkAsProcessed },
   })
   const data = mapGraphqlRequestResult(result, message => new CreateCardsError(message), t)

--- a/administration/src/cards/createCards.ts
+++ b/administration/src/cards/createCards.ts
@@ -57,7 +57,7 @@ const createCards = async (
   projectConfig: ProjectConfig,
   cards: Card[],
   t: TFunction,
-  applicationIdToMarkAsProcessed?: number
+  applicationIdToMarkAsProcessed: number | null
 ): Promise<CreateCardsResult[]> => {
   const { projectId, staticQrCodesEnabled: generateStaticCodes } = projectConfig
   const encodedCardInfos = cards.map(generateCardInfo).map(cardInfo => uint8ArrayToBase64(cardInfo.toBinary()))

--- a/administration/src/cards/deleteCards.ts
+++ b/administration/src/cards/deleteCards.ts
@@ -11,12 +11,12 @@ const extractCardInfoHashes = (codes: CreateCardsResult[]) =>
   )
 
 const deleteCards = async (
-  deleteCardsService: DeleteCardsMutationFn,
+  deleteCardsMutation: DeleteCardsMutationFn,
   regionId: number,
   codes: CreateCardsResult[],
   t: TFunction
 ): Promise<void> => {
-  const result = await deleteCardsService({
+  const result = await deleteCardsMutation({
     variables: { regionId, cardInfoHashBase64List: extractCardInfoHashes(codes) },
   })
   if (result.errors) {

--- a/administration/src/cards/deleteCards.ts
+++ b/administration/src/cards/deleteCards.ts
@@ -1,19 +1,23 @@
-import { ApolloClient, ApolloError } from '@apollo/client'
+import { ApolloError } from '@apollo/client'
 import { TFunction } from 'i18next'
 
 import getMessageFromApolloError from '../errors/getMessageFromApolloError'
-import { DeleteCardsDocument, DeleteCardsMutation, DeleteCardsMutationVariables } from '../generated/graphql'
-import { CreateCardsError } from './createCards'
+import { DeleteCardsMutationFn } from '../generated/graphql'
+import { CreateCardsError, CreateCardsResult } from './createCards'
+
+const extractCardInfoHashes = (codes: CreateCardsResult[]) =>
+  codes.flatMap(({ dynamicCardInfoHashBase64, staticCardInfoHashBase64 }) =>
+    staticCardInfoHashBase64 ? [dynamicCardInfoHashBase64, staticCardInfoHashBase64] : dynamicCardInfoHashBase64
+  )
 
 const deleteCards = async (
-  client: ApolloClient<object>,
+  deleteCardsService: DeleteCardsMutationFn,
   regionId: number,
-  cardInfoHashesBase64: string[],
+  codes: CreateCardsResult[],
   t: TFunction
 ): Promise<void> => {
-  const result = await client.mutate<DeleteCardsMutation, DeleteCardsMutationVariables>({
-    mutation: DeleteCardsDocument,
-    variables: { regionId, cardInfoHashBase64List: cardInfoHashesBase64 },
+  const result = await deleteCardsService({
+    variables: { regionId, cardInfoHashBase64List: extractCardInfoHashes(codes) },
   })
   if (result.errors) {
     const { title } = getMessageFromApolloError(new ApolloError({ graphQLErrors: result.errors }), t)

--- a/administration/src/project-configs/getProjectConfig.ts
+++ b/administration/src/project-configs/getProjectConfig.ts
@@ -26,7 +26,7 @@ import showcaseConfig from './showcase/config'
 
 export type PdfConfig = {
   title: string
-  templatePath: string | null
+  templatePath: string
   issuer: string
   customBoldFont?: string
   elements?: {

--- a/administration/src/util/__tests__/getCustomDeepLinkFromQrCode.test.ts
+++ b/administration/src/util/__tests__/getCustomDeepLinkFromQrCode.test.ts
@@ -1,0 +1,23 @@
+import { mockedCardMutation } from '../../bp-modules/self-service/__mock__/mockSelfServiceCard'
+import { PdfQrCode } from '../../cards/pdf/PdfQrCodeElement'
+import { DynamicActivationCode } from '../../generated/card_pb'
+import koblenzConfig from '../../project-configs/koblenz/config'
+import { base64ToUint8Array } from '../base64'
+import getCustomDeepLinkFromQrCode from '../getCustomDeepLinkFromQrCode'
+
+jest.useFakeTimers({ now: new Date('2024-01-01T00:00:00.000Z') })
+
+describe('getCustomDeepLinkFromQrCode', () => {
+  const dynamicPdfQrCode: PdfQrCode = {
+    case: 'dynamicActivationCode',
+    value: DynamicActivationCode.fromBinary(
+      base64ToUint8Array(mockedCardMutation.result.data.card.dynamicActivationCode.codeBase64)
+    ),
+  }
+
+  it('should generate correct deep link', () => {
+    expect(getCustomDeepLinkFromQrCode(koblenzConfig, dynamicPdfQrCode)).toBe(
+      'koblenzpass://koblenz.sozialpass.app/activation/code#ClcKLQoNS2FybGEgS29ibGVuehDmnwEaGAoCCF8SBAjqvgEqBAiLmgEyBgoEMTIzSxIQL%2Fle3xYGNIKS50god4ITmxoUOUYGq%2FjAE99bK4edMPo2I3ojr78%3D/'
+    )
+  })
+})


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Refactor useCardGenerator and useCardGeneratorSelfService hooks and other utilities.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Move card initialization from query params to useCardGenerator
- Extract code from hooks to new files useSendConfirmationMail and cardGenerationError and some old files
- Reuse code between useCardGenerator and useCardGeneratorSelfService
- Refactor createCards, CsvFactory, deleteCards, PdfFactory

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Pdf download name for self service is now `KoblenzPass.pdf` instead of `KoblenzPass`
- Opening a csv in card import, navigating back (accepting the popup) leads to an error (however, this is the same on main and I was not able to reproduce this on staging).

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Test everything related to card generation (normal + self service) and csv and pdf generation.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1799
