### PR TITLE
Use resource class small to save credits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,6 +244,7 @@ jobs:
     build_administration:
         docker:
             - image: cimg/node:20.18.0
+        resource_class: small
         steps:
             - prepare_workspace
             - install_protobuf_linux
@@ -315,6 +316,7 @@ jobs:
         environment:
             _JAVA_OPTIONS: -Xmx3g
             GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2
+        resource_class: small
         steps:
             - prepare_workspace
             - install_protobuf_linux
@@ -423,6 +425,7 @@ jobs:
     check_administration:
         docker:
             - image: cimg/node:20.18.0
+        resource_class: small
         steps:
             - prepare_workspace
             - check_circleci_config
@@ -451,6 +454,7 @@ jobs:
         environment:
             _JAVA_OPTIONS: -Xmx3g
             GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2
+        resource_class: small
         steps:
             - prepare_workspace
             - check_circleci_config
@@ -583,6 +587,7 @@ jobs:
             production:
                 description: Whether builds are delivered to production or beta.
                 type: boolean
+        resource_class: small
         steps:
             - prepare_workspace
             - add_ssh_keys:
@@ -661,6 +666,7 @@ jobs:
     pack_administration:
         docker:
             - image: debian:12
+        resource_class: small
         steps:
             - prepare_workspace
             - run:
@@ -686,6 +692,7 @@ jobs:
                 - POSTGRES_USER=postgres
                 - POSTGRES_PASSWORD=postgres
               image: postgis/postgis:13-3.0
+        resource_class: small
         steps:
             - prepare_workspace
             - run:
@@ -707,6 +714,7 @@ jobs:
     pack_martin:
         docker:
             - image: debian:12
+        resource_class: small
         steps:
             - prepare_workspace
             - run:
@@ -736,6 +744,7 @@ jobs:
     pack_meta:
         docker:
             - image: debian:12
+        resource_class: small
         steps:
             - prepare_workspace
             - run:
@@ -779,6 +788,7 @@ jobs:
     promote_github_release:
         docker:
             - image: cimg/node:20.18.0
+        resource_class: small
         steps:
             - prepare_workspace
             - install_app_toolbelt
@@ -811,6 +821,7 @@ jobs:
     promote_server:
         docker:
             - image: cimg/node:20.18.0
+        resource_class: small
         steps:
             - prepare_workspace
             - add_ssh_keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,7 @@ jobs:
     build_administration:
         docker:
             - image: cimg/node:20.18.0
-        resource_class: small
+        resource_class: medium
         steps:
             - prepare_workspace
             - install_protobuf_linux

--- a/.circleci/src/jobs/build_administration.yml
+++ b/.circleci/src/jobs/build_administration.yml
@@ -1,5 +1,6 @@
 docker:
   - image: cimg/node:20.18.0
+resource_class: small
 working_directory: ~/project/administration
 steps:
   - prepare_workspace

--- a/.circleci/src/jobs/build_administration.yml
+++ b/.circleci/src/jobs/build_administration.yml
@@ -1,6 +1,6 @@
 docker:
   - image: cimg/node:20.18.0
-resource_class: small
+resource_class: medium
 working_directory: ~/project/administration
 steps:
   - prepare_workspace

--- a/.circleci/src/jobs/build_android.yml
+++ b/.circleci/src/jobs/build_android.yml
@@ -1,5 +1,6 @@
 docker:
   - image: cimg/android:2024.01.1-node
+resource_class: large
 parameters:
   build_config:
     description: "Name of the build config to use"
@@ -8,7 +9,6 @@ parameters:
 environment:
   FASTLANE_SKIP_UPDATE_CHECK: true
   GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m" -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2'
-resource_class: large
 working_directory: ~/project/frontend
 steps:
   - prepare_workspace

--- a/.circleci/src/jobs/build_backend.yml
+++ b/.circleci/src/jobs/build_backend.yml
@@ -3,6 +3,7 @@ environment:
   GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
 docker:
   - image: cimg/openjdk:17.0.13-node
+resource_class: small
 working_directory: ~/project/backend
 steps:
   - prepare_workspace

--- a/.circleci/src/jobs/check_administration.yml
+++ b/.circleci/src/jobs/check_administration.yml
@@ -1,5 +1,6 @@
 docker:
   - image: cimg/node:20.18.0
+resource_class: small
 working_directory: ~/project/administration
 steps:
   - prepare_workspace

--- a/.circleci/src/jobs/check_backend.yml
+++ b/.circleci/src/jobs/check_backend.yml
@@ -3,6 +3,7 @@ environment:
   GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
 docker:
   - image: cimg/openjdk:17.0.13-node
+resource_class: small
 working_directory: ~/project/backend
 steps:
   - prepare_workspace

--- a/.circleci/src/jobs/deliver_server.yml
+++ b/.circleci/src/jobs/deliver_server.yml
@@ -1,5 +1,6 @@
 docker:
   - image: cimg/node:20.18.0
+resource_class: small
 parameters:
   production:
     description: Whether builds are delivered to production or beta.

--- a/.circleci/src/jobs/pack_administration.yml
+++ b/.circleci/src/jobs/pack_administration.yml
@@ -1,5 +1,6 @@
 docker:
   - image: debian:12 # We deploy on debian -> pack on debian
+resource_class: small
 steps:
   - prepare_workspace
   - run:

--- a/.circleci/src/jobs/pack_backend.yml
+++ b/.circleci/src/jobs/pack_backend.yml
@@ -5,6 +5,7 @@ docker:
       - POSTGRES_DB=ehrenamtskarte
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
+resource_class: small
 steps:
   - prepare_workspace
   - run:

--- a/.circleci/src/jobs/pack_martin.yml
+++ b/.circleci/src/jobs/pack_martin.yml
@@ -1,5 +1,6 @@
 docker:
   - image: debian:12 # We deploy on debian -> pack on debian
+resource_class: small
 steps:
   - prepare_workspace
   - run:

--- a/.circleci/src/jobs/pack_meta.yml
+++ b/.circleci/src/jobs/pack_meta.yml
@@ -1,5 +1,6 @@
 docker:
   - image: debian:12 # We deploy on debian -> pack on debian
+resource_class: small
 steps:
   - prepare_workspace
   - run:

--- a/.circleci/src/jobs/promote_github_release.yml
+++ b/.circleci/src/jobs/promote_github_release.yml
@@ -1,5 +1,6 @@
 docker:
   - image: cimg/node:20.18.0
+resource_class: small
 steps:
   - prepare_workspace
   - install_app_toolbelt

--- a/.circleci/src/jobs/promote_server.yml
+++ b/.circleci/src/jobs/promote_server.yml
@@ -1,5 +1,6 @@
 docker:
   - image: cimg/node:20.18.0
+resource_class: small
 steps:
   - prepare_workspace
   - add_ssh_keys:


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
I just realized that we nearly nowhere set the resource class to use in the CI. Therefore the default `medium` is used which costs us a ton of credits.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use `resource_class: small` wherever possible (all jobs except macos and `build_android` (large) and `build_administration` (medium))
- For macOS the default already is m1 medium which is the cheapest

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

Jobs might take slightly longer.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
See that the CI succeeds: https://app.circleci.com/pipelines/github/digitalfabrik/entitlementcard/8028/workflows/1669cbbe-3260-40b7-9e35-02ad1162fe07

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A
