### PR TITLE
2055: Migrate input forms to Mui for Koblenz

### DIFF
--- a/administration/src/bp-modules/self-service/CardSelfServiceForm.tsx
+++ b/administration/src/bp-modules/self-service/CardSelfServiceForm.tsx
@@ -1,6 +1,6 @@
-import { Checkbox, FormGroup, InputGroup, Intent } from '@blueprintjs/core'
+import { Checkbox } from '@blueprintjs/core'
 import InfoOutlined from '@mui/icons-material/InfoOutlined'
-import { styled } from '@mui/material'
+import { FormGroup, TextField, styled } from '@mui/material'
 import React, { ReactElement, useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
@@ -14,6 +14,7 @@ import { removeMultipleSpaces } from '../../util/helper'
 import { useAppToaster } from '../AppToaster'
 import ExtensionForms from '../cards/ExtensionForms'
 import { ActionButton } from './components/ActionButton'
+import CustomFormLabel from './components/CustomFormLabel'
 import FormAlert from './components/FormAlert'
 import { IconTextButton } from './components/IconTextButton'
 import { UnderlineTextButton } from './components/UnderlineTextButton'
@@ -27,6 +28,9 @@ const StyledCheckbox = styled(Checkbox)`
 
 const Container = styled('div')`
   margin-bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 `
 
 type CardSelfServiceFormProps = {
@@ -73,28 +77,38 @@ const CardSelfServiceForm = ({
     setSearchParams(undefined, { replace: true })
   }
 
+  const removeEndAdornmentMargin = { '& .MuiFormHelperText-root': { margin: '0px' } }
+
   return (
     <>
       <Container key={card.id}>
-        <FormGroup label={t('firstNameLastName')} labelFor='name-input'>
-          <InputGroup
-            large={viewportSmall}
+        <FormGroup>
+          <CustomFormLabel htmlFor='name-input' label={t('firstNameLastName')} />
+          <TextField
             id='name-input'
             placeholder='Erika Musterfrau'
             autoFocus
-            rightElement={
-              <ClearInputButton
-                viewportSmall={viewportSmall}
-                onClick={() => updateCard({ fullName: '' })}
-                input={card.fullName}
-              />
-            }
-            intent={isFullNameValid(card) || !showErrorMessage ? undefined : Intent.DANGER}
             value={card.fullName}
             onBlur={() => setTouchedFullName(true)}
             onChange={event => updateCard({ fullName: removeMultipleSpaces(event.target.value) })}
+            error={!isFullNameValid(card) && showErrorMessage}
+            helperText={
+              showErrorMessage ? <FormAlert errorMessage={getFullNameValidationErrorMessage(card.fullName)} /> : null
+            }
+            fullWidth
+            size='small'
+            sx={removeEndAdornmentMargin}
+            InputProps={{
+              sx: { paddingRight: 0 },
+              endAdornment: (
+                <ClearInputButton
+                  viewportSmall={viewportSmall}
+                  onClick={() => updateCard({ fullName: '' })}
+                  input={card.fullName}
+                />
+              ),
+            }}
           />
-          {showErrorMessage && <FormAlert errorMessage={getFullNameValidationErrorMessage(card.fullName)} />}
         </FormGroup>
         <ExtensionForms card={card} updateCard={updateCard} showRequired={formSendAttempt} />
         <IconTextButton onClick={() => setOpenReferenceInformation(true)}>

--- a/administration/src/bp-modules/self-service/components/CustomFormLabel.tsx
+++ b/administration/src/bp-modules/self-service/components/CustomFormLabel.tsx
@@ -1,0 +1,14 @@
+import { FormLabel, styled } from '@mui/material'
+import React, { ReactElement } from 'react'
+
+const CustomFormLabel = ({ label, htmlFor }: { label: string; htmlFor?: string }): ReactElement => {
+  const StyledFormLabel = styled(FormLabel)`
+    font-size: 14px;
+    font-weight: 400;
+    color: #1c2127;
+    margin-bottom: 5px;
+  `
+  return <StyledFormLabel htmlFor={htmlFor}>{label}</StyledFormLabel>
+}
+
+export default CustomFormLabel

--- a/administration/src/cards/extensions/BirthdayExtension.tsx
+++ b/administration/src/cards/extensions/BirthdayExtension.tsx
@@ -1,8 +1,9 @@
-import { FormGroup } from '@blueprintjs/core'
+import { FormGroup } from '@mui/material'
 import React, { ReactElement, useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import CustomDatePicker from '../../bp-modules/components/CustomDatePicker'
+import CustomFormLabel from '../../bp-modules/self-service/components/CustomFormLabel'
 import FormAlert from '../../bp-modules/self-service/components/FormAlert'
 import { ProjectConfigContext } from '../../project-configs/ProjectConfigContext'
 import PlainDate from '../../util/PlainDate'
@@ -45,7 +46,8 @@ const BirthdayForm = ({
   }
 
   return (
-    <FormGroup label={t('birthdayLabel')}>
+    <FormGroup>
+      <CustomFormLabel htmlFor='name-input' label={t('birthdayLabel')} />
       <CustomDatePicker
         value={birthday?.toLocalDate() ?? null}
         onBlur={() => setTouched(true)}

--- a/administration/src/cards/extensions/KoblenzReferenceNumberExtension.tsx
+++ b/administration/src/cards/extensions/KoblenzReferenceNumberExtension.tsx
@@ -1,7 +1,8 @@
-import { FormGroup, InputGroup, Intent } from '@blueprintjs/core'
+import { FormGroup, TextField } from '@mui/material'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import CustomFormLabel from '../../bp-modules/self-service/components/CustomFormLabel'
 import FormAlert from '../../bp-modules/self-service/components/FormAlert'
 import useWindowDimensions from '../../hooks/useWindowDimensions'
 import ClearInputButton from './components/ClearInputButton'
@@ -42,23 +43,29 @@ const KoblenzReferenceNumberExtensionForm = ({
     }
     return errors.join(' ')
   }
+  const removeEndAdornmentPadding = { '& .MuiFormHelperText-root': { margin: '0px' } }
 
   return (
-    <FormGroup label={t('referenceNrLabel')} labelFor='koblenz-reference-number-input'>
-      <InputGroup
-        fill
-        large={viewportSmall}
+    <FormGroup>
+      <CustomFormLabel htmlFor='koblenz-reference-number-input' label={t('referenceNrLabel')} />
+      <TextField
         id='koblenz-reference-number-input'
         placeholder='5.031.025.281, 000D000001, 91459'
-        intent={isValid || !showErrorMessage ? undefined : Intent.DANGER}
-        onBlur={() => setTouched(true)}
+        fullWidth
+        size='small'
         value={koblenzReferenceNumber}
-        rightElement={
-          <ClearInputButton viewportSmall={viewportSmall} onClick={clearInput} input={koblenzReferenceNumber} />
-        }
-        onChange={event => setValue({ koblenzReferenceNumber: event.target.value })}
+        onBlur={() => setTouched(true)}
+        onChange={e => setValue({ koblenzReferenceNumber: e.target.value })}
+        error={!isValid && showErrorMessage}
+        helperText={showErrorMessage ? <FormAlert errorMessage={getErrorMessage()} /> : null}
+        sx={removeEndAdornmentPadding}
+        InputProps={{
+          sx: { paddingRight: 0 },
+          endAdornment: (
+            <ClearInputButton viewportSmall={viewportSmall} onClick={clearInput} input={koblenzReferenceNumber} />
+          ),
+        }}
       />
-      {showErrorMessage && <FormAlert errorMessage={getErrorMessage()} />}
     </FormGroup>
   )
 }

--- a/administration/src/cards/extensions/NuernbergPassIdExtension.tsx
+++ b/administration/src/cards/extensions/NuernbergPassIdExtension.tsx
@@ -15,7 +15,11 @@ const NuernbergPassIdForm = ({
   setValue,
   isValid,
 }: ExtensionComponentProps<NuernbergPassIdExtensionState>): ReactElement => (
-  <FormGroup label='Nürnberg-Pass-ID' labelFor='nuernberg-pass-id-input' intent={isValid ? undefined : Intent.DANGER}>
+  <FormGroup
+    style={{ marginTop: 15 }}
+    label='Nürnberg-Pass-ID'
+    labelFor='nuernberg-pass-id-input'
+    intent={isValid ? undefined : Intent.DANGER}>
     <InputGroup
       id='nuernberg-pass-id-input'
       placeholder='12345678'


### PR DESCRIPTION
### Short Description

Replace the blueprint.js input fields of the KoblenzPass application form with MUI controls.
💡 Hint: there is a separate task for migrating the buttons.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- I started with first-name field used `FormGroup` from mui instead of blueprint and moved the error line at the helper text.
- To make Mui `FormLabel` close to what we have in blueprint as InputGroup label I had to create a `CustomFormLabel` and for consistency of the design I didn't add a label at `TextField` to disable floating label.
-  For birthday extension I replaced `FormGroup` with the Mui one and added a label.
- At CardSelfServiceForm.tsx I changed the container to use flex to be able to use gap (used gap to leave consistent spaces)
- I after I changed birthday extension's Form, NuernbergPassIdExtension needed some space becouse blueprint form adds some margin at the bottom.
- Removed some margins with `removeEndAdornmentMargin` to make it look as the original design.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- This could affect Nurenburg.

### Testing

- Go to http://localhost:3000/erstellen
- Check if all extensions are working correctly
- Go to Nurenburg's admin and see if the form for creating a card behaves correctly.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2055 
