### PR TITLE
2100: Update com.expediagroup.graphql version to 8.7.0

### DIFF
--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -9,13 +9,7 @@ org-jlleitschuh-gradle-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version 
 
 [versions]
 
-# FIXME: Keeping this at 6.10.2 since all versions from 7.0.0 onwards produce an error on tests
-# running in CircleCI (running tests on a local machine works though):
-#
-# Verein360ApplicationTest > should return an error when region not found() FAILED
-#    java.net.SocketTimeoutException at Verein360ApplicationTest.kt:148
-#        Caused by: java.net.SocketException at Verein360ApplicationTest.kt:148
-graphql = "6.10.2"
+graphql = "8.7.0"
 jackson = "2.19.0"
 javalin = "6.6.0"
 jetbrains-exposed = "0.61.0"

--- a/backend/src/test/kotlin/app/ehrenamtskarte/backend/GraphqlApiTest.kt
+++ b/backend/src/test/kotlin/app/ehrenamtskarte/backend/GraphqlApiTest.kt
@@ -12,8 +12,9 @@ import java.io.File
 open class GraphqlApiTest : IntegrationTest() {
     protected val app: Javalin = Javalin.create().apply {
         val backendConfiguration = loadTestConfig()
+        val graphQLHandler = GraphQLHandler(backendConfiguration)
         post("/") { ctx ->
-            GraphQLHandler(backendConfiguration).handle(ctx, applicationData = File("dummy"))
+            graphQLHandler.handle(ctx, applicationData = File("dummy"))
         }
     }
 


### PR DESCRIPTION
### Short Description
Follow up for https://github.com/digitalfabrik/entitlementcard/pull/2104

There was an issue with the com.expediagroup.graphql upgrade - one of the tests always failed in CI due to SocketTimeoutException.

I believe this update affected the initialization of the graphql endpoint, and the graphql endpoint was not yet initialized when the first test was run. As a result, the first graphql test failed.

### Proposed Changes
I changed the initialization of GraphQLHandler in the tests.
The GraphQLHandler object is now initialized before the graphql endpoint is configured.
This solved the issue in tests.

### Side Effects
no

### Testing
Dev only: some graphql requests can be checked (smoke testing)

### Resolved Issues
n/a
