### PR TITLE
2211: Add info data transfer error message

### DIFF
--- a/administration/src/bp-modules/self-service/components/FormAlert.tsx
+++ b/administration/src/bp-modules/self-service/components/FormAlert.tsx
@@ -14,6 +14,7 @@ const Container = styled('div')<{ $severity: 'info' | 'error'; $isToast: boolean
   gap: 8px;
   align-items: center;
   font-size: 14px;
+  white-space: pre-line;
 `
 
 type FormAlertProps = {

--- a/administration/src/util/translations/de.json
+++ b/administration/src/util/translations/de.json
@@ -551,7 +551,7 @@
     },
     "invalidRole": "Diese Rolle kann nicht zugewiesen werden.",
     "invalidApplicationConfirmationNoteSize": "Unzulässige Zeichenlänge der Notiz erreicht. Maximal sind {{maxSize}} Zeichen erlaubt.",
-    "entitlementNotFound": "Wir konnten Ihre Angaben nicht im System finden. Bitte überprüfen Sie Ihre Angaben und versuchen Sie es erneut.",
+    "entitlementNotFound": "Wir konnten Ihre Angaben nicht im System finden.\nAus technischen Gründen stehen die Daten des Jobcenters Koblenz ab Mitte des folgenden Monats zur Verfügung.\nBitte überprüfen Sie Ihre Angaben und versuchen Sie es erneut.",
     "entitlementExpired": "Sie sind nicht länger berechtigt, einen KoblenzPass zu erstellen. Bitte kontaktieren Sie koblenzpass@stadt.koblenz.de für weitere Informationen.",
     "mailNotSend": "Email konnte nicht an {{recipient}} gesendet werden.",
     "passwordResetKeyExpired": "Die Gültigkeit ihres Links ist abgelaufen",


### PR DESCRIPTION
### Short Description

Koblenz wants an additional info if user entitlement can't be found

### Proposed Changes

<!-- Describe this PR in more detail. -->

- adjust text in translation
- add white-space preline to respect new lines in FormAlerts

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- none
### Testing
- Open koblenz pass self service `/erstellen`
- Input form with data that can't be found
- Check for the correct error message and that the message respect new lines
<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2211
