### PR TITLE
2002: Golden Card validation

### DIFF
--- a/administration/src/mui-modules/application/forms/StepCardTypeForm.tsx
+++ b/administration/src/mui-modules/application/forms/StepCardTypeForm.tsx
@@ -72,12 +72,12 @@ const StepCardTypeForm: Form<State, ValidatedInput> = {
     if (partialValidationResult.type === 'error') {
       return { type: 'error' }
     }
+    if (!partialValidationResult.value.wantsPhysicalCard && !partialValidationResult.value.wantsDigitalCard) {
+      return { type: 'error', message: i18next.t('applicationForms:cardTypeNotChosenError') }
+    }
     // Application type must not be null if and only if card type is blue
     if (partialValidationResult.value.cardType !== BavariaCardType.Blue) {
       return { type: 'valid', value: { ...partialValidationResult.value, applicationType: null } }
-    }
-    if (!partialValidationResult.value.wantsPhysicalCard && !partialValidationResult.value.wantsDigitalCard) {
-      return { type: 'error', message: i18next.t('applicationForms:cardTypeNotChosenError') }
     }
     const applicationTypeResult = ApplicationTypeForm.validate(state.applicationType, applicationTypeOptions)
     if (applicationTypeResult.type === 'error') {


### PR DESCRIPTION
### Short Description

At Bayerns form when you select the golden card and uncheck the checkbox on digital and physical options it will let you continue until the final stage where it will say Daten konnten nicht geparsed werden.  without indication where is the missing field/box.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Just putting the partialValidationResult checking above the return for the golden card
`if (partialValidationResult.value.cardType !== BavariaCardType.Blue)`

### Side Effects

none.

### Testing

- Go to http://localhost:3000/beantragen
- Fill the form normally but select the golden card and remove the checkbox on digital and physical options.
- Test also the blue card's digital and physical options.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2002 
