### PR TITLE
1679: Update go router

### DIFF
--- a/administration/src/util/__tests__/getCustomDeepLinkFromQrCode.test.ts
+++ b/administration/src/util/__tests__/getCustomDeepLinkFromQrCode.test.ts
@@ -17,7 +17,7 @@ describe('getCustomDeepLinkFromQrCode', () => {
 
   it('should generate correct deep link', () => {
     expect(getCustomDeepLinkFromQrCode(koblenzConfig, dynamicPdfQrCode)).toBe(
-      'koblenzpass://koblenz.sozialpass.app/activation/code#ClcKLQoNS2FybGEgS29ibGVuehDmnwEaGAoCCF8SBAjqvgEqBAiLmgEyBgoEMTIzSxIQL%2Fle3xYGNIKS50god4ITmxoUOUYGq%2FjAE99bK4edMPo2I3ojr78%3D/'
+      'koblenzpass://koblenz.sozialpass.app/activation/code#ClcKLQoNS2FybGEgS29ibGVuehDmnwEaGAoCCF8SBAjqvgEqBAiLmgEyBgoEMTIzSxIQL%2Fle3xYGNIKS50god4ITmxoUOUYGq%2FjAE99bK4edMPo2I3ojr78%3D'
     )
   })
 })

--- a/administration/src/util/__tests__/getDeepLinkFromQrCode.test.ts
+++ b/administration/src/util/__tests__/getDeepLinkFromQrCode.test.ts
@@ -55,7 +55,7 @@ describe('DeepLink generation', () => {
     localStorage.setItem(LOCAL_STORAGE_PROJECT_KEY, BAYERN_STAGING_ID)
     const projectId = getBuildConfig(window.location.hostname).common.projectId.staging
     expect(getDeepLinkFromQrCode(dynamicPdfQrCode)).toBe(
-      `${HTTPS_SCHEME}://${projectId}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodedActivationCodeBase64}/`
+      `${HTTPS_SCHEME}://${projectId}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodedActivationCodeBase64}`
     )
   })
   it('should generate a correct link for staging', () => {
@@ -63,7 +63,7 @@ describe('DeepLink generation', () => {
     overrideHostname(BAYERN_STAGING_ID)
     const projectId = getBuildConfig(window.location.hostname).common.projectId.staging
     expect(getDeepLinkFromQrCode(dynamicPdfQrCode)).toBe(
-      `${HTTPS_SCHEME}://${projectId}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodedActivationCodeBase64}/`
+      `${HTTPS_SCHEME}://${projectId}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodedActivationCodeBase64}`
     )
   })
   it('should generate a correct link for production', () => {
@@ -71,7 +71,7 @@ describe('DeepLink generation', () => {
     process.env.REACT_APP_IS_PRODUCTION = 'true'
     const projectId = getBuildConfig(window.location.hostname).common.projectId.production
     expect(getDeepLinkFromQrCode(dynamicPdfQrCode)).toBe(
-      `${HTTPS_SCHEME}://${projectId}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodedActivationCodeBase64}/`
+      `${HTTPS_SCHEME}://${projectId}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodedActivationCodeBase64}`
     )
   })
 })

--- a/administration/src/util/getCustomDeepLinkFromQrCode.ts
+++ b/administration/src/util/getCustomDeepLinkFromQrCode.ts
@@ -13,6 +13,6 @@ const getCustomDeepLinkFromQrCode = (projectConfig: ProjectConfig, qrCode: PdfQr
   const { customScheme } = deepLinking
   return `${customScheme}://${host}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodeURIComponent(
     uint8ArrayToBase64(qrCodeContent)
-  )}/`
+  )}`
 }
 export default getCustomDeepLinkFromQrCode

--- a/administration/src/util/getDeepLinkFromQrCode.ts
+++ b/administration/src/util/getDeepLinkFromQrCode.ts
@@ -15,7 +15,7 @@ const getDeepLinkFromQrCode = (qrCode: PdfQrCode): string => {
   const host = isProductionEnvironment() ? buildConfigProjectId.production : buildConfigProjectId.staging
   const deepLink = `${HTTPS_SCHEME}://${host}/${ACTIVATION_PATH}/${ACTIVATION_FRAGMENT}#${encodeURIComponent(
     uint8ArrayToBase64(qrCodeContent)
-  )}/`
+  )}`
   if (!isProductionEnvironment()) {
     console.log(deepLink)
   }

--- a/docs/deep-linking.md
+++ b/docs/deep-linking.md
@@ -27,10 +27,10 @@ The card activation links will be printed on the pdf,send via mail or accessible
 ### Examples:
 
 ```
-https://staging.bayern.ehrenamtskarte.app/activation/code#ClcKLQoNRGVlcGxpbmsgVGVzdBCWnQEaGAoCCF0SAwiIORoHCLPPvgEQASoECKiaARIQBuTHyi60o6UC2U439XGLMRoUBzxIAa%2BPG%2Bj%2FIrBzJVTJACh21KA%3D/
+https://staging.bayern.ehrenamtskarte.app/activation/code#ClcKLQoNRGVlcGxpbmsgVGVzdBCWnQEaGAoCCF0SAwiIORoHCLPPvgEQASoECKiaARIQBuTHyi60o6UC2U439XGLMRoUBzxIAa%2BPG%2Bj%2FIrBzJVTJACh21KA%3D
 
-ehrenamtbayern://bayern.ehrenamtskarte.app/activation/code#ClcKLQoNRGVlcGxpbmsgVGVzdBCWnQEaGAoCCF0SAwiIORoHCLPPvgEQASoECKiaARIQBuTHyi60o6UC2U439XGLMRoUBzxIAa%2BPG%2Bj%2FIrBzJVTJACh21KA%3D/
-koblenzpass://koblenz.sozialpass.app/activation/code#ClcKLQoNRGVlcGxpbmsgVGVzdBCWnQEaGAoCCF0SAwiIORoHCLPPvgEQASoECKiaARIQBuTHyi60o6UC2U439XGLMRoUBzxIAa%2BPG%2Bj%2FIrBzJVTJACh21KA%3D/
+ehrenamtbayern://bayern.ehrenamtskarte.app/activation/code#ClcKLQoNRGVlcGxpbmsgVGVzdBCWnQEaGAoCCF0SAwiIORoHCLPPvgEQASoECKiaARIQBuTHyi60o6UC2U439XGLMRoUBzxIAa%2BPG%2Bj%2FIrBzJVTJACh21KA%3D
+koblenzpass://koblenz.sozialpass.app/activation/code#ClcKLQoNRGVlcGxpbmsgVGVzdBCWnQEaGAoCCF0SAwiIORoHCLPPvgEQASoECKiaARIQBuTHyi60o6UC2U439XGLMRoUBzxIAa%2BPG%2Bj%2FIrBzJVTJACh21KA%3D
 ```
 
 #### Note
@@ -49,13 +49,13 @@ For local testing you have to install the app and add these domains manually.
 - AppSettings -> OpenByDefault -> AddLinks -> enable supported links
 
 ```
-npx uri-scheme open https://staging.nuernberg.sozialpass.app/activation/code#<activationCode>/ --android
+npx uri-scheme open https://staging.nuernberg.sozialpass.app/activation/code#<activationCode> --android
 ```
 
 
 ### b) iOS
 ```
-npx uri-scheme open https://staging.nuernberg.sozialpass.app/activation/code#<activationCode>/ --ios
+npx uri-scheme open https://staging.nuernberg.sozialpass.app/activation/code#<activationCode> --ios
 ```
 
 

--- a/frontend/lib/activation/deeplink_activation.dart
+++ b/frontend/lib/activation/deeplink_activation.dart
@@ -202,8 +202,8 @@ class _WarningText extends StatelessWidget {
 
 DynamicActivationCode? getActivationCode(
     BuildContext context, String encodedBase64qrcode, Function(String message) updateErrorMessage) {
-  // GoRouter >= 13.x did not handle uri fragments properly without trailing slash. After the package update to recent version this was fixed.
-  // Though we need legacy support for old deep links that have a trailing slash.
+  // GoRouter 13.x did not handle uri fragments properly without trailing slash.
+  // Therefore we need legacy support for old deep links that have a trailing slash.
   final sanitizedBase64qrcode = removeTrailingSlash(encodedBase64qrcode);
   try {
     final activationCode = const ActivationCodeParser()

--- a/frontend/lib/activation/deeplink_activation.dart
+++ b/frontend/lib/activation/deeplink_activation.dart
@@ -11,6 +11,7 @@ import 'package:ehrenamtskarte/identification/util/activate_card.dart';
 import 'package:ehrenamtskarte/identification/verification_workflow/verification_qr_code_processor.dart';
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
 import 'package:ehrenamtskarte/proto/card.pb.dart';
+import 'package:ehrenamtskarte/util/string_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
@@ -43,9 +44,9 @@ enum DeepLinkActivationStatus {
 }
 
 class DeepLinkActivation extends StatefulWidget {
-  final String base64qrcode;
+  final String encodedBase64qrcode;
 
-  const DeepLinkActivation({super.key, required this.base64qrcode});
+  const DeepLinkActivation({super.key, required this.encodedBase64qrcode});
 
   @override
   State<DeepLinkActivation> createState() => _DeepLinkActivationState();
@@ -70,8 +71,7 @@ class _DeepLinkActivationState extends State<DeepLinkActivation> {
   @override
   Widget build(BuildContext context) {
     final t = context.t;
-    print(widget.base64qrcode);
-    DynamicActivationCode? activationCode = getActivationCode(context, widget.base64qrcode, updateErrorMessage);
+    DynamicActivationCode? activationCode = getActivationCode(context, widget.encodedBase64qrcode, updateErrorMessage);
     CardInfo? cardInfo = activationCode?.info;
     final userCodeModel = Provider.of<UserCodeModel>(context);
 
@@ -201,9 +201,13 @@ class _WarningText extends StatelessWidget {
 }
 
 DynamicActivationCode? getActivationCode(
-    BuildContext context, String base64qrcode, Function(String message) updateErrorMessage) {
+    BuildContext context, String encodedBase64qrcode, Function(String message) updateErrorMessage) {
+  // GoRouter >= 13.x did not handle uri fragments properly without trailing slash. After the package update to recent version this was fixed.
+  // Though we need legacy support for old deep links that have a trailing slash.
+  final sanitizedBase64qrcode = removeTrailingSlash(encodedBase64qrcode);
   try {
-    final activationCode = const ActivationCodeParser().parseQrCodeContent(const Base64Decoder().convert(base64qrcode));
+    final activationCode = const ActivationCodeParser()
+        .parseQrCodeContent(const Base64Decoder().convert(Uri.decodeComponent(sanitizedBase64qrcode)));
     return activationCode;
   } on CardExpiredException catch (e, _) {
     updateErrorMessage(

--- a/frontend/lib/activation/deeplink_activation.dart
+++ b/frontend/lib/activation/deeplink_activation.dart
@@ -70,6 +70,7 @@ class _DeepLinkActivationState extends State<DeepLinkActivation> {
   @override
   Widget build(BuildContext context) {
     final t = context.t;
+    print(widget.base64qrcode);
     DynamicActivationCode? activationCode = getActivationCode(context, widget.base64qrcode, updateErrorMessage);
     CardInfo? cardInfo = activationCode?.info;
     final userCodeModel = Provider.of<UserCodeModel>(context);

--- a/frontend/lib/activation/deeplink_activation.dart
+++ b/frontend/lib/activation/deeplink_activation.dart
@@ -44,9 +44,9 @@ enum DeepLinkActivationStatus {
 }
 
 class DeepLinkActivation extends StatefulWidget {
-  final String encodedBase64qrcode;
+  final String encodedBase64QrCode;
 
-  const DeepLinkActivation({super.key, required this.encodedBase64qrcode});
+  const DeepLinkActivation({super.key, required this.encodedBase64QrCode});
 
   @override
   State<DeepLinkActivation> createState() => _DeepLinkActivationState();
@@ -71,7 +71,7 @@ class _DeepLinkActivationState extends State<DeepLinkActivation> {
   @override
   Widget build(BuildContext context) {
     final t = context.t;
-    DynamicActivationCode? activationCode = getActivationCode(context, widget.encodedBase64qrcode, updateErrorMessage);
+    DynamicActivationCode? activationCode = getActivationCode(context, widget.encodedBase64QrCode, updateErrorMessage);
     CardInfo? cardInfo = activationCode?.info;
     final userCodeModel = Provider.of<UserCodeModel>(context);
 
@@ -201,13 +201,13 @@ class _WarningText extends StatelessWidget {
 }
 
 DynamicActivationCode? getActivationCode(
-    BuildContext context, String encodedBase64qrcode, Function(String message) updateErrorMessage) {
+    BuildContext context, String encodedBase64QrCode, Function(String message) updateErrorMessage) {
   // GoRouter 13.x did not handle uri fragments properly without trailing slash.
   // Therefore we need legacy support for old deep links that have a trailing slash.
-  final sanitizedBase64qrcode = removeTrailingSlash(encodedBase64qrcode);
+  final sanitizedBase64QrCode = removeTrailingSlash(encodedBase64QrCode);
   try {
     final activationCode = const ActivationCodeParser()
-        .parseQrCodeContent(const Base64Decoder().convert(Uri.decodeComponent(sanitizedBase64qrcode)));
+        .parseQrCodeContent(const Base64Decoder().convert(Uri.decodeComponent(sanitizedBase64QrCode)));
     return activationCode;
   } on CardExpiredException catch (e, _) {
     updateErrorMessage(

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -37,7 +37,7 @@ final GoRouter router = GoRouter(
         GoRoute(
           path: '$activationRouteName/:$activationRouteCodeParamName',
           builder: (BuildContext context, GoRouterState state) {
-            return DeepLinkActivation(base64qrcode: Uri.decodeComponent(state.uri.fragment));
+            return DeepLinkActivation(encodedBase64qrcode: state.uri.fragment);
           },
         ),
       ],

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -37,7 +37,7 @@ final GoRouter router = GoRouter(
         GoRoute(
           path: '$activationRouteName/:$activationRouteCodeParamName',
           builder: (BuildContext context, GoRouterState state) {
-            return DeepLinkActivation(encodedBase64qrcode: state.uri.fragment);
+            return DeepLinkActivation(encodedBase64QrCode: state.uri.fragment);
           },
         ),
       ],

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -37,7 +37,7 @@ final GoRouter router = GoRouter(
         GoRoute(
           path: '$activationRouteName/:$activationRouteCodeParamName',
           builder: (BuildContext context, GoRouterState state) {
-            return DeepLinkActivation(base64qrcode: Uri.decodeFull(state.uri.fragment));
+            return DeepLinkActivation(base64qrcode: Uri.decodeComponent(state.uri.fragment));
           },
         ),
       ],

--- a/frontend/lib/util/string_utils.dart
+++ b/frontend/lib/util/string_utils.dart
@@ -1,0 +1,1 @@
+String removeTrailingSlash(String value) => value.endsWith('/') ? value.substring(0, value.length - 1) : value;

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -480,10 +480,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "7ecb2f391edbca5473db591b48555a8912dde60edd0fb3013bd6743033b2d3f8"
+      sha256: "2b9ba6d4c247457c35a6622f1dee6aab6694a4e15237ff7c32320345044112b6"
       url: "https://pub.dev"
     source: hosted
-    version: "13.2.1"
+    version: "15.1.1"
   gql:
     dependency: "direct dev"
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -53,8 +53,7 @@ dependencies:
   http: ^0.13.5
   equatable: ^2.0.5
   tuple: ^2.0.1
-  # Locking GoRouter version until #1679 Update GoRouter to recent
-  go_router: 13.2.1
+  go_router: ^15.1.1
 
 dev_dependencies:
   build_runner: ^2.4.11


### PR DESCRIPTION
### Short Description

The old `go_router` version didn't resolve url fragments properly without trailing slash, thats why we added some trailings slashes to the deeplinks.
This was not really a good practise since base64 strings could also include `/` 
This is quite error prone.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- update got router to recent
- remove trailing slashes from deeplinks
- add legacy support for old deep links
- adjust tests

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Likely none

### Testing

- Create cards for koblenz (/erstellen) and activate the card
- Create a card for bavaria and copy the custom scheme deeplink in the browser
- Use the command in `deeplinks.md`(devs only)
- `npx uri-scheme open https://staging.nuernberg.sozialpass.app/activation/code#<activationCode> --android`

Test legacy support:
- add to the deeplink a trailing slash using the command line (dev only)
- `npx uri-scheme open https://staging.nuernberg.sozialpass.app/activation/code#<activationCode>/ --android`

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1679
