### PR TITLE
Fix querying for wrong physical store id

### DIFF
--- a/frontend/graphql_queries/stores/accepting_stores_search.graphql
+++ b/frontend/graphql_queries/stores/accepting_stores_search.graphql
@@ -4,6 +4,7 @@ query AcceptingStoresSearch($project: String!, $params: SearchParamsInput!) {
         name
         description
         physicalStore {
+            id
             address {
                 location
             }

--- a/frontend/graphql_queries/stores/physical_store_by_id.graphql
+++ b/frontend/graphql_queries/stores/physical_store_by_id.graphql
@@ -1,4 +1,4 @@
-query AcceptingStoreById($project: String!, $ids: [Int!]!) {
+query PhysicalStoreById($project: String!, $ids: [Int!]!) {
     stores: physicalStoresByIdInProject(project: $project, ids: $ids) {
         id,
         coordinates {

--- a/frontend/graphql_queries/stores/physical_store_summary_by_id.graphql
+++ b/frontend/graphql_queries/stores/physical_store_summary_by_id.graphql
@@ -1,4 +1,4 @@
-query AcceptingStoreSummaryById($project: String!, $ids: [Int!]!) {
+query PhysicalStoreSummaryById($project: String!, $ids: [Int!]!) {
     stores: physicalStoresByIdInProject(project: $project, ids: $ids) {
         id,
         store {

--- a/frontend/lib/favorites/favorite_store.dart
+++ b/frontend/lib/favorites/favorite_store.dart
@@ -1,11 +1,11 @@
-import 'package:ehrenamtskarte/graphql_gen/graphql_queries/stores/accepting_store_by_id.graphql.dart';
+import 'package:ehrenamtskarte/graphql_gen/graphql_queries/stores/physical_store_by_id.graphql.dart';
 
 class FavoriteStore {
   final int storeId;
   final String storeName;
   final int categoryId;
 
-  Query$AcceptingStoreById$stores? physicalStore;
+  Query$PhysicalStoreById$stores? physicalStore;
 
   FavoriteStore(this.storeId, this.storeName, this.categoryId);
 

--- a/frontend/lib/favorites/favorites_loader.dart
+++ b/frontend/lib/favorites/favorites_loader.dart
@@ -13,7 +13,7 @@ import 'package:ehrenamtskarte/store_widgets/removed_store_summary.dart';
 import 'package:ehrenamtskarte/configuration/configuration.dart';
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
 import 'package:provider/provider.dart';
-import 'package:ehrenamtskarte/graphql_gen/graphql_queries/stores/accepting_store_by_id.graphql.dart';
+import 'package:ehrenamtskarte/graphql_gen/graphql_queries/stores/physical_store_by_id.graphql.dart';
 
 class FavoritesLoader extends StatefulWidget {
   const FavoritesLoader({super.key});
@@ -93,7 +93,7 @@ class FavoritesLoaderState extends State<FavoritesLoader> {
     }
   }
 
-  Future<Query$AcceptingStoreById$stores?> _fetchPhysicalStore(int storeId) async {
+  Future<Query$PhysicalStoreById$stores?> _fetchPhysicalStore(int storeId) async {
     final projectId = Configuration.of(context).projectId;
 
     final client = _client;
@@ -101,8 +101,8 @@ class FavoritesLoaderState extends State<FavoritesLoader> {
       throw Exception('GraphQL client is not yet initialized!');
     }
 
-    final result = await client.query$AcceptingStoreById(Options$Query$AcceptingStoreById(
-        variables: Variables$Query$AcceptingStoreById(project: projectId, ids: [storeId])));
+    final result = await client.query$PhysicalStoreById(Options$Query$PhysicalStoreById(
+        variables: Variables$Query$PhysicalStoreById(project: projectId, ids: [storeId])));
     final exception = result.exception;
     if (result.hasException && exception != null) {
       throw exception;

--- a/frontend/lib/home/home_page.dart
+++ b/frontend/lib/home/home_page.dart
@@ -31,7 +31,7 @@ class HomePageState extends State<HomePage> {
   int _currentTabIndex = mapTabIndex;
 
   MapPageController? mapPageController;
-  int? selectedAcceptingStoreId;
+  int? selectedPhysicalStoreId;
   bool followUserLocation = true;
 
   @override
@@ -42,7 +42,7 @@ class HomePageState extends State<HomePage> {
       AppFlow(
         MapPage(
           onMapCreated: (controller) => setState(() => mapPageController = controller),
-          selectAcceptingStore: (id) => setState(() => selectedAcceptingStoreId = id),
+          selectAcceptingStore: (id) => setState(() => selectedPhysicalStoreId = id),
           setFollowUserLocation: (follow) => setState(() => followUserLocation = follow),
         ),
         Icons.map_outlined,
@@ -97,7 +97,7 @@ class HomePageState extends State<HomePage> {
           if (!mounted) return;
           setState(() => followUserLocation = true);
         },
-        selectedAcceptingStoreId: selectedAcceptingStoreId,
+        selectedPhysicalStoreId: selectedPhysicalStoreId,
         followUserLocation: followUserLocation,
         currentTabIndex: _currentTabIndex,
       ),

--- a/frontend/lib/map/floating_action_map_bar.dart
+++ b/frontend/lib/map/floating_action_map_bar.dart
@@ -10,20 +10,20 @@ const mapTabIndex = 0;
 /// of an accepting store as well as to navigate to the current user position.
 class FloatingActionMapBar extends StatelessWidget {
   final Future<void> Function(RequestedPosition) bringCameraToUser;
-  final int? selectedAcceptingStoreId;
+  final int? selectedPhysicalStoreId;
   final bool followUserLocation;
   final int currentTabIndex;
 
   const FloatingActionMapBar(
       {super.key,
       required this.bringCameraToUser,
-      required this.selectedAcceptingStoreId,
+      required this.selectedPhysicalStoreId,
       required this.currentTabIndex,
       required this.followUserLocation});
 
   @override
   Widget build(BuildContext context) {
-    final finalSelectedAcceptingStoreId = selectedAcceptingStoreId;
+    final physicalStoreId = selectedPhysicalStoreId;
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.end,
@@ -41,10 +41,10 @@ class FloatingActionMapBar extends StatelessWidget {
                 child: IntrinsicHeight(
                   child: AnimatedSwitcher(
                     duration: const Duration(milliseconds: 200),
-                    child: finalSelectedAcceptingStoreId != null
+                    child: physicalStoreId != null
                         ? Container(
                             padding: EdgeInsets.only(top: fabPadding.toDouble()),
-                            child: AcceptingStorePreview(finalSelectedAcceptingStoreId),
+                            child: AcceptingStorePreview(physicalStoreId: physicalStoreId),
                           )
                         : null,
                   ),

--- a/frontend/lib/map/preview/accepting_store_preview.dart
+++ b/frontend/lib/map/preview/accepting_store_preview.dart
@@ -1,20 +1,23 @@
 import 'package:ehrenamtskarte/configuration/configuration.dart';
-import 'package:ehrenamtskarte/graphql_gen/graphql_queries/stores/accepting_store_summary_by_id.graphql.dart';
+import 'package:ehrenamtskarte/graphql_gen/graphql_queries/stores/physical_store_summary_by_id.graphql.dart';
 import 'package:ehrenamtskarte/map/preview/accepting_store_preview_card.dart';
 import 'package:ehrenamtskarte/map/preview/models.dart';
 import 'package:flutter/material.dart';
 
 class AcceptingStorePreview extends StatelessWidget {
-  final int acceptingStoreId;
+  final int physicalStoreId;
 
-  const AcceptingStorePreview(this.acceptingStoreId, {super.key});
+  const AcceptingStorePreview({
+    super.key,
+    required this.physicalStoreId,
+  });
 
   @override
   Widget build(BuildContext context) {
     final projectId = Configuration.of(context).projectId;
-    return Query$AcceptingStoreSummaryById$Widget(
-      options: Options$Query$AcceptingStoreSummaryById(
-          variables: Variables$Query$AcceptingStoreSummaryById(project: projectId, ids: [acceptingStoreId])),
+    return Query$PhysicalStoreSummaryById$Widget(
+      options: Options$Query$PhysicalStoreSummaryById(
+          variables: Variables$Query$PhysicalStoreSummaryById(project: projectId, ids: [physicalStoreId])),
       builder: (result, {refetch, fetchMore}) {
         try {
           final exception = result.exception;
@@ -49,7 +52,7 @@ class AcceptingStorePreview extends StatelessWidget {
     );
   }
 
-  AcceptingStoreSummaryModel _convertToAcceptingStoreSummary(Query$AcceptingStoreSummaryById$stores item) {
+  AcceptingStoreSummaryModel _convertToAcceptingStoreSummary(Query$PhysicalStoreSummaryById$stores item) {
     return AcceptingStoreSummaryModel(
       item.id,
       item.store.name,

--- a/frontend/lib/map/preview/accepting_store_preview_card.dart
+++ b/frontend/lib/map/preview/accepting_store_preview_card.dart
@@ -53,7 +53,7 @@ class AcceptingStorePreviewCard extends StatelessWidget {
                   : AcceptingStoreSummary(
                       store: currentAcceptingStore,
                       showLocation: false,
-                      key: ValueKey(currentAcceptingStore.id),
+                      key: ValueKey(currentAcceptingStore.physicalStoreId),
                       showOnMap: null,
                     ),
         ),

--- a/frontend/lib/map/preview/models.dart
+++ b/frontend/lib/map/preview/models.dart
@@ -1,16 +1,18 @@
 class Coordinates {
   double lat;
   double lng;
+
   Coordinates(this.lat, this.lng);
 }
 
 class AcceptingStoreSummaryModel {
-  int id;
+  int? physicalStoreId;
   String? name;
   String? description;
   int categoryId;
   Coordinates? coordinates;
   String? location;
 
-  AcceptingStoreSummaryModel(this.id, this.name, this.description, this.categoryId, this.coordinates, this.location);
+  AcceptingStoreSummaryModel(
+      this.physicalStoreId, this.name, this.description, this.categoryId, this.coordinates, this.location);
 }

--- a/frontend/lib/search/results_loader.dart
+++ b/frontend/lib/search/results_loader.dart
@@ -122,7 +122,7 @@ class ResultsLoaderState extends State<ResultsLoader> {
             child: AcceptingStoreSummary(
               key: ValueKey(item.id),
               store: AcceptingStoreSummaryModel(
-                item.id,
+                item.physicalStore?.id,
                 item.name,
                 item.description,
                 item.categoryId,

--- a/frontend/lib/store_widgets/accepting_store_summary.dart
+++ b/frontend/lib/store_widgets/accepting_store_summary.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:ehrenamtskarte/graphql_gen/schema.graphql.dart';
 import 'package:ehrenamtskarte/map/preview/models.dart';
 import 'package:ehrenamtskarte/routing.dart';
+import 'package:ehrenamtskarte/sentry.dart';
 import 'package:ehrenamtskarte/store_widgets/detail/detail_page.dart';
 import 'package:ehrenamtskarte/store_widgets/category_indicator.dart';
 import 'package:flutter/material.dart';
@@ -76,9 +77,14 @@ class AcceptingStoreSummary extends StatelessWidget {
   }
 
   void _openDetailView(BuildContext context) {
+    final physicalStoreId = store.physicalStoreId;
+    if (physicalStoreId == null) {
+      reportError('Store "${store.name}" has no physical store id', StackTrace.current);
+      return;
+    }
     Navigator.of(context, rootNavigator: true).push(
       AppRoute(
-        builder: (context) => DetailPage(store.id, showOnMap: showOnMap),
+        builder: (context) => DetailPage(physicalStoreId: physicalStoreId, showOnMap: showOnMap),
       ),
     );
   }

--- a/frontend/lib/store_widgets/detail/detail_content.dart
+++ b/frontend/lib/store_widgets/detail/detail_content.dart
@@ -1,7 +1,7 @@
 import 'dart:developer';
 import 'dart:io' show Platform;
 
-import 'package:ehrenamtskarte/graphql_gen/graphql_queries/stores/accepting_store_by_id.graphql.dart';
+import 'package:ehrenamtskarte/graphql_gen/graphql_queries/stores/physical_store_by_id.graphql.dart';
 import 'package:ehrenamtskarte/map/map_page.dart';
 import 'package:ehrenamtskarte/store_widgets/detail/contact_info_row.dart';
 import 'package:ehrenamtskarte/util/color_utils.dart';
@@ -14,7 +14,7 @@ import 'package:url_launcher/url_launcher_string.dart';
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
 
 class DetailContent extends StatelessWidget {
-  final Query$AcceptingStoreById$stores acceptingStore;
+  final Query$PhysicalStoreById$stores acceptingStore;
   final void Function(PhysicalStoreFeatureData)? showOnMap;
   final Color? accentColor;
   final Color? readableOnAccentColor;

--- a/frontend/lib/store_widgets/detail/detail_page.dart
+++ b/frontend/lib/store_widgets/detail/detail_page.dart
@@ -1,5 +1,5 @@
 import 'package:ehrenamtskarte/configuration/configuration.dart';
-import 'package:ehrenamtskarte/graphql_gen/graphql_queries/stores/accepting_store_by_id.graphql.dart';
+import 'package:ehrenamtskarte/graphql_gen/graphql_queries/stores/physical_store_by_id.graphql.dart';
 import 'package:ehrenamtskarte/store_widgets/detail/detail_app_bar.dart';
 import 'package:ehrenamtskarte/store_widgets/detail/detail_content.dart';
 import 'package:ehrenamtskarte/util/color_utils.dart';
@@ -13,18 +13,18 @@ import 'package:ehrenamtskarte/l10n/translations.g.dart';
 import 'package:ehrenamtskarte/map/map_page.dart';
 
 class DetailPage extends StatelessWidget {
-  final int _acceptingStoreId;
+  final int physicalStoreId;
   final void Function(PhysicalStoreFeatureData)? showOnMap;
 
-  const DetailPage(this._acceptingStoreId, {super.key, this.showOnMap});
+  const DetailPage({super.key, required this.physicalStoreId, this.showOnMap});
 
   @override
   Widget build(BuildContext context) {
     final t = context.t;
     final projectId = Configuration.of(context).projectId;
-    return Query$AcceptingStoreById$Widget(
-      options: Options$Query$AcceptingStoreById(
-          variables: Variables$Query$AcceptingStoreById(project: projectId, ids: [_acceptingStoreId])),
+    return Query$PhysicalStoreById$Widget(
+      options: Options$Query$PhysicalStoreById(
+          variables: Variables$Query$PhysicalStoreById(project: projectId, ids: [physicalStoreId])),
       builder: (result, {refetch, fetchMore}) {
         final exception = result.exception;
         final data = result.parsedData;

--- a/frontend/test/favorites/favorites_page_test.dart
+++ b/frontend/test/favorites/favorites_page_test.dart
@@ -1,7 +1,7 @@
 import 'package:ehrenamtskarte/configuration/configuration.dart';
 import 'package:ehrenamtskarte/favorites/favorites_model.dart';
 import 'package:ehrenamtskarte/favorites/favorites_page.dart';
-import 'package:ehrenamtskarte/graphql_gen/graphql_queries/stores/accepting_store_by_id.graphql.dart';
+import 'package:ehrenamtskarte/graphql_gen/graphql_queries/stores/physical_store_by_id.graphql.dart';
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
 import 'package:ehrenamtskarte/store_widgets/accepting_store_summary.dart';
 import 'package:ehrenamtskarte/store_widgets/detail/detail_app_bar.dart';
@@ -23,7 +23,7 @@ void main() {
       registerFallbackValue(FakeQueryOptions());
       registerFallbackValue(FakeRoute());
       registerFallbackValue(
-          Options$Query$AcceptingStoreById(variables: Variables$Query$AcceptingStoreById(project: '', ids: [])));
+          Options$Query$PhysicalStoreById(variables: Variables$Query$PhysicalStoreById(project: '', ids: [])));
     });
 
     final mockClient = MockGraphQLClient();
@@ -56,8 +56,8 @@ void main() {
         'favorites': ['{"storeId":1,"storeName":"Test store","categoryId":9}']
       });
 
-      when(() => mockClient.query(any<Options$Query$AcceptingStoreById>())).thenAnswer((invocation) async {
-        final options = invocation.positionalArguments.first as Options$Query$AcceptingStoreById;
+      when(() => mockClient.query(any<Options$Query$PhysicalStoreById>())).thenAnswer((invocation) async {
+        final options = invocation.positionalArguments.first as Options$Query$PhysicalStoreById;
         return QueryResult(
           data: {
             'stores': [
@@ -111,8 +111,8 @@ void main() {
         'favorites': ['{"storeId":1,"storeName":"Test store","categoryId":9}']
       });
 
-      when(() => mockClient.query(any<Options$Query$AcceptingStoreById>())).thenAnswer((invocation) async {
-        final options = invocation.positionalArguments.first as Options$Query$AcceptingStoreById;
+      when(() => mockClient.query(any<Options$Query$PhysicalStoreById>())).thenAnswer((invocation) async {
+        final options = invocation.positionalArguments.first as Options$Query$PhysicalStoreById;
         return QueryResult(
           data: {
             'stores': [null],


### PR DESCRIPTION
### Short Description

We mix accepting store ids and physical store ids in the frontend.
On staging, these ids sometimes differ and thus we sometimes query physical stores using an invalid id.
Interestingly, on production, the ids always match, so we did not run into the bug yet.

### Proposed Changes

* Adjust naming of related queries and fields to explicitly specify accepting store id vs physical store id.
* Use physical store id instead of accepting store id when appropriate

### Side Effects

None

### Testing

* In the Bayern EAK staging app:
* Search for "Anna Apotheke"
* Clicking on it should successfully open the detail page of the Anna Apotheke
