### PR TITLE
2052: Workaround translation overrides ios

### DIFF
--- a/.idea/runConfigurations/Run__env_local_buildConfig_bayern_.xml
+++ b/.idea/runConfigurations/Run__env_local_buildConfig_bayern_.xml
@@ -1,7 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run (env:local+buildConfig:bayern)" type="FlutterRunConfigurationType" factoryName="Flutter">
-    <option name="additionalArgs" value="--dart-define=environment=local --flavor Bayern" />
+    <option name="additionalArgs" value="--dart-define=environment=local" />
     <option name="attachArgs" value="--dart-define=environment=local" />
+    <option name="buildFlavor" value="bayern" />
     <option name="filePath" value="$PROJECT_DIR$/frontend/lib/main.dart" />
     <method v="2">
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Set build config bayern" run_configuration_type="ShConfigurationType" />

--- a/.idea/runConfigurations/Run__env_local_buildConfig_koblenz_.xml
+++ b/.idea/runConfigurations/Run__env_local_buildConfig_koblenz_.xml
@@ -1,7 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run (env:local+buildConfig:koblenz)" type="FlutterRunConfigurationType" factoryName="Flutter">
-    <option name="additionalArgs" value="--dart-define=environment=local --flavor Koblenz" />
+    <option name="additionalArgs" value="--dart-define=environment=local" />
     <option name="attachArgs" value="--dart-define=environment=local" />
+    <option name="buildFlavor" value="koblenz" />
     <option name="filePath" value="$PROJECT_DIR$/frontend/lib/main.dart" />
     <method v="2">
       <option name="RunConfigurationTask" enabled="false" run_configuration_name="Set build config koblenz" run_configuration_type="ShConfigurationType" />

--- a/.idea/runConfigurations/Run__env_local_buildConfig_nuernberg_.xml
+++ b/.idea/runConfigurations/Run__env_local_buildConfig_nuernberg_.xml
@@ -1,7 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run (env:local+buildConfig:nuernberg)" type="FlutterRunConfigurationType" factoryName="Flutter">
-    <option name="additionalArgs" value="--dart-define=environment=local --flavor Nuernberg" />
+    <option name="additionalArgs" value="--dart-define=environment=local" />
     <option name="attachArgs" value="--dart-define=environment=local" />
+    <option name="buildFlavor" value="nuernberg" />
     <option name="filePath" value="$PROJECT_DIR$/frontend/lib/main.dart" />
     <method v="2">
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Set build config nuernberg" run_configuration_type="ShConfigurationType" />

--- a/.idea/runConfigurations/Run__env_production_buildConfig_bayern_.xml
+++ b/.idea/runConfigurations/Run__env_production_buildConfig_bayern_.xml
@@ -1,7 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run (env:production+buildConfig:bayern)" type="FlutterRunConfigurationType" factoryName="Flutter">
-    <option name="additionalArgs" value="--dart-define=environment=production --flavor Bayern" />
+    <option name="additionalArgs" value="--dart-define=environment=production" />
     <option name="attachArgs" value="--dart-define=environment=production" />
+    <option name="buildFlavor" value="bayern" />
     <option name="filePath" value="$PROJECT_DIR$/frontend/lib/main.dart" />
     <method v="2">
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Set build config bayern" run_configuration_type="ShConfigurationType" />

--- a/.idea/runConfigurations/Run__env_production_buildConfig_koblenz_.xml
+++ b/.idea/runConfigurations/Run__env_production_buildConfig_koblenz_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Run (env:production+buildConfig:koblenz)" type="FlutterRunConfigurationType" factoryName="Flutter">
     <option name="additionalArgs" value="--dart-define=environment=production" />
     <option name="attachArgs" value="--dart-define=environment=production" />
-    <option name="buildFlavor" value="Koblenz" />
+    <option name="buildFlavor" value="koblenz" />
     <option name="filePath" value="$PROJECT_DIR$/frontend/lib/main.dart" />
     <method v="2">
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Set build config koblenz" run_configuration_type="ShConfigurationType" />

--- a/.idea/runConfigurations/Run__env_production_buildConfig_nuernberg_.xml
+++ b/.idea/runConfigurations/Run__env_production_buildConfig_nuernberg_.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Run (env:production+buildConfig:nuernberg)" type="FlutterRunConfigurationType" factoryName="Flutter">
     <option name="additionalArgs" value="--dart-define=environment=production" />
     <option name="attachArgs" value="--dart-define=environment=production" />
-    <option name="buildFlavor" value="Nuernberg" />
+    <option name="buildFlavor" value="nuernberg" />
     <option name="filePath" value="$PROJECT_DIR$/frontend/lib/main.dart" />
     <method v="2">
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Set build config nuernberg" run_configuration_type="ShConfigurationType" />

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -33,6 +33,9 @@ Future<void> main() async {
 }
 
 Future<void> initializeTranslations() async {
+  // This is a workaround for not properly overriding translations on ios, find the issue here: https://github.com/slang-i18n/slang/issues/294
+  // This workaround should be removed when slang v.4.6.1 is available (#2061)
+  await LocaleSettings.instance.loadAllLocales();
   // Only use device locale if set as available in build config, otherwise fallback to de
   final locale = Platform.localeName.split('_')[0];
   if (buildConfig.appLocales.contains(locale)) {


### PR DESCRIPTION
### Short Description

There is an issue that not all locales will be loaded initially with the current `slang` plugin version
https://github.com/slang-i18n/slang/issues/294
I added the workaround that they provided there

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add load function to to add all locales on app start, since they were not properly initialized
- add comment to remove this workaround when new slang version was released (#2061)
- adjust runConfigs to use the flavor lowercase in the particular `buildFlavor`part. That seem to fix the issues tory mentioned

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- likely none

### Testing

See the issue instructions

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2052
