### PR TITLE
1907: Enable dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        # Ignore major updates for all dependencies
+        update-types: [ "version-update:semver-major" ]
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: gradle
+    directory: "/backend"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: pub
+    directory: "/frontend"
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        # Ignore major updates for all dependencies
+        update-types: [ "version-update:semver-major" ]
+
+  - package-ecosystem: gradle
+    directory: "/frontend/android"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: bundler
+    directory: "/frontend/ios"
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        # Ignore major updates for all dependencies
+        update-types: [ "version-update:semver-major" ]
+
+  - package-ecosystem: docker-compose
+    directory: "/"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
### Short Description

Enables automatic dependency updates.

As suggested in the issue description, I (tried to) allow only minor&patch version updates.
Also I limited the bot to only 2 open pull requests for each package-ecosystem.

Feel free to discuss the config :)

### Resolved Issues

Fixes: #1907 
