### PR TITLE
2213: Fix DuplicateColumnException in the ApplicationVerifications table

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/dataloader/ApplicationDataLoader.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/dataloader/ApplicationDataLoader.kt
@@ -2,7 +2,6 @@ package app.ehrenamtskarte.backend.application.webservice.dataloader
 
 import app.ehrenamtskarte.backend.application.database.ApplicationVerificationEntity
 import app.ehrenamtskarte.backend.application.database.ApplicationVerifications
-import app.ehrenamtskarte.backend.application.database.ApplicationVerifications.nullable
 import app.ehrenamtskarte.backend.application.database.Applications
 import app.ehrenamtskarte.backend.application.database.repos.ApplicationRepository
 import app.ehrenamtskarte.backend.application.webservice.schema.view.ApplicationVerificationView
@@ -32,7 +31,7 @@ val verificationsByApplicationLoader = newNamedDataLoader<Int, _>(
         val entities = ids.map { id ->
             groupedByApplication[id]?.let { list ->
                 val verificationEntities = list.mapNotNull {
-                    if (it[ApplicationVerifications.id.nullable()] == null) {
+                    if (it.getOrNull(ApplicationVerifications.id) == null) {
                         null
                     } else {
                         ApplicationVerificationEntity.wrapRow(it)


### PR DESCRIPTION
### Short Description
Sometimes we observe a strange issue in production: application creation stops working because backend returns 500 error.
In the backend log we can see the following exception (full stacktrace is in the task description):
```
May 27 08:14:33 entitlementcard.tuerantuer.org backend[521778]: org.jetbrains.exposed.exceptions.DuplicateColumnException: Duplicate column name "id" in table "ApplicationVerifications"
May 27 08:14:33 entitlementcard.tuerantuer.org backend[521778]:         at org.jetbrains.exposed.sql.Table.addColumn(Table.kt:424)
May 27 08:14:33 entitlementcard.tuerantuer.org backend[521778]:         at org.jetbrains.exposed.sql.Table.replaceColumn(Table.kt:418)
May 27 08:14:33 entitlementcard.tuerantuer.org backend[521778]:         at org.jetbrains.exposed.sql.Table.nullable(Table.kt:943)
May 27 08:14:33 entitlementcard.tuerantuer.org backend[521778]:         at app.ehrenamtskarte.backend.application.webservice.dataloader.ApplicationDataLoaderKt$verificationsByApplicationLoader$1.invokeSuspend$lamb>
```
I guess the root cause is in the verificationsByApplicationLoader().
Based on the stacktrace, the nullable() call tries to recreate the column ApplicationVerifications.id, but it's not possible after the table has already been initialized and the column is registered in the exposed metadata.

_I couldn't find a reliable way to reproduce the exception and I assume it might be related to the caching mechanism, but I'm not sure here._

But in any case I think we shouldn't call nullable() there, and that should prevent an exception from occurring.

### Proposed Changes
- get rid of the nullable() call in the data loader

### Side Effects
no?

### Testing
Test application creation (with and without verification) & application view in the administration

### Resolved Issues
Fixes: #2213
