### PR TITLE
Post install restart backend after migration

### DIFF
--- a/scripts/pack_deb.sh
+++ b/scripts/pack_deb.sh
@@ -70,7 +70,7 @@ if [[ -n "$tarfile" ]]; then
     chmod 0755 "$postinstfile"
     echo "useradd -r backend" >> "$postinstfile"
     echo "sudo -u backend /opt/ehrenamtskarte/backend/bin/backend migrate" >> "$postinstfile"
-    echo "systemctl restart eak-backend.service"
+    echo "systemctl restart eak-backend.service" >> "$postinstfile"
 fi
 if [[ -n "$servicefile" ]]; then
     echo "Copying $servicefile …"

--- a/scripts/pack_deb.sh
+++ b/scripts/pack_deb.sh
@@ -70,6 +70,7 @@ if [[ -n "$tarfile" ]]; then
     chmod 0755 "$postinstfile"
     echo "useradd -r backend" >> "$postinstfile"
     echo "sudo -u backend /opt/ehrenamtskarte/backend/bin/backend migrate" >> "$postinstfile"
+    echo "systemctl restart eak-backend.service"
 fi
 if [[ -n "$servicefile" ]]; then
     echo "Copying $servicefile …"


### PR DESCRIPTION
### Short Description

Since we had some issue that after a package update, the backend service was not restarted successful, i added a service restart in the debian package post install step.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- backend service restart in the backend debian package post install step

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none, if migration runs first

### Testing

Only testable when new package will be installed in the server

