### PR TITLE
2038: Fix PermissionRequestInProgressException

### DIFF
--- a/frontend/lib/intro_slides/intro_screen.dart
+++ b/frontend/lib/intro_slides/intro_screen.dart
@@ -17,11 +17,22 @@ class IntroScreen extends StatefulWidget {
 }
 
 class _IntroScreenState extends State<IntroScreen> {
+  bool _isProcessing = false;
+
   Future<void> _onDonePress(SettingsModel settings) async {
-    await checkAndRequestLocationPermission(context, requestIfNotGranted: true);
-    settings.setFirstStart(enabled: false);
-    if (!mounted) return;
-    GoRouter.of(context).pushReplacement(homeRouteName);
+    if (_isProcessing) return;
+    setState(() => _isProcessing = true);
+
+    try {
+      await checkAndRequestLocationPermission(context, requestIfNotGranted: true);
+      if (!mounted) return;
+      settings.setFirstStart(enabled: false);
+      GoRouter.of(context).pushReplacement(homeRouteName);
+    } catch (e, stacktrace) {
+      debugPrintStack(stackTrace: stacktrace, label: e.toString());
+    } finally {
+      if (mounted) setState(() => _isProcessing = false);
+    }
   }
 
   @override
@@ -30,7 +41,7 @@ class _IntroScreenState extends State<IntroScreen> {
     final settings = Provider.of<SettingsModel>(context);
     final theme = Theme.of(context);
     return IntroSlider(
-      onDonePress: () => _onDonePress(settings),
+      onDonePress: () async => await _onDonePress(settings),
       renderDoneBtn: Text(t.common.next),
       renderNextBtn: Text(t.common.next),
       renderPrevBtn: Text(t.common.previous),


### PR DESCRIPTION
### Short Description
Fix exception from sentry:
```
PermissionRequestInProgressException: A request for location permissions is already running, please wait for it to complete before doing another request.
  File "geolocator_apple.dart", line 63, in GeolocatorApple.requestPermission
  File "determine_position.dart", line 129, in checkAndRequestLocationPermission
  File "intro_screen.dart", line 21, in _IntroScreenState._onDonePress
```
This happens when the user clicks "Weiter" on the last intro screen multiple times.

### Proposed Changes
- add _isProcessing variable to the _IntroScreenState
- check it before executing _onDonePress() and return if the button has already been clicked

### Side Effects
no

### Testing
Dev only:
- perform fresh app installation (intro slides should be displayed)
- open the app, go to the last intro slide
- click "Weiter" or "Next" button multiple times and very fast
- see the exception in the log

### Resolved Issues
Fixes: #2038
