### PR TITLE
2169: Change name of responsible department for the EAK

### DIFF
--- a/administration/src/project-configs/bayern/dataPrivacyBase.tsx
+++ b/administration/src/project-configs/bayern/dataPrivacyBase.tsx
@@ -78,7 +78,7 @@ export const DataPrivacyBaseText = (): ReactElement => (
         <u>Verantwortlich für den Inhalt:</u>
       </span>
       <br />
-      Referat Öffentlichkeitsarbeit
+      Referat III 3
       <br />
       Telefon: 089 1261-01
       <br />

--- a/frontend/build-configs/bayern/disclaimerText.ts
+++ b/frontend/build-configs/bayern/disclaimerText.ts
@@ -1,5 +1,5 @@
 export default `<p>Verantwortlich im Sinne § 7 TMG:</p>
-<p>Referat Öffentlichkeitsarbeit<br>
+<p>Referat III 3<br>
 Telefon: 089 1261-01<br>
 E-Mail: <a href="mailto:poststelle@stmas.bayern.de">poststelle@stmas.bayern.de</a><br>
 Haftung im Sinne §§ 7 - 10 TMG</p>

--- a/frontend/build-configs/bayern/publisherText.ts
+++ b/frontend/build-configs/bayern/publisherText.ts
@@ -8,7 +8,7 @@ E-Mail: <a href="mailto:poststelle@stmas.bayern.de">poststelle@stmas.bayern.de</
 <br>
 <br>
 <h4>Verantwortlich für den Inhalt:</h4>
-<p>Referat Öffentlichkeitsarbeit<br>
+<p>Referat III 3<br>
 Telefon: 089 1261-01<br>
 E-Mail: <a href="mailto:poststelle@stmas.bayern.de">poststelle@stmas.bayern.de</a></p>
 <p>E-Mail zur Ehrenamtskarte: <a href="mailto:ehrenamtskarte@stmas.bayern.de">ehrenamtskarte@stmas.bayern.de</a></p>


### PR DESCRIPTION
### Short Description
In the Ehrenamtskarte app the "Referat Öffentlichkeitsarbeit" is mentioned as the responsible agent for the contents of the app. They asked us to change this to "Referat III 3".

### Proposed Changes
- adjust department name in the app and in the administration

### Side Effects
no

### Testing
Check the department name in the Ehrenamtskarte app:
- "Über" -> "Mehr Informationen"
- "Über" -> "Haftung, Haftungsausschluss und Impressum"

Check the name in the Datenschutzerklärung (last step of the application submission form)
<img width="884" alt="image" src="https://github.com/user-attachments/assets/ac895116-1736-4b3c-a775-ce9fd941f975" />

### Resolved Issues
Fixes: #2169
