### PR TITLE
Downgrade react-router-dom

### DIFF
--- a/administration/package.json
+++ b/administration/package.json
@@ -2,7 +2,8 @@
   "name": "administration",
   "private": true,
   "dependenciesComments": {
-    "typescript": "Keeping on 5.0.x because of current incompatibility of 5.1.x with @typescript-eslint"
+    "typescript": "Keeping on 5.0.x because of current incompatibility of 5.1.x with @typescript-eslint",
+    "react-router-dom": "Keep 6.26.2 since 6.30.0 breaks redirect for login and logout, update to v7 and fix the issue in #2161"
   },
   "dependencies": {
     "@apollo/client": "^3.7.16",

--- a/administration/package.json
+++ b/administration/package.json
@@ -39,7 +39,7 @@
     "react-dom": "^18.2.0",
     "react-flip-move": "^3.0.5",
     "react-i18next": "^15.1.0",
-    "react-router-dom": "^6.30.0",
+    "react-router-dom": "6.26.2",
     "styled-components": "^5.3.11",
     "xregexp": "^5.1.1"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "react-dom": "^18.2.0",
         "react-flip-move": "^3.0.5",
         "react-i18next": "^15.1.0",
-        "react-router-dom": "6.26.0",
+        "react-router-dom": "6.26.2",
         "styled-components": "^5.3.11",
         "xregexp": "^5.1.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "react-dom": "^18.2.0",
         "react-flip-move": "^3.0.5",
         "react-i18next": "^15.1.0",
-        "react-router-dom": "^6.30.0",
+        "react-router-dom": "6.26.2",
         "styled-components": "^5.3.11",
         "xregexp": "^5.1.1"
       },
@@ -459,6 +459,15 @@
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "administration/node_modules/@remix-run/router": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.2.tgz",
+      "integrity": "sha512-baiMx18+IMuD1yyvOGaHM9QrVUPGGG0jC+z+IPHnRJWUAUvaKuWKyE8gjDj2rzv3sz9zOGoRSPgeBVHRhZnBlA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "administration/node_modules/@testing-library/jest-dom": {
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
@@ -809,6 +818,38 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
       "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
       "license": "MIT"
+    },
+    "administration/node_modules/react-router-dom": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.2.tgz",
+      "integrity": "sha512-z7YkaEW0Dy35T3/QKPYB1LjMK2R1fxnHO8kWpUMTBdfVzZrWOiY9a7CtN8HqdWtDUWd5FY6Dl8HFsqVwH4uOtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.2",
+        "react-router": "6.26.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "administration/node_modules/react-router-dom/node_modules/react-router": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.2.tgz",
+      "integrity": "sha512-tvN1iuT03kHgOFnLPfLJ8V95eijteveqdOSk+srqfePtQvqCExB8eHOYnlilbOcyJyKnYkr1vJvf7YqotAJu1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
     },
     "administration/node_modules/supports-color": {
       "version": "7.2.0",
@@ -7796,15 +7837,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
-      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@repeaterjs/repeater": {
@@ -23938,38 +23970,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-router": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
-      "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.30.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.0.tgz",
-      "integrity": "sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-transition-group": {


### PR DESCRIPTION
### Short Description

Apparently the update to `react-router-dom 6.30.0` breaks the redirects for login and logout.
This is described here #2148

Note this is only a workaround to fix the issue. I also created an issue for updating react router to v7 (#2161)

### Proposed Changes

<!-- Describe this PR in more detail. -->

- downgrade react router dom

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. Remove `node_modules` from administration and root folder(dev only)
2. run `npm i` and start administration (dev only)
3. Login should redirect to `/` and logout to the login form , check that this does not happen #2148

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

I will keep #2148 open because its just a workaround.

