### PR TITLE
Revert-bundle-assets-per-flavor (1703)

### DIFF
--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -93,31 +93,21 @@ flutter:
   assets:
     - assets/category_icons/
     - assets/detail_headers/
+    - assets/bayern/intro_slides/
+    - assets/bayern/header-logo.png
+    - assets/bayern/body-logo.png
+    - assets/bayern/icon.png
+    - assets/nuernberg/header-logo.png
+    - assets/nuernberg/body-logo.png
+    - assets/nuernberg/background.png
+    - assets/nuernberg/intro_slides/
+    - assets/nuernberg/l10n/
+    - assets/koblenz/icon.png
+    - assets/koblenz/header-logo.png
+    - assets/koblenz/body-logo.png
+    - assets/koblenz/intro_slides/
+    - assets/koblenz/l10n/
     - assets/ca/
-    - path: assets/bayern/
-      flavors:
-        - bayern
-    - path: assets/bayern/intro_slides/
-      flavors:
-        - bayern
-    - path: assets/nuernberg/
-      flavors:
-        - nuernberg
-    - path: assets/nuernberg/intro_slides/
-      flavors:
-        - nuernberg
-    - path: assets/nuernberg/l10n/
-      flavors:
-        - nuernberg
-    - path: assets/koblenz/
-      flavors:
-        - koblenz
-    - path: assets/koblenz/intro_slides/
-      flavors:
-        - koblenz
-    - path: assets/koblenz/l10n/
-      flavors:
-        - koblenz
 
   # An image asset can refer to one or more resolution-specific 'variants', see
   # https://flutter.dev/assets-and-images/#resolution-aware.


### PR DESCRIPTION
### Short Description

Since fastlane gym can not handle flavors when building ios app, i have to revert 
https://github.com/digitalfabrik/entitlementcard/pull/2024

I created #2076 and reopened #1703 

### Proposed Changes

<!-- Describe this PR in more detail. -->

- revert pubspec.yml to bundle all assets

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- app size will increase

### Testing

- All assets and translation of each project should be initialized properly

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
