### PR TITLE
2094: Improve system overlay and top unsafe area handling

### DIFF
--- a/frontend/lib/about/about_page.dart
+++ b/frontend/lib/about/about_page.dart
@@ -14,6 +14,8 @@ import 'package:url_launcher/url_launcher_string.dart';
 
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
 
+import 'package:ehrenamtskarte/widgets/app_bars.dart';
+
 const String accessibilityPolicyUrl = 'https://berechtigungskarte.app/barrierefreiheit/';
 
 class AboutPage extends StatefulWidget {
@@ -41,7 +43,7 @@ class AboutPageState extends State<AboutPage> {
         final packageInfo = snapshot.data;
         if (snapshot.hasData && packageInfo != null) {
           children = [
-            Container(height: 20),
+            SizedBox(height: 20),
             Center(
               child: Padding(
                 padding: const EdgeInsets.all(10),
@@ -175,7 +177,7 @@ class AboutPageState extends State<AboutPage> {
         } else {
           children = [];
         }
-        return ListView(children: children);
+        return CustomScrollView(slivers: [SliverStatusBarProtector(), SliverList.list(children: children)]);
       },
     );
   }

--- a/frontend/lib/identification/card_detail_view/card_carousel.dart
+++ b/frontend/lib/identification/card_detail_view/card_carousel.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:carousel_slider/carousel_slider.dart';
 
@@ -18,55 +19,48 @@ class CardCarousel extends StatefulWidget {
   CardCarouselState createState() => CardCarouselState();
 }
 
+const double indicatorHeight = 32;
+
 class CardCarouselState extends State<CardCarousel> {
   @override
   Widget build(BuildContext context) {
     final int cardAmount = widget.cards.length;
-    final double indicatorHeight = cardAmount > 1 ? 32 : 0;
 
-    return LayoutBuilder(builder: (context, constraints) {
-      return Column(
-        children: [
-          Expanded(
-            child: SingleChildScrollView(
-              child: CarouselSlider(
-                items: widget.cards,
-                carouselController: widget.carouselController,
-                options: CarouselOptions(
-                    enableInfiniteScroll: false,
-                    viewportFraction: 0.96,
-                    height: constraints.maxHeight - indicatorHeight,
-                    onPageChanged: (index, reason) {
-                      setState(() {
-                        widget.updateIndex(index);
-                      });
-                    }),
-              ),
-            ),
+    return Column(children: [
+      Expanded(
+          child: LayoutBuilder(
+        builder: (context, constraints) => CarouselSlider(
+          items: widget.cards,
+          carouselController: widget.carouselController,
+          options: CarouselOptions(
+            enableInfiniteScroll: false,
+            viewportFraction: 0.96,
+            height: constraints.maxHeight,
+            onPageChanged: (index, reason) => widget.updateIndex(index),
           ),
-          if (cardAmount > 1)
-            Container(
-              height: indicatorHeight,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: widget.cards.asMap().entries.map((entry) {
-                  return GestureDetector(
-                    onTap: () => widget.carouselController.animateToPage(entry.key),
-                    child: Container(
-                      width: 8.0,
-                      height: 8.0,
-                      margin: EdgeInsets.symmetric(horizontal: 4.0),
-                      decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          color: (Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black)
-                              .withOpacity(widget.cardIndex == entry.key ? 0.9 : 0.4)),
-                    ),
-                  );
-                }).toList(),
-              ),
-            ),
-        ],
-      );
-    });
+        ),
+      )),
+      if (cardAmount > 1)
+        Container(
+          height: indicatorHeight,
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: widget.cards
+                .mapIndexed((index, value) => GestureDetector(
+                      onTap: () => widget.carouselController.animateToPage(index),
+                      child: Container(
+                        width: 8.0,
+                        height: 8.0,
+                        margin: EdgeInsets.symmetric(horizontal: 4.0),
+                        decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: (Theme.of(context).brightness == Brightness.dark ? Colors.white : Colors.black)
+                                .withOpacity(widget.cardIndex == index ? 0.9 : 0.4)),
+                      ),
+                    ))
+                .toList(),
+          ),
+        ),
+    ]);
   }
 }

--- a/frontend/lib/identification/identification_page.dart
+++ b/frontend/lib/identification/identification_page.dart
@@ -4,7 +4,7 @@ import 'package:ehrenamtskarte/configuration/settings_model.dart';
 import 'package:ehrenamtskarte/identification/activation_workflow/activation_code_scanner_page.dart';
 import 'package:ehrenamtskarte/identification/card_detail_view/card_carousel.dart';
 import 'package:ehrenamtskarte/identification/card_detail_view/card_detail_view.dart';
-import 'package:ehrenamtskarte/identification/no_card_view.dart';
+import 'package:ehrenamtskarte/identification/no_card_page.dart';
 import 'package:ehrenamtskarte/identification/qr_code_scanner/qr_code_camera_permission_dialog.dart';
 import 'package:ehrenamtskarte/identification/user_code_model.dart';
 import 'package:ehrenamtskarte/identification/util/card_info_utils.dart';
@@ -14,6 +14,7 @@ import 'package:ehrenamtskarte/l10n/translations.g.dart';
 import 'package:ehrenamtskarte/proto/card.pb.dart';
 import 'package:ehrenamtskarte/routing.dart';
 import 'package:ehrenamtskarte/util/get_application_url.dart';
+import 'package:ehrenamtskarte/widgets/app_bars.dart';
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
@@ -76,14 +77,17 @@ class IdentificationPageState extends State<IdentificationPage> {
             ));
           }
 
-          return CardCarousel(
-              cards: carouselCards,
-              cardIndex: cardIndex,
-              updateIndex: _updateCardIndex,
-              carouselController: carouselController);
+          return Scaffold(
+            appBar: StatusBarProtector(),
+            body: CardCarousel(
+                cards: carouselCards,
+                cardIndex: cardIndex,
+                updateIndex: _updateCardIndex,
+                carouselController: carouselController),
+          );
         }
 
-        return NoCardView(
+        return NoCardPage(
           startVerification: () => _showVerificationDialog(context, settings, userCodeModel),
           startActivation: () => _startActivation(context),
           startApplication: () => _startApplication(getApplicationUrl(context)),

--- a/frontend/lib/identification/no_card_page.dart
+++ b/frontend/lib/identification/no_card_page.dart
@@ -1,12 +1,13 @@
 import 'package:ehrenamtskarte/l10n/translations.g.dart';
+import 'package:ehrenamtskarte/widgets/app_bars.dart';
 import 'package:flutter/material.dart';
 
-class NoCardView extends StatelessWidget {
+class NoCardPage extends StatelessWidget {
   final VoidCallback startVerification;
   final VoidCallback startActivation;
   final VoidCallback startApplication;
 
-  const NoCardView({
+  const NoCardPage({
     super.key,
     required this.startVerification,
     required this.startActivation,
@@ -16,39 +17,45 @@ class NoCardView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final t = context.t;
-    return LayoutBuilder(
-      builder: (BuildContext context, BoxConstraints viewportConstraints) => SingleChildScrollView(
-        child: ConstrainedBox(
-          constraints: BoxConstraints(minHeight: viewportConstraints.maxHeight),
-          child: SafeArea(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                _TapableCardWithArea(
-                  onTap: startApplication,
-                  title: t.identification.applyTitle,
-                  description: t.identification.applyDescription,
-                  icon: Icons.assignment,
-                ),
-                _TapableCardWithArea(
-                  onTap: startActivation,
-                  title: t.identification.activateTitle,
-                  description: t.identification.activateDescription,
-                  icon: Icons.add_card,
-                ),
-                _TapableCardWithArea(
-                  onTap: startVerification,
-                  title: t.identification.verifyTitle,
-                  description: t.identification.verifyDescription,
-                  icon: Icons.verified,
-                ),
-              ].wrapWithSpacers(height: 24),
+    return CustomScrollView(slivers: [
+      SliverStatusBarProtector(),
+      SliverLayoutBuilder(builder: (context, constraints) {
+        final remainingExtent = constraints.viewportMainAxisExtent - constraints.precedingScrollExtent;
+        return SliverToBoxAdapter(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: remainingExtent),
+            child: SafeArea(
+              top: false,
+              bottom: false,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  _TapableCardWithArea(
+                    onTap: startApplication,
+                    title: t.identification.applyTitle,
+                    description: t.identification.applyDescription,
+                    icon: Icons.assignment,
+                  ),
+                  _TapableCardWithArea(
+                    onTap: startActivation,
+                    title: t.identification.activateTitle,
+                    description: t.identification.activateDescription,
+                    icon: Icons.add_card,
+                  ),
+                  _TapableCardWithArea(
+                    onTap: startVerification,
+                    title: t.identification.verifyTitle,
+                    description: t.identification.verifyDescription,
+                    icon: Icons.verified,
+                  ),
+                ].wrapWithSpacers(height: 24),
+              ),
             ),
           ),
-        ),
-      ),
-    );
+        );
+      }),
+    ]);
   }
 }
 

--- a/frontend/lib/map/map_page.dart
+++ b/frontend/lib/map/map_page.dart
@@ -2,6 +2,7 @@ import 'package:ehrenamtskarte/location/determine_position.dart';
 import 'package:ehrenamtskarte/map/map/map_controller.dart';
 import 'package:ehrenamtskarte/map/map/map_with_futures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:maplibre_gl/maplibre_gl.dart';
 
 class PhysicalStoreFeatureData {
@@ -41,16 +42,22 @@ class _MapPageState extends State<MapPage> implements MapPageController {
 
   @override
   Widget build(BuildContext context) {
-    return MapWithFutures(
-      onFeatureClick: _onFeatureClick,
-      onNoFeatureClick: stopShowingAcceptingStore,
-      onFeatureClickLayerFilter: const ['physical_stores'],
-      setFollowUserLocation: widget.setFollowUserLocation,
-      onMapCreated: (controller) {
-        controller.setTelemetryEnabled(enabled: false);
-        setState(() => _controller = controller);
-        widget.onMapCreated(this);
-      },
+    // Until we have a (dark) map style for dark theme, the system overlay should always use dark fonts
+    // on the bright map. See #613.
+    // Just as Google Maps, we do NOT protect the system status bar with a gradient.
+    return AnnotatedRegion<SystemUiOverlayStyle>(
+      value: SystemUiOverlayStyle.dark,
+      child: MapWithFutures(
+        onFeatureClick: _onFeatureClick,
+        onNoFeatureClick: stopShowingAcceptingStore,
+        onFeatureClickLayerFilter: const ['physical_stores'],
+        setFollowUserLocation: widget.setFollowUserLocation,
+        onMapCreated: (controller) {
+          controller.setTelemetryEnabled(enabled: false);
+          setState(() => _controller = controller);
+          widget.onMapCreated(this);
+        },
+      ),
     );
   }
 

--- a/frontend/lib/themes.dart
+++ b/frontend/lib/themes.dart
@@ -12,6 +12,10 @@ final bodyMedium = const TextStyle(fontSize: 14.0, fontWeight: FontWeight.normal
 final bodySmall = const TextStyle(fontSize: 12.0, fontWeight: FontWeight.normal);
 final labelSmall = const TextStyle(fontSize: 10.0, fontWeight: FontWeight.normal);
 
+SystemUiOverlayStyle systemOverlayStyleFromAppBarBackgroundColor(Color color) {
+  return color.computeLuminance() > 0.5 ? SystemUiOverlayStyle.dark : SystemUiOverlayStyle.light;
+}
+
 ThemeData get lightTheme {
   final textColor = Colors.black87;
   final defaultTypography = Typography.blackMountainView;
@@ -58,7 +62,7 @@ ThemeData get lightTheme {
       color: Color(0xffeeeeee),
     ),
     appBarTheme: AppBarTheme(
-        systemOverlayStyle: SystemUiOverlayStyle.dark,
+        systemOverlayStyle: SystemUiOverlayStyle.light,
         backgroundColor: lightTheme.colorScheme.primary,
         foregroundColor: backgroundColor,
         titleTextStyle: titleMedium),


### PR DESCRIPTION
### Short Description

The system ui overlay was not properly configured:
 * on some screens in dark mode (e.g. Ausweisen, About), the system status bar was dark on a dark background (=> illegible)
 * on some screens (e.g. Search Page, Herausgeber, etc.), the system status bar was dark, but the title on our app bar was white (=> visually ugly, but all was legible)

Usually, the system ui overlay style is handled through the use of an AppBar.
I added a minimal appbar for status bar protection (using a Gradient) for the Ausweisen and About pages (the protections are especially relevant for landscape mode, where the content exceeds the viewport and can be scrolled).
For the maps page, we likely don't want to further protect the status bar (Google Maps does not do that either; it would look a bit weird), so we can use an AnnotatedRegion to set the system ui overlay style.

### Testing

* Check that system status bar (at the top) is legible on all pages/routes (also check landscape mode, dark mode, etc.)
* Also, especially check on iOS as I cannot test it there.

### Related Issues

Related: #2094 
