### PR TITLE
Add not testable dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,12 +15,16 @@ updates:
     directory: "/backend"
     schedule:
       interval: daily
+    labels:
+      - "not-testable"
     open-pull-requests-limit: 2
 
   - package-ecosystem: pub
     directory: "/frontend"
     schedule:
       interval: daily
+    labels:
+      - "not-testable"
     open-pull-requests-limit: 2
     ignore:
       - dependency-name: "*"
@@ -31,12 +35,16 @@ updates:
     directory: "/frontend/android"
     schedule:
       interval: daily
+    labels:
+      - "not-testable"
     open-pull-requests-limit: 2
 
   - package-ecosystem: bundler
     directory: "/frontend/ios"
     schedule:
       interval: daily
+    labels:
+      - "not-testable"
     open-pull-requests-limit: 2
     ignore:
       - dependency-name: "*"
@@ -47,4 +55,6 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    labels:
+      - "not-testable"
     open-pull-requests-limit: 2


### PR DESCRIPTION
### Short Description

This adds a not testable label for dependabot prs. I think for most of the minor package update this should be fine.
If you think we should set it for every pr manually, feel free to reject.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add "not-testable" label

