### PR TITLE
Exclude ios folders

### DIFF
--- a/frontend/.idea/frontend.iml
+++ b/frontend/.idea/frontend.iml
@@ -21,6 +21,8 @@
       <excludeFolder url="file://$MODULE_DIR$/android/.gradle" />
       <excludeFolder url="file://$MODULE_DIR$/android/build" />
       <excludeFolder url="file://$MODULE_DIR$/android/app/build" />
+      <excludeFolder url="file://$MODULE_DIR$/ios/.symlinks" />
+      <excludeFolder url="file://$MODULE_DIR$/ios/build" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Flutter Plugins" level="project" />


### PR DESCRIPTION
### Short Description

All flutter dart files of plugins are in the `.symlink` folder. That makes searching of code for dart super difficult.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- exclude symlink (plugins) 
- exclude build (not needed)

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

N/A


