### PR TITLE
Fix postgis image on ARM macs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - network
   db-postgis:
     image:  postgis/postgis:17-3.5-alpine
+    platform: linux/amd64
     command: [ "postgres", "-c", "log_statement=all", "-c", "log_destination=stderr" ]
     environment:
       - POSTGRES_DB=ehrenamtskarte


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
The recent update of the postgis image (#2151) breaks starting the database docker compose service on ARM macs:
```
Resolving "postgis/postgis" using unqualified-search registries (/etc/containers/registries.conf.d/999-podman-machine.conf)
Trying to pull docker.io/postgis/postgis:17-3.5-alpine...
Error: choosing an image from manifest list docker://postgis/postgis:17-3.5-alpine: no image found in image index for architecture "arm64", variant "v8", OS "linux"
```

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use `linux/amd64` instead

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
Check that starting docker-compose still works (or works again on macs).

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A
