### PR TITLE
Allow parallel installation of development and production builds

### DIFF
--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -38,7 +38,7 @@ idea {
 ext.setupApplication = { ApplicationProductFlavor flavor, buildConfigName ->
     var buildConfig = createBuildConfig(buildConfigName)
     flavor.applicationId buildConfig.applicationId
-    flavor.manifestPlaceholders = [*:determineIcon(buildConfig)]
+    flavor.manifestPlaceholders = [*:determineAppName(buildConfig), *:determineIcon(buildConfig)]
 
     setupResourceValues(buildConfigName, {
         String type, String name, String value -> flavor.resValue(type, name, value)
@@ -112,7 +112,14 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix = ".development"
+            manifestPlaceholders.appNameSuffix = " DEV"
+        }
+
         release {
+            manifestPlaceholders.appNameSuffix = ""
+
             ndk {
                 // Flutter does not support x86, so we exclude it in the following list: https://github.com/flutter/flutter/issues/9253
                 abiFilters 'armeabi-v7a','arm64-v8a','x86_64'

--- a/frontend/android/app/buildConfigs.gradle
+++ b/frontend/android/app/buildConfigs.gradle
@@ -55,10 +55,13 @@ def setupResourceValues(buildConfigName, resValue) {
     }
 }
 
+def determineAppName(buildConfig) {
+    return [appName: "${buildConfig.appName}"]
+}
+
 def determineIcon(buildConfig) {
     return [icon: "${buildConfig.appIcon}"]
 }
-
 
 def determineBuildConfigName() {
     if (project.hasProperty('BUILD_CONFIG_NAME')) {
@@ -76,6 +79,7 @@ ext {
     // setupGoogleServices = this.&setupGoogleServices
     setupResourceValues = this.&setupResourceValues
     // determineTheme = this.&determineTheme
+    determineAppName = this.&determineAppName
     determineIcon = this.&determineIcon
     determineBuildConfigName = this.&determineBuildConfigName
 }

--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
        additional functionality it is fine to subclass or reimplement
        FlutterApplication and put your custom class here. -->
   <application
-          android:label="@string/BUILD_CONFIG_APP_NAME"
+          android:label="${appName}${appNameSuffix}"
           android:icon="@mipmap/${icon}"
           android:roundIcon="@mipmap/${icon}_round"
           android:allowBackup="true"


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Allow parallel installation of development and production builds on android.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Add `.development` to application id for development builds
- Add ` DEV` suffix to app name for development builds

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Previous installations will not be used anymore, so e.g. cards have to be added again

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Install both a production build from the store and a development build in parallel.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A
