### PR TITLE
1285: Fix launching apple maps

### DIFF
--- a/frontend/lib/store_widgets/detail/detail_content.dart
+++ b/frontend/lib/store_widgets/detail/detail_content.dart
@@ -125,7 +125,7 @@ class DetailContent extends StatelessWidget {
     if (Platform.isAndroid) {
       await launchUrl(Uri(scheme: 'geo', host: '0,0', queryParameters: {'q': query}));
     } else if (Platform.isIOS) {
-      await launchUrl(Uri.https('maps.apple.com', '/', {'q': query}));
+      await launchUrl(Uri.https('maps.apple.com', '/', {'q': query}), mode: LaunchMode.externalNonBrowserApplication);
     } else {
       await launchUrl(Uri.https('www.google.com', '/maps/search/', {'api': '1', 'query': query}));
     }


### PR DESCRIPTION
### Short Description

Currently we are facing an (handled) error if an address of a store was opened on ios

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add launch mode external for ios

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Apple maps is opened directly without safari. I guess that shouldn't be a problem though, since "Maps" can't be deleted from an ios device

### Testing (dev & ios only)
- Open a store in bayrische ehrenamtskarte f.e. search for "Brückstraße" then open on the detail view the address. There shouldn't be error in the console anymore

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1285 
