### PR TITLE
1968: Map stores to regions

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/regions/database/EakBayernRegions.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/regions/database/EakBayernRegions.kt
@@ -202,7 +202,7 @@ val EAK_BAYERN_REGIONS = listOf(
     ),
     listOf(
         "Stadt",
-        "München, Landeshauptstadt",
+        "München",
         "09162",
         "https://www.muenchen.de/rathaus/Stadtverwaltung/Direktorium/Engagiert-Leben/engagement_anerkennen.html"
     ),

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/regions/database/repos/RegionsRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/regions/database/repos/RegionsRepository.kt
@@ -1,6 +1,7 @@
 package app.ehrenamtskarte.backend.regions.database.repos
 
 import app.ehrenamtskarte.backend.common.database.sortByKeys
+import app.ehrenamtskarte.backend.freinet.database.FreinetAgencies
 import app.ehrenamtskarte.backend.projects.database.Projects
 import app.ehrenamtskarte.backend.regions.database.RegionEntity
 import app.ehrenamtskarte.backend.regions.database.Regions
@@ -59,4 +60,15 @@ object RegionsRepository {
             .single().id
         return RegionEntity[regionId]
     }
+
+    fun findRegionByNameAndPrefix(name: String, prefix: String): RegionEntity? =
+        RegionEntity.find { (Regions.name eq name) and (Regions.prefix eq prefix) }.singleOrNull()
+
+    fun findRegionByFreinetId(freinetId: Int): RegionEntity? =
+        (FreinetAgencies innerJoin Regions)
+            .slice(Regions.columns)
+            .select { FreinetAgencies.agencyId eq freinetId }
+            .singleOrNull()?.let {
+                RegionEntity.wrapRow(it)
+            }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/database/repos/AcceptingStoresRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/database/repos/AcceptingStoresRepository.kt
@@ -1,7 +1,10 @@
 package app.ehrenamtskarte.backend.stores.database.repos
 
 import app.ehrenamtskarte.backend.common.database.sortByKeys
+import app.ehrenamtskarte.backend.projects.database.ProjectEntity
 import app.ehrenamtskarte.backend.projects.database.Projects
+import app.ehrenamtskarte.backend.regions.database.RegionEntity
+import app.ehrenamtskarte.backend.regions.database.repos.RegionsRepository
 import app.ehrenamtskarte.backend.stores.COUNTRY_CODE
 import app.ehrenamtskarte.backend.stores.database.AcceptingStoreEntity
 import app.ehrenamtskarte.backend.stores.database.AcceptingStores
@@ -88,8 +91,8 @@ object AcceptingStoresRepository {
 
     fun getIdIfExists(
         acceptingStore: AcceptingStore,
-        projectId:
-            EntityID<Int>
+        projectId: EntityID<Int>,
+        regionId: EntityID<Int>?
     ): Int? {
         return AcceptingStores.innerJoin(PhysicalStores).innerJoin(Addresses).innerJoin(Contacts)
             .slice(AcceptingStores.id).select {
@@ -103,7 +106,7 @@ object AcceptingStoresRepository {
                     (AcceptingStores.name eq acceptingStore.name) and
                     (AcceptingStores.description eq acceptingStore.discount) and
                     (AcceptingStores.categoryId eq acceptingStore.categoryId) and
-                    (AcceptingStores.regionId.isNull()) and // TODO #538: For now the region is always null
+                    (AcceptingStores.regionId eq regionId) and
                     (AcceptingStores.projectId eq projectId) and
                     (
                         PhysicalStores.coordinates eq Point(
@@ -114,17 +117,25 @@ object AcceptingStoresRepository {
             }.firstOrNull()?.let { it[AcceptingStores.id].value }
     }
 
-    fun importAcceptingStores(stores: List<CSVAcceptingStore>, projectId: EntityID<Int>, dryRun: Boolean): StoreImportReturnResultModel {
+    fun importAcceptingStores(stores: List<CSVAcceptingStore>, project: ProjectEntity, dryRun: Boolean): StoreImportReturnResultModel {
         var numStoresCreated = 0
         var numStoresUntouched = 0
+        val projectId = project.id
+        val region = RegionsRepository.findAllInProject(project.project).let {
+            if (it.size == 1) {
+                it.first()
+            } else {
+                null
+            }
+        }
         val acceptingStoreIdsToRemove =
             AcceptingStores.slice(AcceptingStores.id).select { AcceptingStores.projectId eq projectId }
                 .map { it[AcceptingStores.id].value }.toMutableSet()
         stores.map { mapCsvToStore(it) }.forEach {
-            val existingStoreId = getIdIfExists(it, projectId)
+            val existingStoreId = getIdIfExists(it, projectId, region?.id)
             if (existingStoreId == null) {
                 if (!dryRun) {
-                    createStore(it, projectId)
+                    createStore(it, projectId, region)
                 }
                 numStoresCreated += 1
             } else {
@@ -139,7 +150,7 @@ object AcceptingStoresRepository {
         return StoreImportReturnResultModel(numStoresCreated, acceptingStoreIdsToRemove.size, numStoresUntouched)
     }
 
-    fun createStore(acceptingStore: AcceptingStore, currentProjectId: EntityID<Int>) {
+    fun createStore(acceptingStore: AcceptingStore, currentProjectId: EntityID<Int>, region: RegionEntity?) {
         val address = AddressEntity.new {
             street = acceptingStore.streetWithHouseNumber
             postalCode = acceptingStore.postalCode!!
@@ -156,7 +167,7 @@ object AcceptingStoresRepository {
             description = acceptingStore.discount
             contactId = contact.id
             categoryId = EntityID(acceptingStore.categoryId, Categories)
-            regionId = null // TODO #538: For now the region is always null
+            regionId = region?.id
             projectId = currentProjectId
         }
         PhysicalStoreEntity.new {

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/utils/MapStoreToRegion.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/utils/MapStoreToRegion.kt
@@ -1,0 +1,14 @@
+package app.ehrenamtskarte.backend.stores.utils
+
+import app.ehrenamtskarte.backend.regions.database.RegionEntity
+import app.ehrenamtskarte.backend.regions.database.repos.RegionsRepository
+
+fun getRegionIdFromFreinetIdOrDistrictName(freinetId: Int?, districtName: String?): RegionEntity? {
+    if (freinetId != null) {
+        return RegionsRepository.findRegionByFreinetId(freinetId)
+    } else if (!districtName.isNullOrEmpty()) {
+        val split = districtName.split(" ", limit = 2)
+        return RegionsRepository.findRegionByNameAndPrefix(split[1], split[0])
+    }
+    return null
+}

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/AcceptingStoresMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/stores/webservice/AcceptingStoresMutationService.kt
@@ -33,8 +33,7 @@ class AcceptingStoresMutationService {
                 throw ForbiddenException()
             }
 
-            val projectId = projectEntity.id
-            val (storesCreated, storesToDelete, storesUntouched) = AcceptingStoresRepository.importAcceptingStores(stores, projectId, dryRun)
+            val (storesCreated, storesToDelete, storesUntouched) = AcceptingStoresRepository.importAcceptingStores(stores, projectEntity, dryRun)
 
             return@transaction StoreImportReturnResultModel(storesCreated, storesToDelete, storesUntouched)
         }


### PR DESCRIPTION
### Short Description

As we want to add a reporting function at some point for accepting stores, we have to map them to a particular region

### Proposed Changes

<!-- Describe this PR in more detail. -->

- map eak stores with `freinetId` or `districtName` to region
- for projects with only one region (f.e. social passes) map the first matching region
- adjust region `München, Landeshauptstadt` to `München` (not sure if they will like it), we could also add the addition to a separate database field. But in this case we need exact prefix and name for proper mapping

### TODO
- cleanup
- fix tests
- some freinet agencies have duplicated region identifier, thats why 239 stores couldn't get mapped correctly. Waiting for response from freinet when they fix it

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- likely none

### Testing

- run the import job (backend) locally and check if regionIds were updated
- import stores for nürnberg and koblenz via project store manager and check if they have correct regionId in database

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1968
