### PR TITLE
2161: Replace react-router-dom with react-router v7

### DIFF
--- a/administration/package.json
+++ b/administration/package.json
@@ -40,7 +40,7 @@
     "react-dom": "^18.2.0",
     "react-flip-move": "^3.0.5",
     "react-i18next": "^15.1.0",
-    "react-router-dom": "6.26.2",
+    "react-router": "^7.6.0",
     "styled-components": "^5.3.11",
     "xregexp": "^5.1.1"
   },
@@ -66,7 +66,6 @@
     "@types/node": "^20.5.0",
     "@types/react-dev-utils": "^9.0.15",
     "@types/react-dom": "^18.2.6",
-    "@types/react-router-dom": "^5.3.3",
     "@types/resolve": "^1.20.2",
     "@types/styled-components": "^5.1.26",
     "babel-loader": "^9.1.2",

--- a/administration/src/KeepAliveToken.tsx
+++ b/administration/src/KeepAliveToken.tsx
@@ -1,7 +1,7 @@
 import { Button, Classes, Dialog } from '@blueprintjs/core'
 import React, { ReactElement, ReactNode, useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 
 import { TokenPayload } from './AuthProvider'
 import { useWhoAmI } from './WhoAmIProvider'

--- a/administration/src/Router.tsx
+++ b/administration/src/Router.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, useContext, useMemo } from 'react'
-import { Outlet, Route, createBrowserRouter, createRoutesFromElements } from 'react-router'
-import { RouterProvider } from 'react-router/dom'
+import { Outlet, Route, RouterProvider, createBrowserRouter, createRoutesFromElements } from 'react-router'
 import styled from 'styled-components'
 
 import { AuthContext } from './AuthProvider'

--- a/administration/src/Router.tsx
+++ b/administration/src/Router.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useContext, useMemo } from 'react'
-import { Outlet, RouteObject, RouterProvider, createBrowserRouter } from 'react-router-dom'
+import { Outlet, Route, createBrowserRouter, createRoutesFromElements } from 'react-router'
+import { RouterProvider } from 'react-router/dom'
 import styled from 'styled-components'
 
 import { AuthContext } from './AuthProvider'
@@ -42,78 +43,93 @@ const Main = styled.div`
   }
 `
 
-const Router = (): ReactElement => {
+const AuthLayout = (): ReactElement => {
   const { data: authData, signIn, signOut } = useContext(AuthContext)
+  const isLoggedIn = authData !== null && authData.expiry > new Date()
+
+  if (!isLoggedIn) {
+    return <Login onSignIn={signIn} />
+  }
+
+  return (
+    <WhoAmIProvider>
+      <KeepAliveToken authData={authData!} onSignIn={signIn} onSignOut={signOut}>
+        <Navigation onSignOut={signOut} />
+        <Main>
+          <Outlet />
+        </Main>
+      </KeepAliveToken>
+    </WhoAmIProvider>
+  )
+}
+
+const Router = (): ReactElement => {
   const projectConfig = useContext(ProjectConfigContext)
   useMetaTags()
-  const router = useMemo(() => {
-    const isLoggedIn = authData !== null && authData.expiry > new Date()
-    const routes: (RouteObject | null)[] = [
-      { path: '/forgot-password', element: <ForgotPasswordController /> },
-      { path: '/reset-password/', element: <ResetPasswordController /> },
-      { path: '/data-privacy-policy', element: <DataPrivacyPolicy /> },
-      { path: '/activation/:activationCode', element: <ActivationPage /> },
-      ...(projectConfig.applicationFeature
-        ? [
-            { path: '/beantragen', element: <ApplyController /> },
-            {
-              path: '/antrag-verifizieren/:applicationVerificationAccessKey',
-              element: <ApplicationVerificationController />,
-            },
-            { path: '/antrag-einsehen/:accessKey', element: <ApplicationApplicantController /> },
-          ]
-        : []),
-      ...(projectConfig.selfServiceEnabled ? [{ path: '/erstellen', element: <CardSelfServiceView /> }] : []),
-      {
-        path: '*',
-        element: !isLoggedIn ? (
-          <Login onSignIn={signIn} />
-        ) : (
-          <WhoAmIProvider>
-            <KeepAliveToken authData={authData} onSignIn={signIn} onSignOut={signOut}>
-              <Navigation onSignOut={signOut} />
-              <Main>
-                <Outlet />
-              </Main>
-            </KeepAliveToken>
-          </WhoAmIProvider>
-        ),
-        children: [
-          ...(projectConfig.applicationFeature
-            ? [
-                { path: 'applications', element: <ApplicationsController /> },
-                { path: 'region/data-privacy-policy', element: <DataPrivacyController /> },
-                // Currently, '/region' only allows to set the data privacy text for the application form
-                { path: 'region', element: <RegionsController /> },
-              ]
-            : []),
-          ...(projectConfig.cardStatistics.enabled ? [{ path: 'statistics', element: <StatisticsController /> }] : []),
-          ...(projectConfig.cardCreation
-            ? [
-                { path: 'cards', element: <CreateCardsController /> },
-                { path: 'cards/add', element: <AddCardsController /> },
-                { path: 'cards/import', element: <ImportCardsController /> },
-              ]
-            : []),
-          { path: 'users', element: <ManageUsersController /> },
-          { path: 'user-settings', element: <UserSettingsController /> },
-          ...(projectConfig.activityLogConfig
-            ? [
-                {
-                  path: 'activity-log',
-                  element: <ActivityLogController activityLogConfig={projectConfig.activityLogConfig} />,
-                },
-              ]
-            : []),
-          { path: 'stores', element: <StoresController /> },
-          { path: 'stores/import', element: <StoresImportController /> },
-          { path: 'project', element: <ProjectSettingsController /> },
-          { path: '*', element: <HomeController /> },
-        ],
-      },
-    ]
-    return createBrowserRouter(routes.filter((element): element is RouteObject => element !== null))
-  }, [authData, signIn, signOut, projectConfig])
+
+  const router = useMemo(
+    () =>
+      createBrowserRouter(
+        createRoutesFromElements(
+          <>
+            <Route path='/forgot-password' element={<ForgotPasswordController />} />
+            <Route path='/reset-password/' element={<ResetPasswordController />} />
+            <Route path='/data-privacy-policy' element={<DataPrivacyPolicy />} />
+            <Route path='/activation/:activationCode' element={<ActivationPage />} />
+
+            {projectConfig.applicationFeature && (
+              <>
+                <Route path='/beantragen' element={<ApplyController />} />
+                <Route
+                  path='/antrag-verifizieren/:applicationVerificationAccessKey'
+                  element={<ApplicationVerificationController />}
+                />
+                <Route path='/antrag-einsehen/:accessKey' element={<ApplicationApplicantController />} />
+              </>
+            )}
+
+            {projectConfig.selfServiceEnabled && <Route path='/erstellen' element={<CardSelfServiceView />} />}
+
+            <Route path='*' element={<AuthLayout />}>
+              {projectConfig.applicationFeature && (
+                <>
+                  <Route path='applications' element={<ApplicationsController />} />
+                  <Route path='region/data-privacy-policy' element={<DataPrivacyController />} />
+                  {/* Currently, '/region' only allows to set the data privacy text for the application form */}
+                  <Route path='region' element={<RegionsController />} />
+                </>
+              )}
+
+              {projectConfig.cardStatistics.enabled && <Route path='statistics' element={<StatisticsController />} />}
+
+              {projectConfig.cardCreation && (
+                <>
+                  <Route path='cards' element={<CreateCardsController />} />
+                  <Route path='cards/add' element={<AddCardsController />} />
+                  <Route path='cards/import' element={<ImportCardsController />} />
+                </>
+              )}
+
+              <Route path='users' element={<ManageUsersController />} />
+              <Route path='user-settings' element={<UserSettingsController />} />
+
+              {projectConfig.activityLogConfig && (
+                <Route
+                  path='activity-log'
+                  element={<ActivityLogController activityLogConfig={projectConfig.activityLogConfig} />}
+                />
+              )}
+
+              <Route path='stores' element={<StoresController />} />
+              <Route path='stores/import' element={<StoresImportController />} />
+              <Route path='project' element={<ProjectSettingsController />} />
+              <Route path='*' element={<HomeController />} />
+            </Route>
+          </>
+        )
+      ),
+    [projectConfig]
+  )
 
   return <RouterProvider router={router} />
 }

--- a/administration/src/bp-modules/NavigationBar.tsx
+++ b/administration/src/bp-modules/NavigationBar.tsx
@@ -1,7 +1,7 @@
 import { Alignment, Button, Navbar } from '@blueprintjs/core'
 import React, { ReactElement, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
-import { NavLink } from 'react-router-dom'
+import { NavLink } from 'react-router'
 import styled from 'styled-components'
 
 import { useWhoAmI } from '../WhoAmIProvider'

--- a/administration/src/bp-modules/UserMenu.tsx
+++ b/administration/src/bp-modules/UserMenu.tsx
@@ -1,7 +1,7 @@
 import { Button, Divider, Menu, Popover } from '@blueprintjs/core'
 import React, { ReactElement, useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { NavLink, useNavigate } from 'react-router-dom'
+import { NavLink, useNavigate } from 'react-router'
 import styled from 'styled-components'
 
 import { useWhoAmI } from '../WhoAmIProvider'

--- a/administration/src/bp-modules/auth/ForgotPasswordController.tsx
+++ b/administration/src/bp-modules/auth/ForgotPasswordController.tsx
@@ -1,7 +1,7 @@
 import { Button, Card, Classes, FormGroup, H2, H3, H4, InputGroup } from '@blueprintjs/core'
 import React, { ReactElement, useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 
 import getMessageFromApolloError from '../../errors/getMessageFromApolloError'
 import { useSendResetMailMutation } from '../../generated/graphql'

--- a/administration/src/bp-modules/auth/LoginForm.tsx
+++ b/administration/src/bp-modules/auth/LoginForm.tsx
@@ -1,7 +1,7 @@
 import { Button, Classes, FormGroup, InputGroup } from '@blueprintjs/core'
 import React, { ChangeEvent, ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 
 import PasswordInput from '../PasswordInput'
 

--- a/administration/src/bp-modules/auth/ResetPasswordController.tsx
+++ b/administration/src/bp-modules/auth/ResetPasswordController.tsx
@@ -1,7 +1,7 @@
 import { Button, Callout, Card, Classes, FormGroup, H2, H3, H4, InputGroup } from '@blueprintjs/core'
 import React, { ReactElement, useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router'
 
 import getMessageFromApolloError from '../../errors/getMessageFromApolloError'
 import { useCheckPasswordResetLinkQuery, useResetPasswordMutation } from '../../generated/graphql'

--- a/administration/src/bp-modules/cards/AddCardsController.tsx
+++ b/administration/src/bp-modules/cards/AddCardsController.tsx
@@ -1,7 +1,7 @@
 import { NonIdealState, Spinner } from '@blueprintjs/core'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 
 import { useWhoAmI } from '../../WhoAmIProvider'
 import { Region } from '../../generated/graphql'

--- a/administration/src/bp-modules/cards/CreateCardsController.tsx
+++ b/administration/src/bp-modules/cards/CreateCardsController.tsx
@@ -1,7 +1,7 @@
 import { ButtonGroup, NonIdealState } from '@blueprintjs/core'
 import React, { ReactElement, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import styled from 'styled-components'
 
 import { useWhoAmI } from '../../WhoAmIProvider'

--- a/administration/src/bp-modules/cards/ImportCardsController.tsx
+++ b/administration/src/bp-modules/cards/ImportCardsController.tsx
@@ -1,7 +1,7 @@
 import { NonIdealState, Spinner } from '@blueprintjs/core'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 
 import { useWhoAmI } from '../../WhoAmIProvider'
 import { Region } from '../../generated/graphql'

--- a/administration/src/bp-modules/cards/ImportCardsInput.tsx
+++ b/administration/src/bp-modules/cards/ImportCardsInput.tsx
@@ -1,7 +1,7 @@
 import { NonIdealState } from '@blueprintjs/core'
 import React, { ChangeEvent, ReactElement, useCallback, useContext, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router'
 import styled from 'styled-components'
 
 import { Card, initializeCardFromCSV } from '../../cards/Card'

--- a/administration/src/bp-modules/cards/hooks/useCardGenerator.test.tsx
+++ b/administration/src/bp-modules/cards/hooks/useCardGenerator.test.tsx
@@ -3,7 +3,7 @@ import { OverlayToaster } from '@blueprintjs/core'
 import { act, renderHook } from '@testing-library/react'
 import { mocked } from 'jest-mock'
 import React, { ReactNode } from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 
 import { generateCardInfo, initializeCard } from '../../../cards/Card'
 import { PdfError, generatePdf } from '../../../cards/PdfFactory'

--- a/administration/src/bp-modules/cards/hooks/useCardGenerator.ts
+++ b/administration/src/bp-modules/cards/hooks/useCardGenerator.ts
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useState } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router'
 
 import { Card, initializeCardFromCSV, updateCard as updateCardObject } from '../../../cards/Card'
 import { generateCsv, getCSVFilename } from '../../../cards/CsvFactory'

--- a/administration/src/bp-modules/home/HomeController.tsx
+++ b/administration/src/bp-modules/home/HomeController.tsx
@@ -1,7 +1,7 @@
 import { Button, H3 } from '@blueprintjs/core'
 import React, { ReactElement, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
-import { NavLink } from 'react-router-dom'
+import { NavLink } from 'react-router'
 import styled from 'styled-components'
 
 import { useWhoAmI } from '../../WhoAmIProvider'

--- a/administration/src/bp-modules/regions/DataPrivacyCard.tsx
+++ b/administration/src/bp-modules/regions/DataPrivacyCard.tsx
@@ -1,7 +1,7 @@
 import { Button, H2 } from '@blueprintjs/core'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import styled from 'styled-components'
 
 import SettingsCard from '../user-settings/SettingsCard'

--- a/administration/src/bp-modules/regions/data-privacy-policy/DataPrivacyOverview.tsx
+++ b/administration/src/bp-modules/regions/data-privacy-policy/DataPrivacyOverview.tsx
@@ -1,7 +1,7 @@
 import { Button, H3, TextArea, Tooltip } from '@blueprintjs/core'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import styled from 'styled-components'
 
 import graphQlErrorMap from '../../../errors/GraphQlErrorMap'

--- a/administration/src/bp-modules/self-service/CardSelfServiceForm.tsx
+++ b/administration/src/bp-modules/self-service/CardSelfServiceForm.tsx
@@ -3,7 +3,7 @@ import InfoOutlined from '@mui/icons-material/InfoOutlined'
 import { styled } from '@mui/material'
 import React, { ReactElement, useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router'
 
 import { Card, getFullNameValidationErrorMessage, isFullNameValid, isValid } from '../../cards/Card'
 import ClearInputButton from '../../cards/extensions/components/ClearInputButton'

--- a/administration/src/bp-modules/self-service/__tests__/CardSelfServiceForm.test.tsx
+++ b/administration/src/bp-modules/self-service/__tests__/CardSelfServiceForm.test.tsx
@@ -3,7 +3,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers'
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 import { fireEvent } from '@testing-library/react'
 import React, { ReactNode, act } from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 
 import { initializeCardFromCSV } from '../../../cards/Card'
 import koblenzConfig from '../../../project-configs/koblenz/config'

--- a/administration/src/bp-modules/self-service/hooks/__tests__/useCardGeneratorSelfService.test.tsx
+++ b/administration/src/bp-modules/self-service/hooks/__tests__/useCardGeneratorSelfService.test.tsx
@@ -2,7 +2,7 @@ import { MockedProvider, MockedResponse } from '@apollo/client/testing'
 import { OverlayToaster } from '@blueprintjs/core'
 import { act, renderHook } from '@testing-library/react'
 import React, { ReactNode } from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 
 import { ProjectConfigProvider } from '../../../../project-configs/ProjectConfigContext'
 import koblenzConfig from '../../../../project-configs/koblenz/config'

--- a/administration/src/bp-modules/self-service/hooks/useCardGeneratorSelfService.tsx
+++ b/administration/src/bp-modules/self-service/hooks/useCardGeneratorSelfService.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useContext, useState } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router'
 
 import { Card, initializeCardFromCSV } from '../../../cards/Card'
 import { generatePdf } from '../../../cards/PdfFactory'

--- a/administration/src/bp-modules/stores/StoresController.tsx
+++ b/administration/src/bp-modules/stores/StoresController.tsx
@@ -1,7 +1,7 @@
 import { ButtonGroup, NonIdealState } from '@blueprintjs/core'
 import React, { ReactElement, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import styled from 'styled-components'
 
 import { useWhoAmI } from '../../WhoAmIProvider'

--- a/administration/src/bp-modules/stores/StoresImportController.tsx
+++ b/administration/src/bp-modules/stores/StoresImportController.tsx
@@ -1,7 +1,7 @@
 import { NonIdealState, Spinner } from '@blueprintjs/core'
 import React, { ReactElement, useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import styled from 'styled-components'
 
 import { useWhoAmI } from '../../WhoAmIProvider'

--- a/administration/src/bp-modules/util/ProjectSwitcher.tsx
+++ b/administration/src/bp-modules/util/ProjectSwitcher.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@blueprintjs/core'
 import React, { ReactElement } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 
 import { LOCAL_STORAGE_PROJECT_KEY } from '../../project-configs/constants'
 

--- a/administration/src/mui-modules/activation/ActivationPage.tsx
+++ b/administration/src/mui-modules/activation/ActivationPage.tsx
@@ -2,7 +2,7 @@ import { Alert, Card } from '@mui/material'
 import { styled } from '@mui/system'
 import React, { ReactElement, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router'
 
 import { ProjectConfigContext } from '../../project-configs/ProjectConfigContext'
 import ActivationPageContent from './components/ActivationPageContent'

--- a/administration/src/mui-modules/application-verification/ApplicationApplicantController.tsx
+++ b/administration/src/mui-modules/application-verification/ApplicationApplicantController.tsx
@@ -2,7 +2,7 @@ import { Alert } from '@mui/material'
 import { SnackbarProvider } from 'notistack'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useParams } from 'react-router-dom'
+import { useParams } from 'react-router'
 import styled from 'styled-components'
 
 import { useGetApplicationByApplicantQuery } from '../../generated/graphql'

--- a/administration/src/mui-modules/application-verification/ApplicationVerificationController.tsx
+++ b/administration/src/mui-modules/application-verification/ApplicationVerificationController.tsx
@@ -3,7 +3,7 @@ import { Alert, AlertTitle, Button, Card, Divider, Typography, styled } from '@m
 import { SnackbarProvider, useSnackbar } from 'notistack'
 import React, { ReactElement, useContext, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { useParams } from 'react-router-dom'
+import { useParams } from 'react-router'
 
 import JsonFieldView from '../../bp-modules/applications/JsonFieldView'
 import getMessageFromApolloError from '../../errors/getMessageFromApolloError'

--- a/administration/src/testing/render.tsx
+++ b/administration/src/testing/render.tsx
@@ -1,7 +1,7 @@
 import { RenderOptions, RenderResult, render as rawRender } from '@testing-library/react'
 import React, { ReactElement, ReactNode } from 'react'
 import { I18nextProvider } from 'react-i18next'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter } from 'react-router'
 
 import i18n from '../i18n'
 import { ProjectConfigProvider } from '../project-configs/ProjectConfigContext'

--- a/administration/src/types/react-router-dom-shim.d.ts
+++ b/administration/src/types/react-router-dom-shim.d.ts
@@ -1,0 +1,4 @@
+declare module 'react-router/dom' {
+  // Re-export everything your code expects from `react-router`
+  export * from 'react-router'
+}

--- a/administration/src/types/react-router-dom-shim.d.ts
+++ b/administration/src/types/react-router-dom-shim.d.ts
@@ -1,4 +1,0 @@
-declare module 'react-router/dom' {
-  // Re-export everything your code expects from `react-router`
-  export * from 'react-router'
-}

--- a/administration/src/util/useBlockNavigation.ts
+++ b/administration/src/util/useBlockNavigation.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { unstable_usePrompt as unstableUsePrompt } from 'react-router-dom'
+import { unstable_usePrompt as unstableUsePrompt } from 'react-router'
 
 const useBlockNavigation = ({ when, message }: { when: boolean; message: string }): void => {
   unstableUsePrompt({ when, message })

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "react-dom": "^18.2.0",
         "react-flip-move": "^3.0.5",
         "react-i18next": "^15.1.0",
-        "react-router-dom": "6.26.2",
+        "react-router": "^7.6.0",
         "styled-components": "^5.3.11",
         "xregexp": "^5.1.1"
       },
@@ -91,7 +91,6 @@
         "@types/node": "^20.5.0",
         "@types/react-dev-utils": "^9.0.15",
         "@types/react-dom": "^18.2.6",
-        "@types/react-router-dom": "^5.3.3",
         "@types/resolve": "^1.20.2",
         "@types/styled-components": "^5.1.26",
         "babel-loader": "^9.1.2",
@@ -476,15 +475,6 @@
         "node": ">=18"
       }
     },
-    "administration/node_modules/@remix-run/router": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.0.tgz",
-      "integrity": "sha512-zDICCLKEwbVYTS6TjYaWtHXxkdoUvD/QXvyVZjGCsWz5vyH7aFeONlPffPdW+Y/t6KT0MgXb2Mfjun9YpWN1dA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "administration/node_modules/@testing-library/jest-dom/node_modules/chalk": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -852,38 +842,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
       "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
       "license": "MIT"
-    },
-    "administration/node_modules/react-router-dom": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.0.tgz",
-      "integrity": "sha512-RRGUIiDtLrkX3uYcFiCIxKFWMcWQGMojpYZfcstc63A1+sSnVgILGIm9gNUA6na3Fm1QuPGSBQH2EMbAZOnMsQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.19.0",
-        "react-router": "6.26.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "administration/node_modules/react-router-dom/node_modules/react-router": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.0.tgz",
-      "integrity": "sha512-wVQq0/iFYd3iZ9H2l3N3k4PL8EEHcb0XlU2Na8nEwmiXgIUElEH6gaJDtUQxJ+JFzmIXaQjfdpcGWaM6IoQGxg==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.19.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
     },
     "administration/node_modules/supports-color": {
       "version": "7.2.0",
@@ -9111,13 +9069,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/history": {
-      "version": "4.7.11",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
-      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
@@ -9378,29 +9329,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router": {
-      "version": "5.1.20",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
-      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router-dom": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
-      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router": "*"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -24101,6 +24029,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.0.tgz",
+      "integrity": "sha512-GGufuHIVCJDbnIAXP3P9Sxzq3UUsddG3rrI3ut1q6m0FI6vxVBF3JoPQ38+W/blslLH4a5Yutp8drkEpXoddGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -25198,6 +25157,12 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",


### PR DESCRIPTION
### Short Description

We are still using an old version of react-router-dom v6 and should update to a more recent version.

### Proposed Changes

- According to this: [upgrade-to-v7](https://reactrouter.com/upgrading/v6#upgrade-to-v7) I had to remove the old `react-router-dom` and replace it with `"react-router": "^7.6.0"`.
- Updated imports of any file that uses `react-router-dom`.
- After updating imports the issue with unresponsive login and logout still exist so I changed the `router` to JSX way instead of objects so I wrapped it with [createRoutesFromElements](https://reactrouter.com/6.30.0/utils/create-routes-from-elements)
- I changed each object to `<Route path="" element=""/>` as JSX.
- Moved the elements for  `path: '*'` to a component called `AuthLayout`.
- No need for filtering while using JSX so I removed it.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

:warning: Everything could be affected here (you need to test everything you could think of).

### Testing

- Test logging in and out like I did here https://github.com/digitalfabrik/entitlementcard/issues/2148
- Test all pages we have at /Administration for each project.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2161 
