### PR TITLE
Local setup: Let Martin wait for db, sync DB version with salt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,13 @@ services:
     volumes:
       - ./docker/martin-config.yaml:/app/config.yaml
     depends_on:
-      - db-postgis
+      db-postgis:
+        condition: service_healthy
+        restart: true
     networks:
       - network
   db-postgis:
-    image:  postgis/postgis:13-3.0-alpine
+    image:  postgis/postgis:15-3.5-alpine
     command: [ "postgres", "-c", "log_statement=all", "-c", "log_destination=stderr" ]
     environment:
       - POSTGRES_DB=ehrenamtskarte
@@ -19,6 +21,14 @@ services:
       - 127.0.0.1:5432:5432
     networks:
       - network
+    healthcheck:
+      # We use pg_isready to check whether the DB is up and running.
+      # We need to specify the hostname, otherwise pg_isready only checks whether connections via the local loopback
+      # work, which is also the case if the database is still in the process of initialization.
+      test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB} -h db-postgis" ]
+      interval: 10s
+      start_period: 10s
+      start_interval: 1s
   adminer:
     image: "adminer:4.8.1-standalone"
     ports:


### PR DESCRIPTION
### Short Description

There was a race condition seemingly introduced in https://github.com/digitalfabrik/entitlementcard/pull/2116 that results in (sometimes) martin not being able to launch correctly; it seems to fail to connect to the DB.

Therefore, we should make docker compose wait for the DB to spin up completely.

I also adjusted the version of the postgis container to match the postgres version we use in Salt.