### PR TITLE
2089: Add flavor ios build fastlane

### DIFF
--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -93,7 +93,7 @@ platform :ios do
        output_directory: "#{ENV['HOME']}",
        output_name: "#{build_config_name}.ipa",
        export_method: "app-store",
-       xcargs: "DART_DEFINES='#{env_prod_base64}'"
+       xcargs: "DART_DEFINES='#{env_prod_base64}' FLAVOR='#{build_config_name}'"
      )
   end
 


### PR DESCRIPTION
### Short Description

This adds the needed flavors for #1703 to the fastlane ios build

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add flavor to xcargs to be provided in the build

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- likely none

### Testing
I uploaded this ipa to browserstack
https://app.circleci.com/pipelines/github/digitalfabrik/entitlementcard/8008/workflows/782de0d0-bd27-4c66-ab84-bb55085b9026/jobs/54296/artifacts

Check the ipa in browserstack (test-flavor-nuernberg.ipa)
https://app-live.browserstack.com/#os=iOS&os_version=18.0&zoom_to_fit=true&full_screen=true&speed=1

In comparison you can test the broken one `nuernberg.ipa` from main branch also in browserstack
### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2089
