### PR TITLE
1932: Add run configuration to generate graphql test classes

### DIFF
--- a/.idea/runConfigurations/Generate_GraphQL_test_classes.xml
+++ b/.idea/runConfigurations/Generate_GraphQL_test_classes.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Generate GraphQL test classes" type="GradleRunConfiguration" factoryName="Gradle" folderName="Backend Commands">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/backend" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="graphqlGenerateTestClient" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
### Short Description
Follow up for [#1989 ](https://github.com/digitalfabrik/entitlementcard/pull/1989)
Add run configuration to generate graphql test classes

### Proposed Changes
- add run configuration file

### Side Effects
no

### Testing
n/a

### Resolved Issues
n/a
