### PR TITLE
dependabot: Group updates patch single minor

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -70,6 +70,7 @@ updates:
 
   # single updates for minor version
   - package-ecosystem: "npm"
+    target-branch: main # see https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
     directory: "/"
     schedule:
       interval: "daily"
@@ -80,6 +81,7 @@ updates:
     open-pull-requests-limit: 2
 
   - package-ecosystem: gradle
+    target-branch: main # see https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
     directory: "/backend"
     schedule:
       interval: daily
@@ -93,6 +95,7 @@ updates:
     open-pull-requests-limit: 2
 
   - package-ecosystem: pub
+    target-branch: main # see https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
     directory: "/frontend"
     schedule:
       interval: daily
@@ -105,6 +108,7 @@ updates:
         update-types: ["version-update:semver-major", "version-update:semver-patch"]
 
   - package-ecosystem: bundler
+    target-branch: main # see https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219
     directory: "/frontend/ios"
     schedule:
       interval: daily

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,9 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    labels:
+      - "not-testable"
+      - "dependencies"
     ignore:
       - dependency-name: "*"
         # Ignore major and minor updates for all dependencies
@@ -74,6 +77,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "not-testable"
+      - "dependencies"
     ignore:
       - dependency-name: "*"
         # Ignore major and patch updates for all dependencies
@@ -85,13 +91,13 @@ updates:
     directory: "/backend"
     schedule:
       interval: daily
+    labels:
+      - "not-testable"
+      - "dependencies"
     ignore:
       - dependency-name: "*"
         # Ignore major and patch updates for all dependencies
         update-types: ["version-update:semver-major", "version-update:semver-patch"]
-    labels:
-      - "not-testable"
-      - "dependencies"
     open-pull-requests-limit: 2
 
   - package-ecosystem: pub
@@ -101,6 +107,7 @@ updates:
       interval: daily
     labels:
       - "not-testable"
+      - "dependencies"
     open-pull-requests-limit: 2
     ignore:
       - dependency-name: "*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,18 +2,19 @@
 
 version: 2
 updates:
+  # group updates for patch version
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: monthly
     ignore:
       - dependency-name: "*"
-        # Ignore major updates for all dependencies
-        update-types: ["version-update:semver-major"]
+        # Ignore major and minor updates for all dependencies
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     groups:
-      minor:
+      patch:
         patterns: ["*"]
-        update-types: [minor]
+        update-types: [patch]
     open-pull-requests-limit: 1
 
   - package-ecosystem: gradle
@@ -25,12 +26,12 @@ updates:
       - "dependencies"
     ignore:
       - dependency-name: "*"
-        # Ignore major updates for all dependencies
-        update-types: ["version-update:semver-major"]
+        # Ignore major and minor updates for all dependencies
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     groups:
-      minor:
+      patch:
         patterns: ["*"]
-        update-types: [minor]
+        update-types: [patch]
     open-pull-requests-limit: 1
 
   - package-ecosystem: pub
@@ -43,21 +44,12 @@ updates:
     open-pull-requests-limit: 1
     ignore:
       - dependency-name: "*"
-        # Ignore major updates for all dependencies
-        update-types: ["version-update:semver-major"]
+        # Ignore major and minor updates for all dependencies
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     groups:
-      minor:
+      patch:
         patterns: ["*"]
-        update-types: [minor]
-
-  - package-ecosystem: gradle
-    directory: "/frontend/android"
-    schedule:
-      interval: monthly
-    labels:
-      - "not-testable"
-      - "dependencies"
-    open-pull-requests-limit: 1
+        update-types: [patch]
 
   - package-ecosystem: bundler
     directory: "/frontend/ios"
@@ -69,21 +61,77 @@ updates:
     open-pull-requests-limit: 1
     ignore:
       - dependency-name: "*"
-        # Ignore major updates for all dependencies
-        update-types: ["version-update:semver-major"]
+        # Ignore major and minor updates for all dependencies
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     groups:
-      minor:
+      patch:
         patterns: ["*"]
-        update-types: [minor]
+        update-types: [patch]
+
+  # single updates for minor version
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        # Ignore major and patch updates for all dependencies
+        update-types: ["version-update:semver-major", "version-update:semver-patch"]
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: gradle
+    directory: "/backend"
+    schedule:
+      interval: daily
+    ignore:
+      - dependency-name: "*"
+        # Ignore major and patch updates for all dependencies
+        update-types: ["version-update:semver-major", "version-update:semver-patch"]
+    labels:
+      - "not-testable"
+      - "dependencies"
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: pub
+    directory: "/frontend"
+    schedule:
+      interval: daily
+    labels:
+      - "not-testable"
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        # Ignore major and patch updates for all dependencies
+        update-types: ["version-update:semver-major", "version-update:semver-patch"]
+
+  - package-ecosystem: bundler
+    directory: "/frontend/ios"
+    schedule:
+      interval: daily
+    labels:
+      - "not-testable"
+      - "dependencies"
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        # Ignore major and patch updates for all dependencies
+        update-types: ["version-update:semver-major", "version-update:semver-patch"]
+
+  # Single weekly updates for other ecosystems with few dependencies including all update types
+  - package-ecosystem: gradle
+    directory: "/frontend/android"
+    schedule:
+      interval: weekly
+    labels:
+      - "not-testable"
+      - "dependencies"
+    open-pull-requests-limit: 2
 
   - package-ecosystem: docker-compose
     directory: "/"
     schedule:
-      interval: monthly
+      interval: weekly
     labels:
       - "not-testable"
       - "dependencies"
-    open-pull-requests-limit: 1
-    groups:
-      all:
-        patterns: ["*"]
+    open-pull-requests-limit: 2


### PR DESCRIPTION
### Short Description

We had some issues with minor group updates on npm, so i reverted to single for minor and group for patch versions

### Proposed Changes

<!-- Describe this PR in more detail. -->

- group updates for patch versions 
- single updates for minor versions
- weekly single updates for other ecosystems with few dependencies
- add workaround for multiple update schedules on one ecosystem

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Testing

There is a validation tool for the syntax
https://www.npmjs.com/package/@bugron/validate-dependabot-yaml
The rest can only be checked if its merged in main afaics

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
