### PR TITLE
1427: CI koblenz promote native

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -914,6 +914,7 @@ jobs:
                 enum:
                     - bayern
                     - nuernberg
+                    - koblenz
                 type: enum
         resource_class: small
         shell: /bin/bash -eo pipefail
@@ -948,6 +949,7 @@ jobs:
                 enum:
                     - bayern
                     - nuernberg
+                    - koblenz
                 type: enum
         shell: /bin/bash --login -o pipefail
         steps:
@@ -1681,6 +1683,23 @@ workflows:
                 production_delivery: true
                 requires:
                     - build_android_nuernberg
+            - build_android:
+                buildConfig: koblenz
+                context:
+                    - credentials-repo
+                    - credentials-ehrenamtskarte
+                name: build_android_koblenz
+                requires:
+                    - bump_version
+                    - check_frontend
+            - deliver_android:
+                buildConfig: koblenz
+                context:
+                    - tuerantuer-google-play
+                name: deliver_android_koblenz
+                production_delivery: true
+                requires:
+                    - build_android_koblenz
             - build_ios:
                 buildConfig: bayern
                 context:
@@ -1715,6 +1734,23 @@ workflows:
                 production_delivery: true
                 requires:
                     - build_ios_nuernberg
+            - build_ios:
+                buildConfig: koblenz
+                context:
+                    - tuerantuer-apple
+                    - fastlane-match
+                name: build_ios_koblenz
+                requires:
+                    - bump_version
+                    - check_frontend
+            - deliver_ios:
+                buildConfig: koblenz
+                context:
+                    - tuerantuer-apple
+                name: deliver_ios_koblenz
+                production_delivery: true
+                requires:
+                    - build_ios_koblenz
             - notify_release:
                 context:
                     - deliverino
@@ -1722,8 +1758,10 @@ workflows:
                 requires:
                     - deliver_ios_bayern
                     - deliver_ios_nuernberg
+                    - deliver_ios_koblenz
                     - deliver_android_bayern
                     - deliver_android_nuernberg
+                    - deliver_android_koblenz
         when: << pipeline.parameters.run_delivery_production_frontend >>
     promotion_all:
         jobs:
@@ -1739,6 +1777,12 @@ workflows:
                     - mattermost
                     - tuerantuer-google-play
                 name: promote_nuernberg_android
+            - promote_android:
+                build_config_name: koblenz
+                context:
+                    - mattermost
+                    - tuerantuer-google-play
+                name: promote_koblenz_android
             - promote_ios:
                 build_config_name: bayern
                 context:
@@ -1751,6 +1795,12 @@ workflows:
                     - mattermost
                     - tuerantuer-apple
                 name: promote_nuernberg_ios
+            - promote_ios:
+                build_config_name: koblenz
+                context:
+                    - mattermost
+                    - tuerantuer-apple
+                name: promote_koblenz_ios
             - promote_to_server:
                 context:
                     - credentials-ehrenamtskarte
@@ -1780,6 +1830,12 @@ workflows:
                     - mattermost
                     - tuerantuer-google-play
                 name: promote_nuernberg_android
+            - promote_android:
+                build_config_name: koblenz
+                context:
+                    - mattermost
+                    - tuerantuer-google-play
+                name: promote_koblenz_android
             - promote_ios:
                 build_config_name: bayern
                 context:
@@ -1792,5 +1848,11 @@ workflows:
                     - mattermost
                     - tuerantuer-apple
                 name: promote_nuernberg_ios
+            - promote_ios:
+                build_config_name: koblenz
+                context:
+                    - mattermost
+                    - tuerantuer-apple
+                name: promote_koblenz_ios
         when: << pipeline.parameters.run_promotion_frontend >>
 

--- a/.circleci/src/jobs/promote_android.yml
+++ b/.circleci/src/jobs/promote_android.yml
@@ -2,7 +2,7 @@
 parameters:
   build_config_name:
     type: enum
-    enum: [bayern, nuernberg]
+    enum: [bayern, nuernberg, koblenz]
     default: bayern
 docker:
   - image: cimg/android:2024.01.1-node

--- a/.circleci/src/jobs/promote_ios.yml
+++ b/.circleci/src/jobs/promote_ios.yml
@@ -2,7 +2,7 @@
 parameters:
   build_config_name:
     type: enum
-    enum: [bayern, nuernberg]
+    enum: [bayern, nuernberg, koblenz]
     default: bayern
 macos:
   xcode: 15.2.0

--- a/.circleci/src/workflows/delivery_production_frontend.yml
+++ b/.circleci/src/workflows/delivery_production_frontend.yml
@@ -40,23 +40,23 @@ jobs:
       production_delivery: true
       requires:
         - build_android_nuernberg
-#  - build_android:
-#      name: build_android_koblenz
-#      buildConfig: "koblenz"
-#      requires:
-#        - bump_version
-#        - check_frontend
-#      context:
-#        - credentials-repo
-#        - credentials-ehrenamtskarte
-#  - deliver_android:
-#      name: deliver_android_koblenz
-#      buildConfig: "koblenz"
-#      context:
-#        - tuerantuer-google-play
-#      production_delivery: true
-#      requires:
-#        - build_android_koblenz
+  - build_android:
+      name: build_android_koblenz
+      buildConfig: "koblenz"
+      requires:
+        - bump_version
+        - check_frontend
+      context:
+        - credentials-repo
+        - credentials-ehrenamtskarte
+  - deliver_android:
+      name: deliver_android_koblenz
+      buildConfig: "koblenz"
+      context:
+        - tuerantuer-google-play
+      production_delivery: true
+      requires:
+        - build_android_koblenz
   - build_ios:
       name: build_ios_bayern
       buildConfig: "bayern"
@@ -91,23 +91,23 @@ jobs:
       production_delivery: true
       requires:
         - build_ios_nuernberg
-#  - build_ios:
-#      name: build_ios_koblenz
-#      buildConfig: "koblenz"
-#      requires:
-#        - bump_version
-#        - check_frontend
-#      context:
-#        - tuerantuer-apple
-#        - fastlane-match
-#  - deliver_ios:
-#      name: deliver_ios_koblenz
-#      buildConfig: koblenz
-#      context:
-#        - tuerantuer-apple
-#      production_delivery: true
-#      requires:
-#        - build_ios_koblenz
+  - build_ios:
+      name: build_ios_koblenz
+      buildConfig: "koblenz"
+      requires:
+        - bump_version
+        - check_frontend
+      context:
+        - tuerantuer-apple
+        - fastlane-match
+  - deliver_ios:
+      name: deliver_ios_koblenz
+      buildConfig: koblenz
+      context:
+        - tuerantuer-apple
+      production_delivery: true
+      requires:
+        - build_ios_koblenz
   - notify_release:
       production_delivery: true
       context:
@@ -115,7 +115,7 @@ jobs:
       requires:
         - deliver_ios_bayern
         - deliver_ios_nuernberg
-#        - deliver_ios_koblenz
+        - deliver_ios_koblenz
         - deliver_android_bayern
         - deliver_android_nuernberg
-#        - deliver_android_koblenz
+        - deliver_android_koblenz

--- a/.circleci/src/workflows/promotion_all.yml
+++ b/.circleci/src/workflows/promotion_all.yml
@@ -12,6 +12,12 @@ jobs:
       context:
         - mattermost
         - tuerantuer-google-play
+  - promote_android:
+      name: promote_koblenz_android
+      build_config_name: koblenz
+      context:
+        - mattermost
+        - tuerantuer-google-play
   - promote_ios:
       name: promote_bayern_ios
       build_config_name: bayern
@@ -21,6 +27,12 @@ jobs:
   - promote_ios:
       name: promote_nuernberg_ios
       build_config_name: nuernberg
+      context:
+        - mattermost
+        - tuerantuer-apple
+  - promote_ios:
+      name: promote_koblenz_ios
+      build_config_name: koblenz
       context:
         - mattermost
         - tuerantuer-apple

--- a/.circleci/src/workflows/promotion_frontend.yml
+++ b/.circleci/src/workflows/promotion_frontend.yml
@@ -12,6 +12,12 @@ jobs:
       context:
         - mattermost
         - tuerantuer-google-play
+  - promote_android:
+      name: promote_koblenz_android
+      build_config_name: koblenz
+      context:
+        - mattermost
+        - tuerantuer-google-play
   - promote_ios:
       name: promote_bayern_ios
       build_config_name: bayern
@@ -21,6 +27,12 @@ jobs:
   - promote_ios:
       name: promote_nuernberg_ios
       build_config_name: nuernberg
+      context:
+        - mattermost
+        - tuerantuer-apple
+  - promote_ios:
+      name: promote_koblenz_ios
+      build_config_name: koblenz
       context:
         - mattermost
         - tuerantuer-apple

--- a/frontend/ios/fastlane/koblenz/metadata/de-DE/release_notes.txt
+++ b/frontend/ios/fastlane/koblenz/metadata/de-DE/release_notes.txt
@@ -1,0 +1,1 @@
+Wir haben die App weiter für Sie verbessert und einige Fehler entfernt. Helfen Sie mit die App zu verbessern, indem Sie uns Feedback geben.


### PR DESCRIPTION
### Short Description

Since we made our first manual native release for koblenz on production, we can now add them to our ci workflows

### Proposed Changes

<!-- Describe this PR in more detail. -->

- enable native production delivery and promotion for koblenz,
- add required ios release notes for promotion via fastlane

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1427 
