### PR TITLE
1776: Character restriction address fields

### DIFF
--- a/administration/src/cards/Card.test.ts
+++ b/administration/src/cards/Card.test.ts
@@ -13,12 +13,15 @@ import {
   isValid,
   isValueValid,
 } from './Card'
+import AddressExtensions from './extensions/AddressFieldExtensions'
 import BavariaCardTypeExtension, { BAVARIA_CARD_TYPE_EXTENSION_NAME } from './extensions/BavariaCardTypeExtension'
 import BirthdayExtension, { BIRTHDAY_EXTENSION_NAME } from './extensions/BirthdayExtension'
 import KoblenzReferenceNumberExtension, {
   KOBLENZ_REFERENCE_NUMBER_EXTENSION_NAME,
 } from './extensions/KoblenzReferenceNumberExtension'
+import NuernbergPassIdExtension from './extensions/NuernbergPassIdExtension'
 import RegionExtension, { REGION_EXTENSION_NAME } from './extensions/RegionExtension'
+import StartDayExtension from './extensions/StartDayExtension'
 
 jest.useFakeTimers({ now: new Date('2020-01-01') })
 
@@ -139,6 +142,45 @@ describe('Card', () => {
       expect(isValueValid(card, cardConfig, 'Name')).toBeFalsy()
       expect(isValueValid(card, cardConfig, 'Ablaufdatum')).toBeFalsy()
       expect(isValueValid(card, cardConfig, 'Kartentyp')).toBeFalsy()
+      expect(isValid(card, cardConfig)).toBeFalsy()
+    })
+
+    it('should correctly identify invalid arabic characters in name and address fields', () => {
+      const cardConfig = {
+        defaultValidity: { years: 3 },
+        nameColumnName: 'Name',
+        expiryColumnName: 'Ablaufdatum',
+        extensionColumnNames: ['Startdatum', 'Geburtsdatum', 'Pass-ID', 'Adresszeile 1', 'Adresszeile 2', 'PLZ', 'Ort'],
+        extensions: [StartDayExtension, BirthdayExtension, NuernbergPassIdExtension, ...AddressExtensions],
+      }
+      const line = [
+        'Torben عربيزي Trost',
+        '03.3.2026',
+        '03.9.2024',
+        '15.03.2010',
+        '54216782',
+        'عربيزي',
+        'ربي',
+        '',
+        'عربيزي',
+      ]
+      const headers = [
+        'Name',
+        'Ablaufdatum',
+        'Startdatum',
+        'Geburtsdatum',
+        'Pass-ID',
+        'Adresszeile 1',
+        'Adresszeile 2',
+        'PLZ',
+        'Ort',
+      ]
+      const card = initializeCardFromCSV(cardConfig, line, headers, region)
+
+      expect(isValueValid(card, cardConfig, 'Name')).toBeFalsy()
+      expect(isValueValid(card, cardConfig, 'Adresszeile 1')).toBeFalsy()
+      expect(isValueValid(card, cardConfig, 'Adresszeile 2')).toBeFalsy()
+      expect(isValueValid(card, cardConfig, 'Ort')).toBeFalsy()
       expect(isValid(card, cardConfig)).toBeFalsy()
     })
   })

--- a/administration/src/cards/extensions/AddressFieldExtensions.ts
+++ b/administration/src/cards/extensions/AddressFieldExtensions.ts
@@ -22,8 +22,7 @@ const getAddressFieldExtension = <T extends AddressFieldExtension>(
   getInitialState: () => ({ [name]: '' } as AddressFieldExtensionState<T>),
   causesInfiniteLifetime: () => false,
   getProtobufData: () => ({}),
-  isValid: (state): boolean =>
-    !state || state[name].length === 0 ? true : containsOnlyLatinAndCommonCharset(state[name]),
+  isValid: (state): boolean => !state || containsOnlyLatinAndCommonCharset(state[name]),
   fromString: (value: string) => ({ [name]: value } as AddressFieldExtensionState<T>),
   toString: (state): string => state[name],
   fromSerialized: (value: string) => ({ [name]: value } as AddressFieldExtensionState<T>),

--- a/administration/src/cards/extensions/AddressFieldExtensions.ts
+++ b/administration/src/cards/extensions/AddressFieldExtensions.ts
@@ -1,3 +1,4 @@
+import { containsOnlyLatinAndCommonCharset } from '../../util/helper'
 import type { Card } from '../Card'
 import type { Extension } from './extensions'
 
@@ -21,7 +22,8 @@ const getAddressFieldExtension = <T extends AddressFieldExtension>(
   getInitialState: () => ({ [name]: '' } as AddressFieldExtensionState<T>),
   causesInfiniteLifetime: () => false,
   getProtobufData: () => ({}),
-  isValid: () => true,
+  isValid: (state): boolean =>
+    !state || state[name].length === 0 ? true : containsOnlyLatinAndCommonCharset(state[name]),
   fromString: (value: string) => ({ [name]: value } as AddressFieldExtensionState<T>),
   toString: (state): string => state[name],
   fromSerialized: (value: string) => ({ [name]: value } as AddressFieldExtensionState<T>),

--- a/administration/src/util/helper.ts
+++ b/administration/src/util/helper.ts
@@ -28,7 +28,7 @@ export const containsSpecialCharacters = (value: string): boolean =>
  * Checking for latin charset should be fine because all fonts we're going to use for pdf generation should be latin based.
  * */
 export const containsOnlyLatinAndCommonCharset = (value: string): boolean =>
-  XRegExp('^[\\p{Latin}\\p{Common}]+$').test(value)
+  XRegExp('^[\\p{Latin}\\p{Common}]*$').test(value)
 
 export const toLowerCaseFirstLetter = (value: string): string => value.charAt(0).toLowerCase() + value.slice(1)
 


### PR DESCRIPTION
### Short Description

Since only latin and common charset is working for pdf creation, we should add a check to character fields that will be used in the pdf creation.

Even for address field the pdf creation may not break but result in invalid characters as you can see here.
This is how the pdf will look without the check (currently)
<img width="263" alt="image" src="https://github.com/user-attachments/assets/4a79b302-24b0-4c52-b46d-0d84b4eecc52" />

### Proposed Changes

- add a check to the `isValid()` function of the address fields
- add a test for csv lines that contain arabic characters

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing
1. Switch to nuernberg
2. Add f.e. arabic characters or emojis to the card import csv files for character fields like name and address fields
3. Import the csv file
4. Check the table preview that it marks the invalid fields and cards can not be created

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1776
