### PR TITLE
1999: Limit the Nürnberg Pass-Id to 9 characters

### DIFF
--- a/administration/src/cards/extensions/NuernbergPassIdExtension.tsx
+++ b/administration/src/cards/extensions/NuernbergPassIdExtension.tsx
@@ -8,7 +8,7 @@ export const NUERNBERG_PASS_ID_EXTENSION_NAME = 'nuernbergPassId'
 
 type NuernbergPassIdExtensionState = { [NUERNBERG_PASS_ID_EXTENSION_NAME]: number | null }
 
-const nuernbergPassIdLength = 10
+const nuernbergPassIdLength = 9
 
 const NuernbergPassIdForm = ({
   value,


### PR DESCRIPTION
### Short Description
In the card creation form, it was possible to enter Nürnberg-Pass-ID = 9999999999, but an error occurred when generating the card.
<img width="1325" alt="image" src="https://github.com/user-attachments/assets/39ab5c18-954f-42ce-96a0-8de5ab090434" />

### Proposed Changes
Set the max length of the of nürnberg pass id to 9

### Side Effects
no

### Testing
1. Login to Nürnberg administration as region admin
2. Go to "Karten erstellen" --> "Einzelne Karten erstellen"
3. Check that it is not possible to enter Nürnberg-Pass-ID = 9999999999 (10 chars). Only 9 characters are allowed.
Additionally can be checked that a card with Nürnberg-Pass-ID = 999999999 (9 chars) can be generated without errors.

### Resolved Issues
Fixes: #1999
 