### PR TITLE
2003: Fix uncaught exception regions by postal code

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/regions/database/repos/RegionsRepository.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/regions/database/repos/RegionsRepository.kt
@@ -55,15 +55,13 @@ object RegionsRepository {
         region.activatedForCardConfirmationMail = activatedForConfirmationMail
     }
 
-    fun findRegionByRegionIdentifier(regionIdentifier: String, projectId: EntityID<Int>): RegionEntity {
-        val regionId = RegionEntity
+    fun findRegionByRegionIdentifier(regionIdentifier: String, projectId: EntityID<Int>): RegionEntity? =
+        RegionEntity
             .find {
                 Regions.regionIdentifier eq regionIdentifier and (Regions.projectId eq projectId) and
                     Regions.activatedForApplication
             }
-            .single().id
-        return RegionEntity[regionId]
-    }
+            .singleOrNull()
 
     fun findRegionByNameAndPrefix(name: String, prefix: String, projectId: EntityID<Int>): RegionEntity? =
         RegionEntity.find {


### PR DESCRIPTION
### Short Description

Currently a 500 error (check console) occurs if the user types a postal code in the application form that has no valid `regionIdentifier`(ars) in our `regions` table. You can find example postal codes in the issue comment.

Note: We use a csv file that consists all postalCodes and the corresponding regionIdentifiers to find the `ars` for a particular postal code, since a region can have multiple postal codes but has one single (4 digit) ars

### Proposed Changes

<!-- Describe this PR in more detail. -->

- adjust `findRegionByRegionIdentifier` to return `.singleOrNull)` before it was unsafely tried to get the region via id that couldn't be found in some cases and leading to internal error
- concatenate filtering regions by postalCode and finding the region by ars in the database

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- likely none

### Testing

- type in a postal code that has no corresponding ars in our database (check issue description)
- a)Check that the error mentioned in the issue description will not be thrown (dev only)
- b)Check that there is no 500 error in the browser console
- check that in both cases an info alert should be shown that the region couldn't be determined

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2003 
