### PR TITLE
2222: Replaced deprecated Mui properties

### DIFF
--- a/administration/src/bp-modules/applications/ApplicationCard.tsx
+++ b/administration/src/bp-modules/applications/ApplicationCard.tsx
@@ -81,7 +81,12 @@ const DeleteDialog = (p: {
   return (
     <Dialog open={p.isOpen} aria-describedby='alert-dialog-description'>
       <DialogContent id='alert-dialog-description'>
-        <Stack direction='row' gap={2} alignItems='center'>
+        <Stack
+          direction='row'
+          sx={{
+            gap: 2,
+            alignItems: 'center',
+          }}>
           {p.deleteResult.loading || p.deleteResult.called ? (
             <CircularProgress size={64} />
           ) : (
@@ -224,7 +229,7 @@ const ApplicationCard = ({
       </AccordionSummary>
 
       <AccordionDetails>
-        <Stack sx={{ p: 2 }} gap={2}>
+        <Stack sx={{ p: 2, gap: 2 }}>
           <Stack direction='row' spacing={2} alignItems='flex-start'>
             {withdrawalDate ? (
               <Box sx={{ bgcolor: theme.palette.warning.light, p: 2, flexGrow: 1 }}>

--- a/administration/src/bp-modules/self-service/CardSelfServiceForm.tsx
+++ b/administration/src/bp-modules/self-service/CardSelfServiceForm.tsx
@@ -93,15 +93,17 @@ const CardSelfServiceForm = ({
             fullWidth
             size='small'
             sx={{ '& .MuiFormHelperText-root': { margin: '0px' } }}
-            InputProps={{
-              sx: { paddingRight: 0 },
-              endAdornment: (
-                <ClearInputButton
-                  viewportSmall={viewportSmall}
-                  onClick={() => updateCard({ fullName: '' })}
-                  input={card.fullName}
-                />
-              ),
+            slotProps={{
+              input: {
+                sx: { paddingRight: 0 },
+                endAdornment: (
+                  <ClearInputButton
+                    viewportSmall={viewportSmall}
+                    onClick={() => updateCard({ fullName: '' })}
+                    input={card.fullName}
+                  />
+                ),
+              },
             }}
           />
         </FormGroup>

--- a/administration/src/cards/extensions/KoblenzReferenceNumberExtension.tsx
+++ b/administration/src/cards/extensions/KoblenzReferenceNumberExtension.tsx
@@ -58,11 +58,13 @@ const KoblenzReferenceNumberExtensionForm = ({
         error={!isValid && showErrorMessage}
         helperText={showErrorMessage ? <FormAlert errorMessage={getErrorMessage()} /> : null}
         sx={removeEndAdornmentMargin}
-        InputProps={{
-          sx: { paddingRight: 0 },
-          endAdornment: (
-            <ClearInputButton viewportSmall={viewportSmall} onClick={clearInput} input={koblenzReferenceNumber} />
-          ),
+        slotProps={{
+          input: {
+            sx: { paddingRight: 0 },
+            endAdornment: (
+              <ClearInputButton viewportSmall={viewportSmall} onClick={clearInput} input={koblenzReferenceNumber} />
+            ),
+          },
         }}
       />
     </FormGroup>

--- a/administration/src/mui-modules/ErrorHandler.tsx
+++ b/administration/src/mui-modules/ErrorHandler.tsx
@@ -18,7 +18,12 @@ const ErrorHandler = ({ refetch, title, description }: ErrorHandlerProps): React
   return (
     <ErrorContainer>
       <Typography variant='h6'>{title ?? t('unknownError')}</Typography>
-      <Typography my='8px' variant='body1' component='div'>
+      <Typography
+        variant='body1'
+        component='div'
+        sx={{
+          my: '8px',
+        }}>
         {description}
       </Typography>
       <Button color='primary' variant='contained' onClick={() => refetch()}>

--- a/administration/src/mui-modules/NonIdealState.tsx
+++ b/administration/src/mui-modules/NonIdealState.tsx
@@ -14,7 +14,11 @@ const NonIdealState = ({
 
   return (
     <Container sx={{ color: theme.palette.text.disabled }} maxWidth='sm'>
-      <Stack alignItems='center' gap={2}>
+      <Stack
+        sx={{
+          alignItems: 'center',
+          gap: 2,
+        }}>
         {icon}
         <Typography variant='h4'>{title}</Typography>
         {description}

--- a/administration/src/mui-modules/application-verification/ApplicationApplicantView.tsx
+++ b/administration/src/mui-modules/application-verification/ApplicationApplicantView.tsx
@@ -81,7 +81,7 @@ const ApplicationApplicantView = ({
   return (
     <ApplicationViewCard elevation={2}>
       <ApplicationViewCardContent>
-        <Typography mb='8px' variant='h6'>
+        <Typography sx={{ mb: '8px' }} variant='h6'>
           {`${t('headline')} ${formatDateWithTimezone(createdDateString, config.timezone)}`}
         </Typography>
         <JsonFieldView
@@ -97,7 +97,7 @@ const ApplicationApplicantView = ({
         {!application.withdrawalDate && (
           <>
             <StyledDivider />
-            <Typography mt='8px' mb='16px' variant='body2'>
+            <Typography sx={{ mt: '8px', mb: '16px' }} variant='body2'>
               {t('withdrawInformation')}
             </Typography>
             <Button variant='contained' endIcon={<Delete />} onClick={() => setDialogOpen(true)}>

--- a/administration/src/mui-modules/application-verification/ApplicationVerificationController.tsx
+++ b/administration/src/mui-modules/application-verification/ApplicationVerificationController.tsx
@@ -107,17 +107,17 @@ const ApplicationVerification = ({ applicationVerificationAccessKey }: Applicati
   return (
     <ApplicationViewCard elevation={2}>
       <div style={{ overflow: 'visible', padding: '20px' }}>
-        <Typography mb='12px' variant='h4'>
+        <Typography sx={{ mb: '12px' }} variant='h4'>
           {config.name}
         </Typography>
-        <Typography my='8px' variant='body1'>
+        <Typography sx={{ my: '8px' }} variant='body1'>
           {t('greeting', { contactName: verification.contactName })}
           <br />
           <br />
           <Trans i18nKey='applicationVerification:text' values={{ organizationName: verification.organizationName }} />
         </Typography>
         <Divider style={{ margin: '24px 0px' }} />
-        <Typography variant='h6' mb='8px'>
+        <Typography variant='h6' sx={{ mb: '8px' }}>
           Antrag vom {formatDateWithTimezone(createdDateString, config.timezone)}
         </Typography>
         <JsonFieldView
@@ -128,7 +128,7 @@ const ApplicationVerification = ({ applicationVerificationAccessKey }: Applicati
           expandedRoot
         />
         <Divider style={{ margin: '24px 0px' }} />
-        <Typography mt='8px' variant='body1'>
+        <Typography sx={{ mt: '8px' }} variant='body1'>
           <Trans
             i18nKey='applicationVerification:confirmationMessage'
             values={{ organizationName: verification.organizationName }}

--- a/administration/src/mui-modules/application/primitive-inputs/EmailForm.tsx
+++ b/administration/src/mui-modules/application/primitive-inputs/EmailForm.tsx
@@ -50,10 +50,12 @@ const EmailForm: Form<State, ValidatedInput, AdditionalProps> = {
         error={touched && isInvalid}
         value={state.email}
         disabled={disableAllInputs}
-        inputProps={{ maxLength: MAX_SHORT_TEXT_LENGTH }}
         onBlur={() => setTouched(true)}
         onChange={e => setState(() => ({ email: e.target.value }))}
         helperText={(showAllErrors || touched) && isInvalid ? validationResult.message : ''}
+        slotProps={{
+          htmlInput: { maxLength: MAX_SHORT_TEXT_LENGTH },
+        }}
       />
     )
   },

--- a/administration/src/mui-modules/application/primitive-inputs/NumberForm.tsx
+++ b/administration/src/mui-modules/application/primitive-inputs/NumberForm.tsx
@@ -49,7 +49,9 @@ const NumberForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
         onBlur={() => setTouched(true)}
         onChange={e => setState(() => ({ type: 'NumberForm', value: e.target.value }))}
         helperText={touched && isInvalid ? validationResult.message : ''}
-        inputProps={{ inputMode: 'numeric', min: options.min, max: options.max }}
+        slotProps={{
+          htmlInput: { inputMode: 'numeric', min: options.min, max: options.max },
+        }}
       />
     )
   },

--- a/administration/src/mui-modules/application/primitive-inputs/ShortTextForm.tsx
+++ b/administration/src/mui-modules/application/primitive-inputs/ShortTextForm.tsx
@@ -34,13 +34,15 @@ const Component = <I,>({
       style={{ margin: '4px 0', minWidth }}
       label={label}
       required={required}
-      inputProps={{ maxLength: MAX_SHORT_TEXT_LENGTH }}
       disabled={disableAllInputs}
       error={touched && isInvalid}
       onBlur={() => setTouched(true)}
       value={state.shortText}
       onChange={e => setState(() => ({ shortText: e.target.value }))}
       helperText={(showAllErrors || touched) && isInvalid ? validationResult.message : ''}
+      slotProps={{
+        htmlInput: { maxLength: MAX_SHORT_TEXT_LENGTH },
+      }}
     />
   )
 }

--- a/administration/src/project-configs/common/ActivationText.tsx
+++ b/administration/src/project-configs/common/ActivationText.tsx
@@ -17,7 +17,7 @@ export const ActivationText = (
   t: TFunction
 ): ReactElement => (
   <div>
-    <Typography variant='h6' mb='8px'>
+    <Typography variant='h6' sx={{ mb: '8px' }}>
       {t('headline')}
     </Typography>
     <span>


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

I followed the guide some of it manually and some automatically by doing this command :

```bash
npx @mui/codemod@latest deprecations/all src/**/*.{ts,tsx}
```
- Manual changes like `my`, `mb`, `gap` and `mt` moved them to `sx={{}}`.

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- hopefully nothing.

### Testing

- Test the following where I changed for ex.:
   - koblenz http://localhost:3000/erstellen
   - http://localhost:3000/applications at bayern
   -  NonIdealState.tsx maybe shut the server down while you are at applications to see it in action.
   -  http://localhost:3000/beantragen for email form and ShortTextForm.tsx.

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2222
