### PR TITLE
2035: Update xcode to 16.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,7 +346,7 @@ jobs:
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         macos:
-            xcode: 15.2.0
+            xcode: 16.1.0
         parameters:
             build_config:
                 description: Name of the build config to use
@@ -547,7 +547,7 @@ jobs:
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         macos:
-            xcode: 15.2.0
+            xcode: 16.1.0
         parameters:
             build_config:
                 enum:
@@ -790,7 +790,7 @@ jobs:
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         macos:
-            xcode: 15.2.0
+            xcode: 16.1.0
         parameters:
             build_config:
                 default: bayern

--- a/.circleci/src/jobs/build_ios.yml
+++ b/.circleci/src/jobs/build_ios.yml
@@ -1,5 +1,5 @@
 macos:
-  xcode: 15.2.0
+  xcode: 16.1.0
 parameters:
   build_config:
     description: "Name of the build config to use"

--- a/.circleci/src/jobs/deliver_ios.yml
+++ b/.circleci/src/jobs/deliver_ios.yml
@@ -7,7 +7,7 @@ parameters:
     description: Whether to deliver the build to production.
     type: boolean
 macos:
-  xcode: 15.2.0
+  xcode: 16.1.0
 environment:
   FASTLANE_SKIP_UPDATE_CHECK: true
 working_directory: ~/project/frontend/ios

--- a/.circleci/src/jobs/promote_ios.yml
+++ b/.circleci/src/jobs/promote_ios.yml
@@ -5,7 +5,7 @@ parameters:
     enum: [bayern, nuernberg, koblenz]
     default: bayern
 macos:
-  xcode: 15.2.0
+  xcode: 16.1.0
 environment:
   FASTLANE_SKIP_UPDATE_CHECK: true
 working_directory: ~/project/frontend/ios


### PR DESCRIPTION
### Short Description

Due to not being able to push new ios releases starting 24th of april with xcode 15 builds (ios 17 sdk), we have to update to XCode 16.x.x

### Proposed Changes

<!-- Describe this PR in more detail. -->

- i tried to update to latest circle ci version (16.2.0) but got some errors with signing: [here](https://app.circleci.com/pipelines/github/digitalfabrik/entitlementcard/7963/workflows/0a737d86-63d1-4af2-be49-be10284bb3a7/jobs/53904)
- so i updated to xcode 16.1.0 since its quite urgent and Version 16.1.0 also used ios sdk 18

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- likely none

### Testing
Check build ios job in the `commit_main` workflow
https://app.circleci.com/pipelines/github/digitalfabrik/entitlementcard?branch=2035-update-xcode-16.1.0

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2035
