### PR TITLE
Do not fail build when running detekt

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -96,6 +96,7 @@ detekt {
     config.setFrom(file("../detekt.yml"))
     buildUponDefaultConfig = true
     basePath = project.layout.projectDirectory.toString()
+    ignoreFailures = true
 }
 
 ktlint {


### PR DESCRIPTION
### Short Description

Apparently `detekt` is run on all Gradle builds within the "check" phase and there is [no easy API](https://github.com/detekt/detekt/discussions/4196) to just skip this, so ignore the errors (for now).

### Proposed Changes

<!-- Describe this PR in more detail. -->

-

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
