### PR TITLE
2190: Fix KOBLENZ_PEPPER in gradle config

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -130,7 +130,7 @@ kover {
 tasks.withType<JavaExec>().configureEach {
     systemProperties = properties
     environment("JWT_SECRET", "HelloWorld")
-    environment("KOBLENZ_PEPPER", "testasdf")
+    environment("KOBLENZ_PEPPER", "123456789ABC")
 }
 
 tasks.register<Copy>("copyStyle") {


### PR DESCRIPTION
### Short Description
Fix KOBLENZ_PEPPER in gradle config

### Proposed Changes
Fix KOBLENZ_PEPPER in gradle config

### Side Effects
These variables wont be used on production, right? (not sure how do we run backend there)

### Testing
Card creation for Koblenz should work locally 

### Resolved Issues
Fixes: #2190
