### PR TITLE
1766: Unify date picker components 

### DIFF
--- a/administration/package.json
+++ b/administration/package.json
@@ -17,7 +17,7 @@
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.6",
     "@mui/system": "^5.13.6",
-    "@mui/x-date-pickers": "^7.22.2",
+    "@mui/x-date-pickers": "^7.27.3",
     "@nivo/bar": "^0.85.1",
     "@pdf-lib/fontkit": "^1.1.1",
     "@sentry/react": "^8.55.0",

--- a/administration/package.json
+++ b/administration/package.json
@@ -17,6 +17,7 @@
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.6",
     "@mui/system": "^5.13.6",
+    "@mui/utils": "^6.4.6",
     "@mui/x-date-pickers": "^7.27.3",
     "@nivo/bar": "^0.85.1",
     "@pdf-lib/fontkit": "^1.1.1",

--- a/administration/package.json
+++ b/administration/package.json
@@ -18,7 +18,7 @@
     "@mui/material": "^5.13.6",
     "@mui/system": "^5.13.6",
     "@mui/utils": "^6.4.6",
-    "@mui/x-date-pickers": "^7.27.3",
+    "@mui/x-date-pickers": "^7.28.2",
     "@nivo/bar": "^0.85.1",
     "@pdf-lib/fontkit": "^1.1.1",
     "@sentry/react": "^8.55.0",

--- a/administration/src/bp-modules/StickyBottomBar.tsx
+++ b/administration/src/bp-modules/StickyBottomBar.tsx
@@ -11,9 +11,8 @@ const StickyBottomBar = styled(Card)`
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
-  & button {
-    margin: 5px;
-  }
+  align-items: center;
+  gap: 16px;
 `
 
 export default StickyBottomBar

--- a/administration/src/bp-modules/cards/AddCardForm.tsx
+++ b/administration/src/bp-modules/cards/AddCardForm.tsx
@@ -1,5 +1,4 @@
 import { Button, FormGroup, InputGroup, Intent, Card as UiCard } from '@blueprintjs/core'
-import { TextField } from '@mui/material'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -8,6 +7,7 @@ import { hasInfiniteLifetime, isExpirationDateValid, isFullNameValid } from '../
 import type { Card } from '../../cards/Card'
 import { maxCardValidity } from '../../cards/constants'
 import PlainDate from '../../util/PlainDate'
+import CustomDatePicker from '../components/CustomDatePicker'
 import ExtensionForms from './ExtensionForms'
 
 const CardHeader = styled.div`
@@ -45,20 +45,21 @@ const AddCardForm = ({ card, onRemove, updateCard }: CreateCardsFormProps): Reac
       </FormGroup>
       {!hasInfiniteLifetime(card) && (
         <FormGroup label={t('expirationDate')}>
-          <TextField
-            fullWidth
-            type='date'
-            required
-            size='small'
-            error={!isExpirationDateValid(card)}
-            value={card.expirationDate?.toString()}
-            sx={{ '& input[value=""]:not(:focus)': { color: 'transparent' }, '& fieldset': { borderRadius: 0 } }}
-            inputProps={{
-              style: { fontSize: 14, padding: '6px 10px' },
-              min: today.toString(),
-              max: today.add(maxCardValidity).toString(),
+          <CustomDatePicker
+            value={card.expirationDate?.toLocalDate() ?? null}
+            isValid={!isExpirationDateValid(card)}
+            minDate={today.toLocalDate()}
+            maxDate={today.add(maxCardValidity).toLocalDate()}
+            onChange={date => {
+              updateCard({ expirationDate: PlainDate.constructSafely(date, PlainDate.fromLocalDate) })
             }}
-            onChange={event => updateCard({ expirationDate: PlainDate.safeFrom(event.target.value) })}
+            textFieldSlotProps={{
+              sx: {
+                '.MuiPickersSectionList-root': {
+                  padding: '5px 0',
+                },
+              },
+            }}
           />
         </FormGroup>
       )}

--- a/administration/src/bp-modules/cards/AddCardForm.tsx
+++ b/administration/src/bp-modules/cards/AddCardForm.tsx
@@ -47,7 +47,7 @@ const AddCardForm = ({ card, onRemove, updateCard }: CreateCardsFormProps): Reac
         <FormGroup label={t('expirationDate')}>
           <CustomDatePicker
             value={card.expirationDate?.toLocalDate() ?? null}
-            isValid={isExpirationDateValid(card)}
+            error={!isExpirationDateValid(card)}
             minDate={today.toLocalDate()}
             maxDate={today.add(maxCardValidity).toLocalDate()}
             onChange={date => {

--- a/administration/src/bp-modules/cards/AddCardForm.tsx
+++ b/administration/src/bp-modules/cards/AddCardForm.tsx
@@ -47,7 +47,7 @@ const AddCardForm = ({ card, onRemove, updateCard }: CreateCardsFormProps): Reac
         <FormGroup label={t('expirationDate')}>
           <CustomDatePicker
             value={card.expirationDate?.toLocalDate() ?? null}
-            isValid={!isExpirationDateValid(card)}
+            isValid={isExpirationDateValid(card)}
             minDate={today.toLocalDate()}
             maxDate={today.add(maxCardValidity).toLocalDate()}
             onChange={date => {

--- a/administration/src/bp-modules/cards/AddCardForm.tsx
+++ b/administration/src/bp-modules/cards/AddCardForm.tsx
@@ -51,7 +51,7 @@ const AddCardForm = ({ card, onRemove, updateCard }: CreateCardsFormProps): Reac
             minDate={today.toLocalDate()}
             maxDate={today.add(maxCardValidity).toLocalDate()}
             onChange={date => {
-              updateCard({ expirationDate: PlainDate.constructSafely(date, PlainDate.fromLocalDate) })
+              updateCard({ expirationDate: PlainDate.safeFromLocalDate(date) })
             }}
             textFieldSlotProps={{
               sx: {

--- a/administration/src/bp-modules/components/CustomDatePicker.tsx
+++ b/administration/src/bp-modules/components/CustomDatePicker.tsx
@@ -4,8 +4,6 @@ import type { DesktopDatePickerSlotProps } from '@mui/x-date-pickers/DesktopDate
 import { deDE } from '@mui/x-date-pickers/locales'
 import React, { ReactElement } from 'react'
 
-import useWindowDimensions from '../../hooks/useWindowDimensions'
-
 type CustomDatePickerProps = {
   value?: Date | null
   disabled?: boolean
@@ -36,60 +34,55 @@ const CustomDatePicker = ({
   disablePast,
   textFieldHelperText,
   textFieldSlotProps,
-}: CustomDatePickerProps): ReactElement => {
-  const { viewportSmall } = useWindowDimensions()
-
-  return (
-    <DesktopDatePicker
-      disabled={disabled}
-      label={label}
-      views={['year', 'month', 'day']}
-      openTo='year'
-      value={value}
-      format='dd.MM.yyyy'
-      sx={{ '& input[value=""]:not(:focus)': { color: 'transparent' } }}
-      slotProps={{
-        openPickerIcon: { fontSize: 'small' },
-        field: {
-          clearable: true,
-          onClear,
-        },
-        textField: deepmerge(
-          {
-            helperText: textFieldHelperText,
-            placeholder: 'TT.MM.JJJJ',
-            error: !isValid,
-            spellCheck: false,
-            onBlur,
-            size: 'small',
-            sx: {
-              width: '100%',
-              boxShadow: !isValid
-                ? `
+}: CustomDatePickerProps): ReactElement => (
+  <DesktopDatePicker
+    disabled={disabled}
+    label={label}
+    views={['year', 'month', 'day']}
+    openTo='year'
+    value={value}
+    format='dd.MM.yyyy'
+    sx={{ '& input[value=""]:not(:focus)': { color: 'transparent' } }}
+    slotProps={{
+      openPickerIcon: { fontSize: 'small' },
+      field: {
+        clearable: true,
+        onClear,
+      },
+      textField: deepmerge(
+        {
+          helperText: textFieldHelperText,
+          placeholder: 'TT.MM.JJJJ',
+          error: !isValid,
+          spellCheck: false,
+          onBlur,
+          size: 'small',
+          sx: {
+            width: '100%',
+            boxShadow: !isValid
+              ? `
                 0 0 0 0 rgba(205, 66, 70, 0),
                 inset 0 0 0 1px #cd4246,
                 inset 0 0 0 1px rgba(17, 20, 24, 0.2),
                 inset 0 1px 1px rgba(17, 20, 24, 0.3),
               `
-                : undefined,
-              '.MuiPickersInputBase-root': {
-                fontSize: viewportSmall ? '16px' : '14px',
-                borderRadius: '2px',
-              },
+              : undefined,
+            '.MuiPickersInputBase-root': {
+              borderRadius: '2px',
             },
           },
-          textFieldSlotProps
-        ),
-      }}
-      enableAccessibleFieldDOMStructure
-      localeText={deDE.components.MuiLocalizationProvider.defaultProps.localeText}
-      disableFuture={disableFuture}
-      disablePast={disablePast}
-      minDate={minDate}
-      maxDate={maxDate}
-      onChange={onChange}
-    />
-  )
-}
+        },
+        textFieldSlotProps
+      ),
+    }}
+    enableAccessibleFieldDOMStructure
+    localeText={deDE.components.MuiLocalizationProvider.defaultProps.localeText}
+    disableFuture={disableFuture}
+    disablePast={disablePast}
+    minDate={minDate}
+    maxDate={maxDate}
+    onChange={onChange}
+  />
+)
 
 export default CustomDatePicker

--- a/administration/src/bp-modules/components/CustomDatePicker.tsx
+++ b/administration/src/bp-modules/components/CustomDatePicker.tsx
@@ -5,7 +5,7 @@ import React, { CSSProperties, ReactElement } from 'react'
 import useWindowDimensions from '../../hooks/useWindowDimensions'
 
 type CustomDatePickerProps = {
-  date: Date | null
+  value?: Date | null
   disabled?: boolean
   label?: string
   onBlur?: () => void
@@ -21,7 +21,7 @@ type CustomDatePickerProps = {
 }
 
 const CustomDatePicker = ({
-  date,
+  value,
   disabled,
   label,
   onBlur,
@@ -44,7 +44,7 @@ const CustomDatePicker = ({
       disabled={disabled}
       label={label}
       views={['year', 'month', 'day']}
-      value={date}
+      value={value}
       format='dd.MM.yyyy'
       slotProps={{
         clearIcon: { fontSize: viewportSmall ? 'medium' : 'small' },

--- a/administration/src/bp-modules/components/CustomDatePicker.tsx
+++ b/administration/src/bp-modules/components/CustomDatePicker.tsx
@@ -1,22 +1,29 @@
 import { DesktopDatePicker } from '@mui/x-date-pickers'
 import { deDE } from '@mui/x-date-pickers/locales'
-import React, { ReactElement } from 'react'
+import React, { CSSProperties, ReactElement } from 'react'
 
 import useWindowDimensions from '../../hooks/useWindowDimensions'
 
 type CustomDatePickerProps = {
   date: Date | null
+  disabled?: boolean
+  label?: string
   onBlur?: () => void
   onChange?: (date: Date | null) => void
   onClear?: () => void
   isValid: boolean
   minDate?: Date
   maxDate?: Date
-  disableFuture: boolean
+  disableFuture?: boolean
+  disablePast?: boolean
+  textFieldHelperText?: string
+  textFieldStyle?: CSSProperties
 }
 
 const CustomDatePicker = ({
   date,
+  disabled,
+  label,
   onBlur,
   onChange,
   onClear,
@@ -24,6 +31,9 @@ const CustomDatePicker = ({
   minDate,
   maxDate,
   disableFuture,
+  disablePast,
+  textFieldHelperText,
+  textFieldStyle,
 }: CustomDatePickerProps): ReactElement => {
   const { viewportSmall } = useWindowDimensions()
   const formStyle = viewportSmall ? { fontSize: 16, padding: '9px 10px' } : { fontSize: 14, padding: '6px 10px' }
@@ -31,6 +41,8 @@ const CustomDatePicker = ({
     '0 0 0 0 rgba(205, 66, 70, 0), 0 0 0 0 rgba(205, 66, 70, 0), inset 0 0 0 1px #cd4246, inset 0 0 0 1px rgba(17, 20, 24, 0.2), inset 0 1px 1px rgba(17, 20, 24, 0.3)'
   return (
     <DesktopDatePicker
+      disabled={disabled}
+      label={label}
       views={['year', 'month', 'day']}
       value={date}
       format='dd.MM.yyyy'
@@ -39,10 +51,12 @@ const CustomDatePicker = ({
         openPickerIcon: { fontSize: 'small' },
         field: { clearable: true, onClear },
         textField: {
+          helperText: textFieldHelperText,
           placeholder: 'TT.MM.JJJJ',
           error: !isValid,
           spellCheck: false,
           onBlur,
+          style: textFieldStyle,
           sx: {
             width: '100%',
             input: formStyle,
@@ -52,6 +66,7 @@ const CustomDatePicker = ({
       }}
       localeText={deDE.components.MuiLocalizationProvider.defaultProps.localeText}
       disableFuture={disableFuture}
+      disablePast={disablePast}
       minDate={minDate}
       maxDate={maxDate}
       onChange={onChange}

--- a/administration/src/bp-modules/components/CustomDatePicker.tsx
+++ b/administration/src/bp-modules/components/CustomDatePicker.tsx
@@ -5,6 +5,8 @@ import type { DesktopDatePickerSlotProps } from '@mui/x-date-pickers/DesktopDate
 import { deDE } from '@mui/x-date-pickers/locales'
 import React, { ReactElement } from 'react'
 
+export type CustomDatePickerTextFieldProps = DesktopDatePickerSlotProps<Date, true>['textField']
+
 type CustomDatePickerProps = {
   value?: Date | null
   disabled?: boolean
@@ -18,7 +20,7 @@ type CustomDatePickerProps = {
   disableFuture?: boolean
   disablePast?: boolean
   textFieldHelperText?: string
-  textFieldSlotProps?: DesktopDatePickerSlotProps<Date, true>['textField']
+  textFieldSlotProps?: CustomDatePickerTextFieldProps
 }
 
 const CustomDatePicker = ({

--- a/administration/src/bp-modules/components/CustomDatePicker.tsx
+++ b/administration/src/bp-modules/components/CustomDatePicker.tsx
@@ -36,9 +36,7 @@ const CustomDatePicker = ({
   textFieldStyle,
 }: CustomDatePickerProps): ReactElement => {
   const { viewportSmall } = useWindowDimensions()
-  const formStyle = viewportSmall ? { fontSize: 16, padding: '9px 10px' } : { fontSize: 14, padding: '6px 10px' }
-  const textFieldBoxShadow =
-    '0 0 0 0 rgba(205, 66, 70, 0), 0 0 0 0 rgba(205, 66, 70, 0), inset 0 0 0 1px #cd4246, inset 0 0 0 1px rgba(17, 20, 24, 0.2), inset 0 1px 1px rgba(17, 20, 24, 0.3)'
+
   return (
     <DesktopDatePicker
       disabled={disabled}
@@ -46,10 +44,13 @@ const CustomDatePicker = ({
       views={['year', 'month', 'day']}
       value={value}
       format='dd.MM.yyyy'
+      sx={{ '& input[value=""]:not(:focus)': { color: 'transparent' } }}
       slotProps={{
-        clearIcon: { fontSize: viewportSmall ? 'medium' : 'small' },
         openPickerIcon: { fontSize: 'small' },
-        field: { clearable: true, onClear },
+        field: {
+          clearable: true,
+          onClear,
+        },
         textField: {
           helperText: textFieldHelperText,
           placeholder: 'TT.MM.JJJJ',
@@ -57,10 +58,21 @@ const CustomDatePicker = ({
           spellCheck: false,
           onBlur,
           style: textFieldStyle,
+          size: 'small',
           sx: {
             width: '100%',
-            input: formStyle,
-            boxShadow: !isValid ? textFieldBoxShadow : undefined,
+            boxShadow: !isValid
+              ? `
+                0 0 0 0 rgba(205, 66, 70, 0),
+                inset 0 0 0 1px #cd4246,
+                inset 0 0 0 1px rgba(17, 20, 24, 0.2),
+                inset 0 1px 1px rgba(17, 20, 24, 0.3),
+              `
+              : undefined,
+            '.MuiPickersInputBase-root': {
+              fontSize: viewportSmall ? '16px' : '14px',
+              borderRadius: '2px',
+            },
           },
         },
       }}

--- a/administration/src/bp-modules/components/CustomDatePicker.tsx
+++ b/administration/src/bp-modules/components/CustomDatePicker.tsx
@@ -6,9 +6,9 @@ import useWindowDimensions from '../../hooks/useWindowDimensions'
 
 type CustomDatePickerProps = {
   date: Date | null
-  onBlur: () => void
-  onChange: (date: Date | null) => void
-  onClear: () => void
+  onBlur?: () => void
+  onChange?: (date: Date | null) => void
+  onClear?: () => void
   isValid: boolean
   minDate?: Date
   maxDate?: Date

--- a/administration/src/bp-modules/components/CustomDatePicker.tsx
+++ b/administration/src/bp-modules/components/CustomDatePicker.tsx
@@ -12,7 +12,7 @@ type CustomDatePickerProps = {
   onBlur?: () => void
   onChange?: (date: Date | null) => void
   onClear?: () => void
-  isValid: boolean
+  error: boolean
   minDate?: Date
   maxDate?: Date
   disableFuture?: boolean
@@ -28,7 +28,7 @@ const CustomDatePicker = ({
   onBlur,
   onChange,
   onClear,
-  isValid,
+  error,
   minDate,
   maxDate,
   disableFuture,
@@ -57,13 +57,13 @@ const CustomDatePicker = ({
           {
             helperText: textFieldHelperText,
             placeholder: 'TT.MM.JJJJ',
-            error: !isValid,
+            error,
             spellCheck: false,
             onBlur,
             size: 'small',
             sx: {
               width: '100%',
-              boxShadow: !isValid
+              boxShadow: error
                 ? `
                   0 0 0 0 rgba(205, 66, 70, 0),
                   inset 0 0 0 1px #cd4246,

--- a/administration/src/bp-modules/components/CustomDatePicker.tsx
+++ b/administration/src/bp-modules/components/CustomDatePicker.tsx
@@ -1,6 +1,8 @@
+import { deepmerge } from '@mui/utils'
 import { DesktopDatePicker } from '@mui/x-date-pickers'
+import type { DesktopDatePickerSlotProps } from '@mui/x-date-pickers/DesktopDatePicker/DesktopDatePicker.types'
 import { deDE } from '@mui/x-date-pickers/locales'
-import React, { CSSProperties, ReactElement } from 'react'
+import React, { ReactElement } from 'react'
 
 import useWindowDimensions from '../../hooks/useWindowDimensions'
 
@@ -17,7 +19,7 @@ type CustomDatePickerProps = {
   disableFuture?: boolean
   disablePast?: boolean
   textFieldHelperText?: string
-  textFieldStyle?: CSSProperties
+  textFieldSlotProps?: DesktopDatePickerSlotProps<Date, true>['textField']
 }
 
 const CustomDatePicker = ({
@@ -33,7 +35,7 @@ const CustomDatePicker = ({
   disableFuture,
   disablePast,
   textFieldHelperText,
-  textFieldStyle,
+  textFieldSlotProps,
 }: CustomDatePickerProps): ReactElement => {
   const { viewportSmall } = useWindowDimensions()
 
@@ -52,30 +54,32 @@ const CustomDatePicker = ({
           clearable: true,
           onClear,
         },
-        textField: {
-          helperText: textFieldHelperText,
-          placeholder: 'TT.MM.JJJJ',
-          error: !isValid,
-          spellCheck: false,
-          onBlur,
-          style: textFieldStyle,
-          size: 'small',
-          sx: {
-            width: '100%',
-            boxShadow: !isValid
-              ? `
+        textField: deepmerge(
+          {
+            helperText: textFieldHelperText,
+            placeholder: 'TT.MM.JJJJ',
+            error: !isValid,
+            spellCheck: false,
+            onBlur,
+            size: 'small',
+            sx: {
+              width: '100%',
+              boxShadow: !isValid
+                ? `
                 0 0 0 0 rgba(205, 66, 70, 0),
                 inset 0 0 0 1px #cd4246,
                 inset 0 0 0 1px rgba(17, 20, 24, 0.2),
                 inset 0 1px 1px rgba(17, 20, 24, 0.3),
               `
-              : undefined,
-            '.MuiPickersInputBase-root': {
-              fontSize: viewportSmall ? '16px' : '14px',
-              borderRadius: '2px',
+                : undefined,
+              '.MuiPickersInputBase-root': {
+                fontSize: viewportSmall ? '16px' : '14px',
+                borderRadius: '2px',
+              },
             },
           },
-        },
+          textFieldSlotProps
+        ),
       }}
       enableAccessibleFieldDOMStructure
       localeText={deDE.components.MuiLocalizationProvider.defaultProps.localeText}

--- a/administration/src/bp-modules/components/CustomDatePicker.tsx
+++ b/administration/src/bp-modules/components/CustomDatePicker.tsx
@@ -1,3 +1,4 @@
+import { useMediaQuery } from '@mui/system'
 import { deepmerge } from '@mui/utils'
 import { DesktopDatePicker } from '@mui/x-date-pickers'
 import type { DesktopDatePickerSlotProps } from '@mui/x-date-pickers/DesktopDatePicker/DesktopDatePicker.types'
@@ -34,55 +35,64 @@ const CustomDatePicker = ({
   disablePast,
   textFieldHelperText,
   textFieldSlotProps,
-}: CustomDatePickerProps): ReactElement => (
-  <DesktopDatePicker
-    disabled={disabled}
-    label={label}
-    views={['year', 'month', 'day']}
-    openTo='year'
-    value={value}
-    format='dd.MM.yyyy'
-    sx={{ '& input[value=""]:not(:focus)': { color: 'transparent' } }}
-    slotProps={{
-      openPickerIcon: { fontSize: 'small' },
-      field: {
-        clearable: true,
-        onClear,
-      },
-      textField: deepmerge(
-        {
-          helperText: textFieldHelperText,
-          placeholder: 'TT.MM.JJJJ',
-          error: !isValid,
-          spellCheck: false,
-          onBlur,
-          size: 'small',
-          sx: {
-            width: '100%',
-            boxShadow: !isValid
-              ? `
-                0 0 0 0 rgba(205, 66, 70, 0),
-                inset 0 0 0 1px #cd4246,
-                inset 0 0 0 1px rgba(17, 20, 24, 0.2),
-                inset 0 1px 1px rgba(17, 20, 24, 0.3),
-              `
-              : undefined,
-            '.MuiPickersInputBase-root': {
-              borderRadius: '2px',
+}: CustomDatePickerProps): ReactElement => {
+  const isMobile = !useMediaQuery('(pointer: fine)')
+
+  return (
+    <DesktopDatePicker
+      disabled={disabled}
+      label={label}
+      views={['year', 'month', 'day']}
+      openTo='year'
+      value={value}
+      format='dd.MM.yyyy'
+      sx={{ '& input[value=""]:not(:focus)': { color: 'transparent' } }}
+      slotProps={{
+        openPickerIcon: { fontSize: 'small' },
+        field: {
+          clearable: true,
+          onClear,
+        },
+        textField: deepmerge(
+          {
+            helperText: textFieldHelperText,
+            placeholder: 'TT.MM.JJJJ',
+            error: !isValid,
+            spellCheck: false,
+            onBlur,
+            size: 'small',
+            sx: {
+              width: '100%',
+              boxShadow: !isValid
+                ? `
+                  0 0 0 0 rgba(205, 66, 70, 0),
+                  inset 0 0 0 1px #cd4246,
+                  inset 0 0 0 1px rgba(17, 20, 24, 0.2),
+                  inset 0 1px 1px rgba(17, 20, 24, 0.3),
+                `
+                : undefined,
+              '.MuiPickersInputBase-root': {
+                borderRadius: '2px',
+              },
             },
           },
-        },
-        textFieldSlotProps
-      ),
-    }}
-    enableAccessibleFieldDOMStructure
-    localeText={deDE.components.MuiLocalizationProvider.defaultProps.localeText}
-    disableFuture={disableFuture}
-    disablePast={disablePast}
-    minDate={minDate}
-    maxDate={maxDate}
-    onChange={onChange}
-  />
-)
+          textFieldSlotProps
+        ),
+      }}
+      // We use this property, since it (sort of) fixes some issues for Firefox Mobile (keyboard
+      // does not show digits only). On the other hand, it introduces a bug with keyboard
+      // navigation (inability to navigate out of component), so we switch on a media query here,
+      // to provide a satisfying result.
+      // TODO This property will become be the default and by then, hopefully all bugs will be fixed
+      enableAccessibleFieldDOMStructure={isMobile}
+      localeText={deDE.components.MuiLocalizationProvider.defaultProps.localeText}
+      disableFuture={disableFuture}
+      disablePast={disablePast}
+      minDate={minDate}
+      maxDate={maxDate}
+      onChange={onChange}
+    />
+  )
+}
 
 export default CustomDatePicker

--- a/administration/src/bp-modules/components/CustomDatePicker.tsx
+++ b/administration/src/bp-modules/components/CustomDatePicker.tsx
@@ -77,6 +77,7 @@ const CustomDatePicker = ({
           },
         },
       }}
+      enableAccessibleFieldDOMStructure
       localeText={deDE.components.MuiLocalizationProvider.defaultProps.localeText}
       disableFuture={disableFuture}
       disablePast={disablePast}

--- a/administration/src/bp-modules/components/CustomDatePicker.tsx
+++ b/administration/src/bp-modules/components/CustomDatePicker.tsx
@@ -42,6 +42,7 @@ const CustomDatePicker = ({
       disabled={disabled}
       label={label}
       views={['year', 'month', 'day']}
+      openTo='year'
       value={value}
       format='dd.MM.yyyy'
       sx={{ '& input[value=""]:not(:focus)': { color: 'transparent' } }}

--- a/administration/src/bp-modules/statistics/StatisticsController.tsx
+++ b/administration/src/bp-modules/statistics/StatisticsController.tsx
@@ -17,7 +17,7 @@ import { defaultEndDate, defaultStartDate } from './constants'
 const ViewProjectStatistics = () => {
   const { projectId } = useContext(ProjectConfigContext)
   const cardStatisticsQuery = useGetCardStatisticsInProjectQuery({
-    variables: { projectId, dateEnd: defaultEndDate, dateStart: defaultStartDate },
+    variables: { projectId, dateEnd: defaultEndDate.toString(), dateStart: defaultStartDate.toString() },
   })
   const cardStatisticsQueryResult = getQueryResult(cardStatisticsQuery)
 
@@ -36,8 +36,8 @@ const ViewRegionStatistics = ({ region }: { region: Region }) => {
   const cardStatisticsQuery = useGetCardStatisticsInRegionQuery({
     variables: {
       projectId,
-      dateEnd: defaultEndDate,
-      dateStart: defaultStartDate,
+      dateEnd: defaultEndDate.toString(),
+      dateStart: defaultStartDate.toString(),
       regionId: region.id,
     },
   })

--- a/administration/src/bp-modules/statistics/components/StatisticsFilterBar.test.tsx
+++ b/administration/src/bp-modules/statistics/components/StatisticsFilterBar.test.tsx
@@ -1,4 +1,7 @@
+import { LocalizationProvider } from '@mui/x-date-pickers'
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 import { act, fireEvent } from '@testing-library/react'
+import formatDate from 'date-fns/format'
 import React from 'react'
 
 import { renderWithTranslation } from '../../../testing/render'
@@ -6,6 +9,8 @@ import { defaultEndDate, defaultStartDate } from '../constants'
 import StatisticsFilterBar from './StatisticsFilterBar'
 
 jest.useFakeTimers()
+const dateFormat = 'dd.MM.yyyy'
+
 describe('StatisticFilterBar', () => {
   const onApplyFilter = jest.fn()
   const onExportCsv = jest.fn()
@@ -14,7 +19,9 @@ describe('StatisticFilterBar', () => {
 
   it('should execute onApplyFilter if filter button was clicked', async () => {
     const { getByText } = renderWithTranslation(
-      <StatisticsFilterBar onApplyFilter={onApplyFilter} isDataAvailable onExportCsv={onExportCsv} />
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <StatisticsFilterBar onApplyFilter={onApplyFilter} isDataAvailable onExportCsv={onExportCsv} />
+      </LocalizationProvider>
     )
     const applyFilterButton = getByText('Filter anwenden')
     fireEvent.click(applyFilterButton)
@@ -24,30 +31,38 @@ describe('StatisticFilterBar', () => {
 
   it('should disable filter button if start date is after end date', async () => {
     const { getByText, getByDisplayValue } = renderWithTranslation(
-      <StatisticsFilterBar onApplyFilter={onApplyFilter} isDataAvailable onExportCsv={onExportCsv} />
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <StatisticsFilterBar onApplyFilter={onApplyFilter} isDataAvailable onExportCsv={onExportCsv} />
+      </LocalizationProvider>
     )
     const applyFilterButton = getByText('Filter anwenden')
-    const startInput = getByDisplayValue(defaultStartDate)
-    const endInput = getByDisplayValue(defaultEndDate)
+    const startInput = getByDisplayValue(formatDate(defaultStartDate.toLocalDate(), dateFormat))
+    const endInput = getByDisplayValue(formatDate(defaultEndDate.toLocalDate(), dateFormat))
+
     fireEvent.change(startInput, {
       target: {
-        value: '2024-06-01',
+        value: '01.06.2024',
       },
     })
     fireEvent.change(endInput, {
       target: {
-        value: '2024-02-01',
+        value: '01.02.2024',
       },
     })
+
     expect(applyFilterButton.closest('button')).toBeDisabled()
   })
 
   it('should disable filter button if input is not a correct date string', () => {
     const { getByText, getByDisplayValue } = renderWithTranslation(
-      <StatisticsFilterBar onApplyFilter={onApplyFilter} isDataAvailable onExportCsv={onExportCsv} />
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <StatisticsFilterBar onApplyFilter={onApplyFilter} isDataAvailable onExportCsv={onExportCsv} />
+      </LocalizationProvider>
     )
+
     const applyFilterButton = getByText('Filter anwenden')
-    const startInput = getByDisplayValue(defaultStartDate)
+    const startInput = getByDisplayValue(formatDate(defaultStartDate.toLocalDate(), dateFormat))
+
     fireEvent.change(startInput, {
       target: {
         value: '2024-06-xx',
@@ -58,20 +73,25 @@ describe('StatisticFilterBar', () => {
 
   it('should display a proper tooltip message if filter button is disabled and filtering should not be applied', async () => {
     const { getByText, getByDisplayValue } = renderWithTranslation(
-      <StatisticsFilterBar onApplyFilter={onApplyFilter} isDataAvailable onExportCsv={onExportCsv} />
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <StatisticsFilterBar onApplyFilter={onApplyFilter} isDataAvailable onExportCsv={onExportCsv} />
+      </LocalizationProvider>
     )
-    const startInput = getByDisplayValue(defaultStartDate)
+    const applyFilterButton = getByText('Filter anwenden')
+    const startInput = getByDisplayValue(formatDate(defaultStartDate.toLocalDate(), dateFormat))
+
     fireEvent.change(startInput, {
       target: {
         value: '2024-06-xx',
       },
     })
-    const applyFilterButton = getByText('Filter anwenden')
     fireEvent.mouseOver(applyFilterButton)
     fireEvent.click(applyFilterButton)
+
     await act(async () => {
       jest.advanceTimersByTime(100)
     })
+
     expect(
       getByText(
         'Bitte geben Sie ein gültiges Start- und Enddatum an. Das Enddatum darf nicht vor dem Startdatum liegen.'
@@ -82,7 +102,9 @@ describe('StatisticFilterBar', () => {
 
   it('should execute onExportCsv if csv export button was clicked', async () => {
     const { getByText } = renderWithTranslation(
-      <StatisticsFilterBar onApplyFilter={onApplyFilter} isDataAvailable onExportCsv={onExportCsv} />
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <StatisticsFilterBar onApplyFilter={onApplyFilter} isDataAvailable onExportCsv={onExportCsv} />
+      </LocalizationProvider>
     )
     const csvExportButton = getByText('CSV Export')
     fireEvent.click(csvExportButton)
@@ -92,7 +114,9 @@ describe('StatisticFilterBar', () => {
 
   it('should disable csv export button if no data is available and show tooltip', async () => {
     const { getByText } = renderWithTranslation(
-      <StatisticsFilterBar onApplyFilter={onApplyFilter} isDataAvailable={false} onExportCsv={onExportCsv} />
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <StatisticsFilterBar onApplyFilter={onApplyFilter} isDataAvailable={false} onExportCsv={onExportCsv} />
+      </LocalizationProvider>
     )
 
     const csvExportButton = getByText('CSV Export')

--- a/administration/src/bp-modules/statistics/components/StatisticsFilterBar.tsx
+++ b/administration/src/bp-modules/statistics/components/StatisticsFilterBar.tsx
@@ -11,6 +11,7 @@ import { defaultEndDate, defaultStartDate } from '../constants'
 const StyledFormGroup = styled(FormGroup)`
   margin: 0 16px 0 0;
   align-self: center;
+  align-items: center;
 `
 
 const filterDateFormat = 'yyyy-MM-dd'

--- a/administration/src/bp-modules/statistics/components/StatisticsFilterBar.tsx
+++ b/administration/src/bp-modules/statistics/components/StatisticsFilterBar.tsx
@@ -1,4 +1,6 @@
-import { Button, FormGroup, Tooltip } from '@blueprintjs/core'
+import { Button, Tooltip } from '@blueprintjs/core'
+import { FormControlLabel } from '@mui/material'
+import type { FormControlLabelProps } from '@mui/material'
 import formatDate from 'date-fns/format'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -6,22 +8,18 @@ import styled from 'styled-components'
 
 import StickyBottomBar from '../../StickyBottomBar'
 import CustomDatePicker from '../../components/CustomDatePicker'
+import type { CustomDatePickerTextFieldProps } from '../../components/CustomDatePicker'
 import { defaultEndDate, defaultStartDate } from '../constants'
-
-const StyledFormGroup = styled(FormGroup)`
-  margin: 0 16px 0 0;
-  align-self: center;
-  align-items: center;
-`
 
 const filterDateFormat = 'yyyy-MM-dd'
 
 const InputContainer = styled.div`
   flex-direction: row;
   display: flex;
-  justify-content: flex-start;
+  justify-content: start;
+  align-items: center;
   flex: 1;
-  padding: 0 20px;
+  gap: 16px;
 `
 type StatisticsFilterBarProps = {
   onApplyFilter: (dateStart: string, dateEnd: string) => void
@@ -33,6 +31,19 @@ const isValidDate = (value: Date | null): value is Date => value !== null && !Nu
 
 const isValidDateTimePeriod = (dateStart: Date | null, dateEnd: Date | null): boolean =>
   isValidDate(dateStart) && isValidDate(dateEnd) && dateStart.valueOf() <= dateEnd.valueOf()
+
+const formControlStyle: FormControlLabelProps['sx'] = {
+  marginLeft: 0,
+  marginRight: 0,
+  gap: '8px',
+}
+
+const datePickerTextFieldProps: CustomDatePickerTextFieldProps = {
+  size: 'small',
+  sx: {
+    width: '180px',
+  },
+}
 
 const StatisticsFilterBar = ({
   onApplyFilter,
@@ -46,42 +57,38 @@ const StatisticsFilterBar = ({
   return (
     <StickyBottomBar>
       <InputContainer>
-        <StyledFormGroup label={t('start')} inline>
-          <CustomDatePicker
-            value={dateStart}
-            error={!isValidDate(dateStart)}
-            maxDate={dateEnd ?? defaultStartDate.toLocalDate()}
-            textFieldSlotProps={{
-              size: 'small',
-              sx: {
-                '.MuiPickersSectionList-root': {
-                  padding: '5px 0',
-                },
-              },
-            }}
-            onChange={date => {
-              setDateStart(date)
-            }}
-          />
-        </StyledFormGroup>
-        <StyledFormGroup label={t('end')} inline>
-          <CustomDatePicker
-            value={dateEnd}
-            error={!isValidDate(dateEnd)}
-            textFieldSlotProps={{
-              size: 'small',
-              sx: {
-                '.MuiPickersSectionList-root': {
-                  padding: '5px 0',
-                },
-              },
-            }}
-            maxDate={new Date()}
-            onChange={date => {
-              setDateEnd(date)
-            }}
-          />
-        </StyledFormGroup>
+        <FormControlLabel
+          label={t('start')}
+          labelPlacement='start'
+          sx={formControlStyle}
+          control={
+            <CustomDatePicker
+              value={dateStart}
+              error={!isValidDate(dateStart)}
+              maxDate={dateEnd ?? defaultStartDate.toLocalDate()}
+              textFieldSlotProps={datePickerTextFieldProps}
+              onChange={date => {
+                setDateStart(date)
+              }}
+            />
+          }
+        />
+        <FormControlLabel
+          label={t('end')}
+          labelPlacement='start'
+          sx={formControlStyle}
+          control={
+            <CustomDatePicker
+              value={dateEnd}
+              error={!isValidDate(dateEnd)}
+              textFieldSlotProps={datePickerTextFieldProps}
+              maxDate={new Date()}
+              onChange={date => {
+                setDateEnd(date)
+              }}
+            />
+          }
+        />
         <Tooltip disabled={isValidDateTimePeriod(dateStart, dateEnd)} content={t('invalidStartOrEnd')}>
           <Button
             icon='tick'

--- a/administration/src/bp-modules/statistics/components/StatisticsFilterBar.tsx
+++ b/administration/src/bp-modules/statistics/components/StatisticsFilterBar.tsx
@@ -49,7 +49,7 @@ const StatisticsFilterBar = ({
         <StyledFormGroup label={t('start')} inline>
           <CustomDatePicker
             value={dateStart}
-            isValid={isValidDate(dateStart)}
+            error={!isValidDate(dateStart)}
             maxDate={dateEnd ?? defaultStartDate.toLocalDate()}
             textFieldSlotProps={{
               size: 'small',
@@ -67,7 +67,7 @@ const StatisticsFilterBar = ({
         <StyledFormGroup label={t('end')} inline>
           <CustomDatePicker
             value={dateEnd}
-            isValid={isValidDate(dateEnd)}
+            error={!isValidDate(dateEnd)}
             textFieldSlotProps={{
               size: 'small',
               sx: {

--- a/administration/src/bp-modules/statistics/constants/index.ts
+++ b/administration/src/bp-modules/statistics/constants/index.ts
@@ -3,7 +3,7 @@ import { addDays, subYears } from 'date-fns'
 import PlainDate from '../../../util/PlainDate'
 
 // subtract a year from now and add a day to have exactly one year, since end date is included in time period. this approach also considers leap years
-export const defaultStartDate = PlainDate.fromLocalDate(addDays(subYears(new Date(), 1), 1)).toString()
-export const defaultEndDate = PlainDate.fromLocalDate(new Date()).toString()
+export const defaultStartDate = PlainDate.fromLocalDate(addDays(subYears(new Date(), 1), 1))
+export const defaultEndDate = PlainDate.fromLocalDate(new Date())
 
 export const statisticKeyLabels = ['region', 'cardsCreated', 'cardsActivated']

--- a/administration/src/cards/extensions/BirthdayExtension.tsx
+++ b/administration/src/cards/extensions/BirthdayExtension.tsx
@@ -53,7 +53,7 @@ const BirthdayForm = ({
           setValue({ birthday: PlainDate.safeFromLocalDate(date) })
         }}
         onClear={() => setValue({ birthday: null })}
-        isValid={isValid || !showErrorMessage}
+        error={!isValid && showErrorMessage}
         disableFuture
         textFieldSlotProps={{
           sx: {

--- a/administration/src/cards/extensions/BirthdayExtension.tsx
+++ b/administration/src/cards/extensions/BirthdayExtension.tsx
@@ -12,7 +12,6 @@ export const BIRTHDAY_EXTENSION_NAME = 'birthday'
 export type BirthdayExtensionState = { [BIRTHDAY_EXTENSION_NAME]: PlainDate | null }
 
 const minBirthday = new PlainDate(1900, 1, 1)
-const getInitialState = (): BirthdayExtensionState => ({ birthday: null })
 
 const BirthdayForm = ({
   value,
@@ -66,7 +65,7 @@ const BirthdayForm = ({
 const BirthdayExtension: Extension<BirthdayExtensionState> = {
   name: BIRTHDAY_EXTENSION_NAME,
   Component: BirthdayForm,
-  getInitialState,
+  getInitialState: (): BirthdayExtensionState => ({ birthday: null }),
   causesInfiniteLifetime: () => false,
   getProtobufData: ({ birthday }: BirthdayExtensionState) => ({
     extensionBirthday: {

--- a/administration/src/cards/extensions/BirthdayExtension.tsx
+++ b/administration/src/cards/extensions/BirthdayExtension.tsx
@@ -45,16 +45,14 @@ const BirthdayForm = ({
     return null
   }
 
-  const changeBirthday = (date: Date | null) => {
-    setValue({ birthday: PlainDate.safeFromLocalDate(date) })
-  }
-
   return (
     <FormGroup label={t('birthdayLabel')}>
       <CustomDatePicker
         value={birthday?.toLocalDate() ?? null}
         onBlur={() => setTouched(true)}
-        onChange={changeBirthday}
+        onChange={date => {
+          setValue({ birthday: PlainDate.safeFromLocalDate(date) })
+        }}
         onClear={() => setValue({ birthday: null })}
         isValid={isValid || !showErrorMessage}
         disableFuture

--- a/administration/src/cards/extensions/BirthdayExtension.tsx
+++ b/administration/src/cards/extensions/BirthdayExtension.tsx
@@ -52,7 +52,7 @@ const BirthdayForm = ({
   return (
     <FormGroup label={t('birthdayLabel')}>
       <CustomDatePicker
-        date={birthday?.toLocalDate() ?? null}
+        value={birthday?.toLocalDate() ?? null}
         onBlur={() => setTouched(true)}
         onChange={changeBirthday}
         onClear={() => setValue({ birthday: null })}

--- a/administration/src/cards/extensions/BirthdayExtension.tsx
+++ b/administration/src/cards/extensions/BirthdayExtension.tsx
@@ -57,7 +57,6 @@ const BirthdayForm = ({
         onChange={changeBirthday}
         onClear={() => setValue({ birthday: null })}
         isValid={isValid || !showErrorMessage}
-        maxDate={new Date()}
         disableFuture
       />
       {showErrorMessage && <FormAlert severity='error' errorMessage={getErrorMessage()} />}

--- a/administration/src/cards/extensions/BirthdayExtension.tsx
+++ b/administration/src/cards/extensions/BirthdayExtension.tsx
@@ -55,6 +55,13 @@ const BirthdayForm = ({
         onClear={() => setValue({ birthday: null })}
         isValid={isValid || !showErrorMessage}
         disableFuture
+        textFieldSlotProps={{
+          sx: {
+            '.MuiPickersSectionList-root': {
+              padding: '5px 0',
+            },
+          },
+        }}
       />
       {showErrorMessage && <FormAlert severity='error' errorMessage={getErrorMessage()} />}
       {showBirthdayHint() && <FormAlert severity='info' errorMessage={t('birthdayHint')} />}

--- a/administration/src/cards/extensions/StartDayExtension.tsx
+++ b/administration/src/cards/extensions/StartDayExtension.tsx
@@ -1,8 +1,8 @@
 import { FormGroup } from '@blueprintjs/core'
-import { TextField } from '@mui/material'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import CustomDatePicker from '../../bp-modules/components/CustomDatePicker'
 import PlainDate from '../../util/PlainDate'
 import type { Extension, ExtensionComponentProps } from './extensions'
 
@@ -16,23 +16,21 @@ const StartDayForm = ({ value, setValue, isValid }: ExtensionComponentProps<Star
   const { t } = useTranslation('extensions')
   return (
     <FormGroup label={t('startDayLabel')}>
-      <TextField
-        fullWidth
-        type='date'
-        required
-        size='small'
-        error={!isValid}
-        value={value.startDay?.toString() ?? null}
-        sx={{ '& input[value=""]:not(:focus)': { color: 'transparent' }, '& fieldset': { borderRadius: 0 } }}
-        inputProps={{
-          min: minStartDay.toString(),
-          style: { fontSize: 14, padding: '6px 10px' },
-        }}
-        onChange={event => {
-          const date = PlainDate.safeFrom(event.target.value)
+      <CustomDatePicker
+        value={value.startDay?.toLocalDate()}
+        onChange={date => {
           if (date !== null) {
-            setValue({ startDay: date })
+            setValue({ startDay: PlainDate.fromLocalDate(date) })
           }
+        }}
+        isValid={isValid}
+        minDate={minStartDay.toLocalDate()}
+        textFieldSlotProps={{
+          sx: {
+            '.MuiPickersSectionList-root': {
+              padding: '5px 0',
+            },
+          },
         }}
       />
     </FormGroup>

--- a/administration/src/cards/extensions/StartDayExtension.tsx
+++ b/administration/src/cards/extensions/StartDayExtension.tsx
@@ -23,7 +23,7 @@ const StartDayForm = ({ value, setValue, isValid }: ExtensionComponentProps<Star
             setValue({ startDay: PlainDate.fromLocalDate(date) })
           }
         }}
-        isValid={isValid}
+        error={!isValid}
         minDate={minStartDay.toLocalDate()}
         textFieldSlotProps={{
           sx: {

--- a/administration/src/mui-modules/application/SteppedSubForms.tsx
+++ b/administration/src/mui-modules/application/SteppedSubForms.tsx
@@ -9,6 +9,10 @@ import { SetState, useUpdateStateCallback } from './hooks/useUpdateStateCallback
 import { Form, ValidationResult } from './util/FormType'
 
 type FormContextType = {
+  /**
+   * When submitting the form, this property is true and all form elements
+   * must display their error status when their data is invalid.
+   */
   showAllErrors: boolean
   disableAllInputs: boolean
 }

--- a/administration/src/mui-modules/application/forms/JuleicaEntitlementForm.tsx
+++ b/administration/src/mui-modules/application/forms/JuleicaEntitlementForm.tsx
@@ -26,7 +26,7 @@ type ValidatedInput = BlueCardJuleicaEntitlementInput
 const JuleicaEntitlementForm: Form<State, ValidatedInput> = {
   initialState: createCompoundInitialState(SubForms),
   getArrayBufferKeys: createCompoundGetArrayBufferKeys(SubForms),
-  validate: createCompoundValidate(SubForms, { juleicaExpirationDate: { maximumDate: null } }),
+  validate: createCompoundValidate(SubForms, { juleicaExpirationDate: { maximumDate: undefined } }),
   Component: ({ state, setState }: FormComponentProps<State>) => {
     const { t } = useTranslation('application')
     const juleicaBackSetState = useUpdateStateCallback(setState, 'copyOfJuleicaBack')
@@ -42,7 +42,7 @@ const JuleicaEntitlementForm: Form<State, ValidatedInput> = {
           label={t('juleicaExpiration')}
           state={state.juleicaExpirationDate}
           setState={useUpdateStateCallback(setState, 'juleicaExpirationDate')}
-          options={{ maximumDate: null }}
+          options={{ maximumDate: undefined }}
         />
         <h4>{t('applicationForms:juleicaCardAttachmentTitle')}</h4>
         <p>

--- a/administration/src/mui-modules/application/forms/WorkAtOrganizationForm.tsx
+++ b/administration/src/mui-modules/application/forms/WorkAtOrganizationForm.tsx
@@ -63,7 +63,7 @@ const WorkAtOrganizationForm: Form<State, ValidatedInput, AdditionalProps> = {
   validate: createCompoundValidate(SubForms, {
     amountOfWork: amountOfWorkOptions,
     payment: paymentOptions,
-    workSinceDate: { maximumDate: null },
+    workSinceDate: { maximumDate: undefined },
   }),
   Component: ({ state, setState, onDelete, applicantName }: FormComponentProps<State, AdditionalProps>) => {
     const { t } = useTranslation('application')
@@ -82,7 +82,7 @@ const WorkAtOrganizationForm: Form<State, ValidatedInput, AdditionalProps> = {
               label={t('workSinceDate')}
               state={state.workSinceDate}
               setState={useUpdateStateCallback(setState, 'workSinceDate')}
-              options={{ maximumDate: null }}
+              options={{ maximumDate: undefined }}
             />
           </div>
           <div style={{ flex: '3' }}>

--- a/administration/src/mui-modules/application/primitive-inputs/DateForm.tsx
+++ b/administration/src/mui-modules/application/primitive-inputs/DateForm.tsx
@@ -32,6 +32,9 @@ const DateForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
     if (Number.isNaN(date.valueOf())) {
       return { type: 'error', message: i18next.t('applicationForms:invalidDateError') }
     }
+    if (date <= minDate) {
+      return { type: 'error', message: 'Das Datum muss nach dem 1.1.1900 liegen' }
+    }
     if (options.maximumDate && date > options.maximumDate) {
       return { type: 'error', message: options.maximumDateErrorMessage }
     }

--- a/administration/src/mui-modules/application/primitive-inputs/DateForm.tsx
+++ b/administration/src/mui-modules/application/primitive-inputs/DateForm.tsx
@@ -56,7 +56,7 @@ const DateForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
       <CustomDatePicker
         value={parseDateFromState(state.value)}
         disabled={disableAllInputs}
-        error={touched && isInvalid}
+        error={(showAllErrors || touched) && isInvalid}
         label={label}
         minDate={minDate}
         maxDate={options.maximumDate}

--- a/administration/src/mui-modules/application/primitive-inputs/DateForm.tsx
+++ b/administration/src/mui-modules/application/primitive-inputs/DateForm.tsx
@@ -26,18 +26,16 @@ const DateForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
     if (value === '') {
       return { type: 'error', message: i18next.t('applicationForms:fieldRequiredError') }
     }
+
     const date = parseISO(value)
+
     if (Number.isNaN(date.valueOf())) {
       return { type: 'error', message: i18next.t('applicationForms:invalidDateError') }
     }
-
-    if (options.maximumDate) {
-      if (date > options.maximumDate) {
-        return { type: 'error', message: options.maximumDateErrorMessage }
-      }
+    if (options.maximumDate && date > options.maximumDate) {
+      return { type: 'error', message: options.maximumDateErrorMessage }
     }
-    const localISODate = formatISO(date, { representation: 'date' })
-    return { type: 'valid', value: { date: localISODate } }
+    return { type: 'valid', value: { date: formatISO(date, { representation: 'date' }) } }
   },
   Component: ({
     state,

--- a/administration/src/mui-modules/application/primitive-inputs/DateForm.tsx
+++ b/administration/src/mui-modules/application/primitive-inputs/DateForm.tsx
@@ -1,16 +1,24 @@
-import { TextField } from '@mui/material'
 import { formatISO, parseISO } from 'date-fns'
 import React, { useContext, useState } from 'react'
 
+import CustomDatePicker from '../../../bp-modules/components/CustomDatePicker'
 import { DateInput } from '../../../generated/graphql'
 import i18next from '../../../i18n'
 import { FormContext } from '../SteppedSubForms'
-import { Form, FormComponentProps } from '../util/FormType'
+import type { Form, FormComponentProps } from '../util/FormType'
 
 type State = { type: 'DateForm'; value: string }
 type ValidatedInput = DateInput
 type Options = { maximumDate: Date; maximumDateErrorMessage: string } | { maximumDate: null }
 type AdditionalProps = { label: string; minWidth?: number }
+
+const minDate = new Date('1900-01-01')
+
+const parseDateFromState = (state: string): Date | null => {
+  const date = new Date(state)
+  return !Number.isNaN(date.valueOf()) ? date : null
+}
+
 const DateForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
   initialState: { type: 'DateForm', value: '' },
   getArrayBufferKeys: () => [],
@@ -41,28 +49,26 @@ const DateForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
     const [touched, setTouched] = useState(false)
     const { showAllErrors, disableAllInputs } = useContext(FormContext)
     const validationResult = DateForm.validate(state, options)
-
     const isInvalid = validationResult.type === 'error'
 
     return (
-      <TextField
-        variant='standard'
-        fullWidth
-        style={{ margin: '4px 0', minWidth }}
-        type='date'
-        label={label}
-        required
-        inputProps={{
-          max: options.maximumDate ? formatISO(options.maximumDate, { representation: 'date' }) : undefined,
-          min: '1900-01-01',
-        }}
+      <CustomDatePicker
+        value={parseDateFromState(state.value)}
         disabled={disableAllInputs}
-        error={touched && isInvalid}
-        value={state.value}
-        sx={{ '& input[value=""]:not(:focus)': { color: 'transparent' } }}
+        isValid={!touched || !isInvalid}
+        label={label}
+        minDate={minDate}
+        maxDate={options.maximumDate ? options.maximumDate : undefined}
         onBlur={() => setTouched(true)}
-        onChange={e => setState(() => ({ type: 'DateForm', value: e.target.value }))}
-        helperText={(showAllErrors || touched) && isInvalid ? validationResult.message : ''}
+        onChange={date => {
+          setState(() => ({
+            type: 'DateForm',
+            // Catch invalid dates: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date
+            value: date && !Number.isNaN(date.valueOf()) ? date.toISOString() : '',
+          }))
+        }}
+        textFieldHelperText={(showAllErrors || touched) && isInvalid ? validationResult.message : undefined}
+        textFieldStyle={{ marginTop: '12px', minWidth }}
       />
     )
   },

--- a/administration/src/mui-modules/application/primitive-inputs/DateForm.tsx
+++ b/administration/src/mui-modules/application/primitive-inputs/DateForm.tsx
@@ -56,7 +56,7 @@ const DateForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
       <CustomDatePicker
         value={parseDateFromState(state.value)}
         disabled={disableAllInputs}
-        isValid={!touched || !isInvalid}
+        error={touched && isInvalid}
         label={label}
         minDate={minDate}
         maxDate={options.maximumDate}

--- a/administration/src/mui-modules/application/primitive-inputs/DateForm.tsx
+++ b/administration/src/mui-modules/application/primitive-inputs/DateForm.tsx
@@ -9,7 +9,7 @@ import type { Form, FormComponentProps } from '../util/FormType'
 
 type State = { type: 'DateForm'; value: string }
 type ValidatedInput = DateInput
-type Options = { maximumDate: Date; maximumDateErrorMessage: string } | { maximumDate: null }
+type Options = { maximumDate: Date; maximumDateErrorMessage: string } | { maximumDate: undefined }
 type AdditionalProps = { label: string; minWidth?: number }
 
 const minDate = new Date('1900-01-01')
@@ -31,7 +31,7 @@ const DateForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
       return { type: 'error', message: i18next.t('applicationForms:invalidDateError') }
     }
 
-    if (options.maximumDate !== null) {
+    if (options.maximumDate) {
       if (date > options.maximumDate) {
         return { type: 'error', message: options.maximumDateErrorMessage }
       }
@@ -58,7 +58,7 @@ const DateForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
         isValid={!touched || !isInvalid}
         label={label}
         minDate={minDate}
-        maxDate={options.maximumDate ? options.maximumDate : undefined}
+        maxDate={options.maximumDate}
         onBlur={() => setTouched(true)}
         onChange={date => {
           setState(() => ({

--- a/administration/src/mui-modules/application/primitive-inputs/DateForm.tsx
+++ b/administration/src/mui-modules/application/primitive-inputs/DateForm.tsx
@@ -66,7 +66,15 @@ const DateForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
           }))
         }}
         textFieldHelperText={(showAllErrors || touched) && isInvalid ? validationResult.message : undefined}
-        textFieldStyle={{ marginTop: '12px', minWidth }}
+        textFieldSlotProps={{
+          required: true,
+          variant: 'standard',
+          style: { margin: '4px 0', minWidth },
+          sx: {
+            input: { paddingTop: '4px' },
+            '.MuiInputAdornment-root': { transform: 'translateX(-8px)' },
+          },
+        }}
       />
     )
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@mui/material": "^5.13.6",
         "@mui/system": "^5.13.6",
         "@mui/utils": "^6.4.6",
-        "@mui/x-date-pickers": "^7.27.3",
+        "@mui/x-date-pickers": "^7.28.2",
         "@nivo/bar": "^0.85.1",
         "@pdf-lib/fontkit": "^1.1.1",
         "@sentry/react": "^8.55.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.6",
         "@mui/system": "^5.13.6",
+        "@mui/utils": "^6.4.6",
         "@mui/x-date-pickers": "^7.27.3",
         "@nivo/bar": "^0.85.1",
         "@pdf-lib/fontkit": "^1.1.1",
@@ -118,6 +119,18 @@
         "webpack": "^5.94.0",
         "webpack-dev-server": "^4.15.1",
         "webpack-manifest-plugin": "^5.0.0"
+      }
+    },
+    "administration/node_modules/@babel/runtime": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "administration/node_modules/@eslint-community/eslint-utils": {
@@ -238,6 +251,50 @@
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "administration/node_modules/@mui/utils": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.6.tgz",
+      "integrity": "sha512-43nZeE1pJF2anGafNydUcYFPtHwAqiBiauRtaMvurdrZI3YrUjHkAu43RBsxef7OFtJMXGiHFvq43kb7lig0sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mui/types": "^7.2.21",
+        "@types/prop-types": "^15.7.14",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "administration/node_modules/@mui/utils/node_modules/@mui/types": {
+      "version": "7.2.21",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.21.tgz",
+      "integrity": "sha512-6HstngiUxNqLU+/DPqlUJDIPbzUBxIVHb1MmXP0eTWDIROiCR2viugXpEif0PPe2mLqqakPzzRClWAnK+8UJww==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "administration/node_modules/@mui/x-date-pickers": {
@@ -372,6 +429,12 @@
           "optional": true
         }
       }
+    },
+    "administration/node_modules/@types/prop-types": {
+      "version": "15.7.14",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "license": "MIT"
     },
     "administration/node_modules/acorn": {
       "version": "8.14.0",
@@ -1624,6 +1687,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "administration/node_modules/react-is": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
+      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
+      "license": "MIT"
     },
     "administration/node_modules/reflect.getprototypeof": {
       "version": "1.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.6",
         "@mui/system": "^5.13.6",
-        "@mui/x-date-pickers": "^7.22.2",
+        "@mui/x-date-pickers": "^7.27.3",
         "@nivo/bar": "^0.85.1",
         "@pdf-lib/fontkit": "^1.1.1",
         "@sentry/react": "^8.55.0",
@@ -238,6 +238,92 @@
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "administration/node_modules/@mui/x-date-pickers": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.27.3.tgz",
+      "integrity": "sha512-igfKTPC4ZVCmS5j/NXcXBtj/hHseQHzRpCpIB1PMnJGhMdRYXnz8qZz5XhlNBKlzJVXkGu6Uil+obZpCLNj1xg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0",
+        "@mui/x-internals": "7.26.0",
+        "@types/react-transition-group": "^4.4.11",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^5.15.14 || ^6.0.0",
+        "@mui/system": "^5.15.14 || ^6.0.0",
+        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
+        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0",
+        "dayjs": "^1.10.7",
+        "luxon": "^3.0.2",
+        "moment": "^2.29.4",
+        "moment-hijri": "^2.1.2 || ^3.0.0",
+        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "date-fns": {
+          "optional": true
+        },
+        "date-fns-jalali": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        },
+        "moment-hijri": {
+          "optional": true
+        },
+        "moment-jalaali": {
+          "optional": true
+        }
+      }
+    },
+    "administration/node_modules/@mui/x-date-pickers/node_modules/@mui/x-internals": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.26.0.tgz",
+      "integrity": "sha512-VxTCYQcZ02d3190pdvys2TDg9pgbvewAVakEopiOgReKAUhLdRlgGJHcOA/eAuGLyK1YIo26A6Ow6ZKlSRLwMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.7",
+        "@mui/utils": "^5.16.6 || ^6.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "administration/node_modules/@testing-library/dom": {
@@ -7493,90 +7579,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@mui/x-date-pickers": {
-      "version": "7.22.2",
-      "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-7.22.2.tgz",
-      "integrity": "sha512-1KHSlIlnSoY3oHm820By8X344pIdGYqPvCCvfVHrEeeIQ/pHdxDD8tjZFWkFl4Jgm9oVFK90fMcqNZAzc+WaCw==",
-      "dependencies": {
-        "@babel/runtime": "^7.25.7",
-        "@mui/utils": "^5.16.6 || ^6.0.0",
-        "@mui/x-internals": "7.21.0",
-        "@types/react-transition-group": "^4.4.11",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.9.0",
-        "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.15.14 || ^6.0.0",
-        "@mui/system": "^5.15.14 || ^6.0.0",
-        "date-fns": "^2.25.0 || ^3.2.0 || ^4.0.0",
-        "date-fns-jalali": "^2.13.0-0 || ^3.2.0-0",
-        "dayjs": "^1.10.7",
-        "luxon": "^3.0.2",
-        "moment": "^2.29.4",
-        "moment-hijri": "^2.1.2 || ^3.0.0",
-        "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        },
-        "date-fns-jalali": {
-          "optional": true
-        },
-        "dayjs": {
-          "optional": true
-        },
-        "luxon": {
-          "optional": true
-        },
-        "moment": {
-          "optional": true
-        },
-        "moment-hijri": {
-          "optional": true
-        },
-        "moment-jalaali": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/x-internals": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-7.21.0.tgz",
-      "integrity": "sha512-94YNyZ0BhK5Z+Tkr90RKf47IVCW8R/1MvdUhh6MCQg6sZa74jsX+x+gEZ4kzuCqOsuyTyxikeQ8vVuCIQiP7UQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.25.7",
-        "@mui/utils": "^5.16.6 || ^6.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@nivo/annotations": {


### PR DESCRIPTION
### Short Description

Replaces `<TextField>` components in `DateForm` with `<CustomDatePicker>`.

### Proposed Changes

- Updates the package `@mui/x-date-pickers` to 7.27.3.
- Replaces the `<TextField>` component in `DateForm` with `<CustomDatePicker>` components. 
- Uses `enableAccessibleFieldDOMStructure` for `<CustomDatePicker>`, which will be the [future default](enableAccessibleFieldDOMStructure) for MUI components.
- Uses the proper `format` for `<CustomDatePicker>`, fixing the text input. The format will also be displayed and having the month fields in lower case looks slightly misplaced, but I think this is tolerable. Could be fixed with some more CSS.
- Remove some box shadows that looked misplaced.
- Make all event handlers optional in `<CustomDatePicker>`.

### Side Effects

None.

### Testing

- Start backend and frontend
- Visit http://localhost:3000/beantragen and look at date form fields

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1766

