### PR TITLE
Group dependabot updates and reduce frequency

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,60 +1,89 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
+
 version: 2
 updates:
-
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: monthly
     ignore:
       - dependency-name: "*"
         # Ignore major updates for all dependencies
-        update-types: [ "version-update:semver-major" ]
-    open-pull-requests-limit: 2
+        update-types: ["version-update:semver-major"]
+    groups:
+      minor:
+        patterns: ["*"]
+        update-types: [minor]
+    open-pull-requests-limit: 1
 
   - package-ecosystem: gradle
     directory: "/backend"
     schedule:
-      interval: daily
+      interval: monthly
     labels:
       - "not-testable"
-    open-pull-requests-limit: 2
+      - "dependencies"
+    ignore:
+      - dependency-name: "*"
+        # Ignore major updates for all dependencies
+        update-types: ["version-update:semver-major"]
+    groups:
+      minor:
+        patterns: ["*"]
+        update-types: [minor]
+    open-pull-requests-limit: 1
 
   - package-ecosystem: pub
     directory: "/frontend"
     schedule:
-      interval: daily
+      interval: monthly
     labels:
       - "not-testable"
-    open-pull-requests-limit: 2
+      - "dependencies"
+    open-pull-requests-limit: 1
     ignore:
       - dependency-name: "*"
         # Ignore major updates for all dependencies
-        update-types: [ "version-update:semver-major" ]
+        update-types: ["version-update:semver-major"]
+    groups:
+      minor:
+        patterns: ["*"]
+        update-types: [minor]
 
   - package-ecosystem: gradle
     directory: "/frontend/android"
     schedule:
-      interval: daily
+      interval: monthly
     labels:
       - "not-testable"
-    open-pull-requests-limit: 2
+      - "dependencies"
+    open-pull-requests-limit: 1
 
   - package-ecosystem: bundler
     directory: "/frontend/ios"
     schedule:
-      interval: daily
+      interval: monthly
     labels:
       - "not-testable"
-    open-pull-requests-limit: 2
+      - "dependencies"
+    open-pull-requests-limit: 1
     ignore:
       - dependency-name: "*"
         # Ignore major updates for all dependencies
-        update-types: [ "version-update:semver-major" ]
+        update-types: ["version-update:semver-major"]
+    groups:
+      minor:
+        patterns: ["*"]
+        update-types: [minor]
 
   - package-ecosystem: docker-compose
     directory: "/"
     schedule:
-      interval: daily
+      interval: monthly
     labels:
       - "not-testable"
-    open-pull-requests-limit: 2
+      - "dependencies"
+    open-pull-requests-limit: 1
+    groups:
+      all:
+        patterns: ["*"]


### PR DESCRIPTION
### Short Description

Groups dependabot updates and reduces frequency to reduce the number of PRs.


### Testing

n/a

### Comment

Could someone with sufficient permissions check in the repository settings whether we have to enable dependabot security updates (and if so enable them)? I have no access to the repo settings...

Here's a guide:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates