### PR TITLE
Cancel exclusion of android and ios folders in IntelliJ

### DIFF
--- a/frontend/.idea/frontend.iml
+++ b/frontend/.idea/frontend.iml
@@ -5,11 +5,10 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/lib" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/android/app/src/main/res" type="java-resource" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
-      <excludeFolder url="file://$MODULE_DIR$/android" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/ios" />
       <excludeFolder url="file://$MODULE_DIR$/.fvm/flutter_sdk" />
       <excludeFolder url="file://$MODULE_DIR$/pubs/df_build_config/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/pubs/df_build_config/build" />
@@ -19,6 +18,9 @@
       <excludeFolder url="file://$MODULE_DIR$/pubs/df_protobuf/build" />
       <excludeFolder url="file://$MODULE_DIR$/vendor" />
       <excludeFolder url="file://$MODULE_DIR$/.fvm/versions" />
+      <excludeFolder url="file://$MODULE_DIR$/android/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/android/build" />
+      <excludeFolder url="file://$MODULE_DIR$/android/app/build" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Flutter Plugins" level="project" />


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Cancel exclusion of android and ios folders in IntelliJ to allow for easy search in these directories.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Cancel exclusion of android and ios folders in IntelliJ to allow for easy search in these directories.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A
