### PR TITLE
Update sentry

### DIFF
--- a/frontend/ios/Podfile.lock
+++ b/frontend/ios/Podfile.lock
@@ -82,11 +82,11 @@ PODS:
     - Flutter
   - PromisesObjC (2.4.0)
   - ReachabilitySwift (5.2.4)
-  - Sentry/HybridSDK (8.42.0)
-  - sentry_flutter (8.12.0):
+  - Sentry/HybridSDK (8.46.0)
+  - sentry_flutter (8.14.1):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.42.0)
+    - Sentry/HybridSDK (= 8.46.0)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -155,11 +155,11 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  connectivity_plus: 481668c94744c30c53b8895afb39159d1e619bdf
-  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
+  connectivity_plus: bf0076dd84a130856aa636df1c71ccaff908fa1d
+  device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_secure_storage: 2c2ff13db9e0a5647389bff88b0ecac56e3f3418
-  geolocator_apple: 1560c3c875af2a412242c7a923e15d0d401966ff
+  flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
+  geolocator_apple: 9bcea1918ff7f0062d98345d238ae12718acfbc1
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleMLKit: 2bd0dc6253c4d4f227aad460f69215a504b2980e
   GoogleToolboxForMac: 8bef7c7c5cf7291c687cf5354f39f9db6399ad34
@@ -167,23 +167,23 @@ SPEC CHECKSUMS:
   GoogleUtilitiesComponents: 679b2c881db3b615a2777504623df6122dd20afe
   GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
   MapLibre: 0ebfa9329d313cec8bf0a5ba5a336a1dc903785e
-  maplibre_gl: 7fc8dd5a5f356891c38f227fe1647d33b9af0400
+  maplibre_gl: be7b98f1c3ed75bf77f321eec04df359d0ff6f62
   MLImage: 7bb7c4264164ade9bf64f679b40fb29c8f33ee9b
   MLKitBarcodeScanning: 04e264482c5f3810cb89ebc134ef6b61e67db505
   MLKitCommon: c1b791c3e667091918d91bda4bba69a91011e390
   MLKitVision: 8baa5f46ee3352614169b85250574fde38c36f49
-  mobile_scanner: b67191637a5ea7ba15652ca208069d2bae1900ab
+  mobile_scanner: 38dcd8a49d7d485f632b7de65e4900010187aef2
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
-  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  Sentry: 38ed8bf38eab5812787274bf591e528074c19e02
-  sentry_flutter: a72ca0eb6e78335db7c4ddcddd1b9f6c8ed5b764
-  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
-  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  Sentry: da60d980b197a46db0b35ea12cb8f39af48d8854
+  sentry_flutter: 6a134f9d381e49f22ea25a67736cf0cf4d02ec9c
+  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: 911aea8a3150d910789c4f32e348c4d0ff803162
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -1129,18 +1129,18 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: "576ad83415102ba2060142a6701611abc6e67a55af1d7ab339cedd3ba1b0f84c"
+      sha256: "077b03f9ee44cfb1eaadbf8af58255e670de62b3f240ca154ce96a5591dc3885"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.0"
+    version: "8.14.1"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: dc3761e8659839cc67a18432d9f12e5531affb7ff68e196dbb56846909b5dfdc
+      sha256: a348e2a365a8ad7682dd09db54f50f19f1c87180b8278f088bc393c511aea5e0
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.0"
+    version: "8.14.1"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   intro_slider: ^4.2.0
   shared_preferences: ^2.3.3
   tinycolor2: ^3.0.1
-  sentry_flutter: ^8.11.0
+  sentry_flutter: ^8.14.1
   carousel_slider: ^5.0.0
   slang: ^4.2.1
   slang_flutter: ^4.2.0


### PR DESCRIPTION
### Short Description

I faced some issue while building the flutter app on ios with recent Xcode 16.3
The issue seems to be related to sentry. Anyways a package update should not harm.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- update sentry to latest

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- likely none

### Testing
- check notes if the package update does not work for you
- build and run the app on ios

Note:
- i had to do the followings steps to get the package update work and be able to build the app again:
```
flutter clean
flutter pub get
cd ios
rm -f Podfile.lock
pod install --repo-update
```
### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #

### Additional Infos

```
Semantic Issue (Xcode): Static assertion failed due to requirement '!is_const<const sentry::profiling::ThreadMetadataCache::ThreadHandleMetadataPair>::value': std::allocator does not support const types
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.4.sdk/usr/include/c++/v1/__memory/allocator.h:94:16

Semantic Issue (Xcode): Static assertion failed due to requirement 'is_same<std::allocator<const sentry::profiling::ThreadMetadataCache::ThreadHandleMetadataPair>, std::allocator<int>>::value': [allocator.requirements] states that rebinding an allocator to the same type should result in the original allocator
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.4.sdk/usr/include/c++/v1/__memory/allocator_traits.h:377:16

Semantic Issue (Xcode): No type named 'value_type' in 'std::allocator<const sentry::profiling::ThreadMetadataCache::ThreadHandleMetadataPair>'
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.4.sdk/usr/include/c++/v1/vector:426:49

Semantic Issue (Xcode): No type named 'type' in 'std::enable_if<false, int>'; 'enable_if' cannot be used to disable this declaration
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.4.sdk/usr/include/c++/v1/__type_traits/enable_if.h:27:57

Could not build the application for the simulator.
Error launching application on iPhone 16 Pro Max.
```