### PR TITLE
1918: Fix ResizeObserver loop error

### DIFF
--- a/administration/src/bp-modules/stores/StoresButtonBar.tsx
+++ b/administration/src/bp-modules/stores/StoresButtonBar.tsx
@@ -1,5 +1,4 @@
 import { Alert, Button, Tooltip } from '@blueprintjs/core'
-import { TFunction } from 'i18next'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -13,16 +12,6 @@ type UploadStoresButtonBarProps = {
   importStores: () => void
   dryRun: boolean
   setDryRun: (value: boolean) => void
-}
-
-const getToolTipMessage = (hasNoAcceptingStores: boolean, hasInvalidStores: boolean, t: TFunction): string => {
-  if (hasNoAcceptingStores) {
-    return t('hasNoAcceptingStores')
-  }
-  if (hasInvalidStores) {
-    return t('hasInvalidStores')
-  }
-  return t('importStores')
 }
 
 const StoresButtonBar = ({
@@ -46,8 +35,8 @@ const StoresButtonBar = ({
       <Button icon='arrow-left' text={t('backToSelection')} onClick={goBack} />
       <Tooltip
         placement='top'
-        content={getToolTipMessage(hasNoAcceptingStores, hasInvalidStores, t)}
-        disabled={false}
+        content={hasNoAcceptingStores ? t('hasNoAcceptingStores') : t('hasInvalidStores')}
+        disabled={!hasNoAcceptingStores && !hasInvalidStores}
         openOnTargetFocus={false}>
         <Button
           icon='upload'


### PR DESCRIPTION
### Short Description
Under some conditions, the following error occurred on the page of importing stores when hovering the cursor over the “Importiere Akzeptanzpartner ” button.
![image](https://github.com/user-attachments/assets/febcb10e-4eee-4a31-bfcb-931ceb33b912)

### Proposed Changes
Adding a condition to disable the tooltip helps avoid the error

### Side Effects
no?

### Testing
Please follow the steps from the issue description

### Resolved Issues
Fixes: #1918
