### PR TITLE
1935: Sentry sends reports for staging

### DIFF
--- a/administration/src/util/__tests__/getDeepLinkFromQrCode.test.ts
+++ b/administration/src/util/__tests__/getDeepLinkFromQrCode.test.ts
@@ -57,6 +57,7 @@ describe('DeepLink generation', () => {
     })
 
   it('should generate a correct link for development', () => {
+    process.env.REACT_APP_IS_PRODUCTION = 'false'
     localStorage.setItem(LOCAL_STORAGE_PROJECT_KEY, BAYERN_STAGING_ID)
     const projectId = getBuildConfig(window.location.hostname).common.projectId.staging
     expect(getDeepLinkFromQrCode(dynamicPdfQrCode)).toBe(
@@ -64,6 +65,7 @@ describe('DeepLink generation', () => {
     )
   })
   it('should generate a correct link for staging', () => {
+    process.env.REACT_APP_IS_PRODUCTION = 'true'
     overrideHostname(BAYERN_STAGING_ID)
     const projectId = getBuildConfig(window.location.hostname).common.projectId.staging
     expect(getDeepLinkFromQrCode(dynamicPdfQrCode)).toBe(
@@ -72,6 +74,7 @@ describe('DeepLink generation', () => {
   })
   it('should generate a correct link for production', () => {
     overrideHostname(BAYERN_PRODUCTION_ID)
+    process.env.REACT_APP_IS_PRODUCTION = 'true'
     const projectId = getBuildConfig(window.location.hostname).common.projectId.production
     expect(getDeepLinkFromQrCode(dynamicPdfQrCode)).toBe(
       `${HTTPS_SCHEME}://${projectId}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodedActivationCodeBase64}/`

--- a/administration/src/util/getDeepLinkFromQrCode.ts
+++ b/administration/src/util/getDeepLinkFromQrCode.ts
@@ -4,7 +4,7 @@ import { PdfQrCode } from '../cards/pdf/PdfQrCodeElement'
 import { QrCode } from '../generated/card_pb'
 import { uint8ArrayToBase64 } from './base64'
 import { getBuildConfig } from './getBuildConfig'
-import { isDevMode, isStagingMode } from './helper'
+import { isDevEnvironment, isStagingEnvironment } from './helper'
 
 const getDeepLinkFromQrCode = (qrCode: PdfQrCode): string => {
   const qrCodeContent = new QrCode({
@@ -12,11 +12,12 @@ const getDeepLinkFromQrCode = (qrCode: PdfQrCode): string => {
   }).toBinary()
   const buildConfigProjectId = getBuildConfig(window.location.hostname).common.projectId
   // custom link schemes don't work in browsers or pdf thats why we use the staging link scheme also for development
-  const host = isStagingMode() || isDevMode() ? buildConfigProjectId.staging : buildConfigProjectId.production
+  const host =
+    isStagingEnvironment() || isDevEnvironment() ? buildConfigProjectId.staging : buildConfigProjectId.production
   const deepLink = `${HTTPS_SCHEME}://${host}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodeURIComponent(
     uint8ArrayToBase64(qrCodeContent)
   )}/`
-  if (isDevMode() || isStagingMode()) {
+  if (isDevEnvironment() || isStagingEnvironment()) {
     console.log(deepLink)
   }
   return deepLink

--- a/administration/src/util/getDeepLinkFromQrCode.ts
+++ b/administration/src/util/getDeepLinkFromQrCode.ts
@@ -4,7 +4,7 @@ import { PdfQrCode } from '../cards/pdf/PdfQrCodeElement'
 import { QrCode } from '../generated/card_pb'
 import { uint8ArrayToBase64 } from './base64'
 import { getBuildConfig } from './getBuildConfig'
-import { isDevEnvironment, isStagingEnvironment } from './helper'
+import { isProductionEnvironment } from './helper'
 
 const getDeepLinkFromQrCode = (qrCode: PdfQrCode): string => {
   const qrCodeContent = new QrCode({
@@ -12,12 +12,11 @@ const getDeepLinkFromQrCode = (qrCode: PdfQrCode): string => {
   }).toBinary()
   const buildConfigProjectId = getBuildConfig(window.location.hostname).common.projectId
   // custom link schemes don't work in browsers or pdf thats why we use the staging link scheme also for development
-  const host =
-    isStagingEnvironment() || isDevEnvironment() ? buildConfigProjectId.staging : buildConfigProjectId.production
+  const host = isProductionEnvironment() ? buildConfigProjectId.production : buildConfigProjectId.staging
   const deepLink = `${HTTPS_SCHEME}://${host}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodeURIComponent(
     uint8ArrayToBase64(qrCodeContent)
   )}/`
-  if (isDevEnvironment() || isStagingEnvironment()) {
+  if (!isProductionEnvironment()) {
     console.log(deepLink)
   }
   return deepLink

--- a/administration/src/util/helper.ts
+++ b/administration/src/util/helper.ts
@@ -3,7 +3,6 @@ import XRegExp from 'xregexp'
 export const isStagingEnvironment = (): boolean => !!window.location.hostname.match(/staging./)
 export const isProductionEnvironment = (): boolean =>
   process.env.REACT_APP_IS_PRODUCTION === 'true' && !isStagingEnvironment()
-export const isDevEnvironment = (): boolean => window.location.hostname === 'localhost'
 
 export const updateArrayItem = <T>(array: T[], updatedItem: T, index: number): T[] => {
   if (index >= array.length || index < 0) {

--- a/administration/src/util/helper.ts
+++ b/administration/src/util/helper.ts
@@ -1,8 +1,9 @@
 import XRegExp from 'xregexp'
 
-export const isProductionEnvironment = (): boolean => process.env.REACT_APP_IS_PRODUCTION === 'true'
-export const isDevMode = (): boolean => window.location.hostname === 'localhost'
-export const isStagingMode = (): boolean => !!window.location.hostname.match(/staging./)
+export const isStagingEnvironment = (): boolean => !!window.location.hostname.match(/staging./)
+export const isProductionEnvironment = (): boolean =>
+  process.env.REACT_APP_IS_PRODUCTION === 'true' && !isStagingEnvironment()
+export const isDevEnvironment = (): boolean => window.location.hostname === 'localhost'
 
 export const updateArrayItem = <T>(array: T[], updatedItem: T, index: number): T[] => {
   if (index >= array.length || index < 0) {


### PR DESCRIPTION
### Short Description

Since we build the same bundles for staging and production on web, we have to distinguish between staging and production on the basis of the domain. Thats why we currently send reports also for staging.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add a missing hostname check
- unify function names

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1935
