### PR TITLE
Fix card activation

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/cards/webservice/schema/CardMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/cards/webservice/schema/CardMutationService.kt
@@ -309,7 +309,7 @@ class CardMutationService {
 
         // Avoid race conditions when activating a card.
         val activationResult = transaction(TRANSACTION_REPEATABLE_READ) t@{
-            this.maxAttempts = 0
+            this.maxAttempts = 1
 
             val card = CardRepository.findByHash(project, cardHash)
             val activationSecretHash = card?.activationSecretHash


### PR DESCRIPTION
### Short Description
Card activation is currently broken
Exception in the backend:
```
[JettyServerThreadPool-287] WARN io.javalin.Javalin - Uncaught exception
java.lang.IllegalArgumentException: maxAttempts must be set to perform at least 1 attempt.
	at org.jetbrains.exposed.sql.Transaction.setMaxAttempts(Transaction.kt:77)
	at app.ehrenamtskarte.backend.cards.webservice.schema.CardMutationService.activateCard$lambda$4(CardMutationService.kt:312)
```

### Proposed Changes
Change the transaction's max attempts property to 1 so that the transaction is executed once instead of never

### Side Effects
no

### Testing
1. create card (for any project)
2. activate/add card in the app

### Resolved Issues
n/a
