### PR TITLE
1958: Fix the key for JuLeiCa card attachment title in the application form

### DIFF
--- a/administration/src/mui-modules/application/forms/JuleicaEntitlementForm.tsx
+++ b/administration/src/mui-modules/application/forms/JuleicaEntitlementForm.tsx
@@ -44,7 +44,7 @@ const JuleicaEntitlementForm: Form<State, ValidatedInput> = {
           setState={useUpdateStateCallback(setState, 'juleicaExpirationDate')}
           options={{ maximumDate: null }}
         />
-        <h4>{t('applicationForms:juleicaCardAttachment')}</h4>
+        <h4>{t('applicationForms:juleicaCardAttachmentTitle')}</h4>
         <p>
           {t('applicationForms:juleicaCardAttachmentDescription')} {FileRequirementsText}
         </p>


### PR DESCRIPTION
### Short Description

Fix a key for a translation.

### Proposed Changes

-

### Side Effects

-

### Testing

- Start the administration frontend: `npm run start` in `/administration`
- Visit http://localhost:3000/beantragen
- In step 2, choose "Blaue Ehrenamtskarte", (for easier stepping, comment line 120 in `administration/src/mui-modules/application/SteppedSubForms.tsx`
- In step 4, see the attachment title

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1958 
