### PR TITLE
2153: Fix latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@eslint/compat": "^1.2.7",
         "@eslint/eslintrc": "^3.3.0",
-        "app-toolbelt": "github:digitalfabrik/app-toolbelt#semver:0.4.0",
+        "app-toolbelt": "github:digitalfabrik/app-toolbelt#semver:0.5.1",
         "eslint": "^9.21.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.8.0",
@@ -10375,7 +10375,7 @@
     },
     "node_modules/app-toolbelt": {
       "version": "0.4.0",
-      "resolved": "git+ssh://git@github.com/digitalfabrik/app-toolbelt.git#f83f15e6cf30d3eb2cded63cd315dfd6cf96b3d9",
+      "resolved": "git+ssh://git@github.com/digitalfabrik/app-toolbelt.git#277c8d5bf307e3448be2925afcee1b42deff0042",
       "dev": true,
       "dependencies": {
         "@octokit/auth-app": "^7.1.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@eslint/compat": "^1.2.7",
     "@eslint/eslintrc": "^3.3.0",
-    "app-toolbelt": "github:digitalfabrik/app-toolbelt#semver:0.4.0",
+    "app-toolbelt": "github:digitalfabrik/app-toolbelt#semver:0.5.1",
     "eslint": "^9.21.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.8.0",


### PR DESCRIPTION
### Short Description

Currently the latest flag is not set when promoting a github release

### Proposed Changes

<!-- Describe this PR in more detail. -->

- use new app-toolbelt version that correctly sets the latest flag

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2153 

related: https://github.com/digitalfabrik/app-toolbelt/pull/32
