### PR TITLE
2239: Runtime error start date

### DIFF
--- a/administration/src/cards/extensions/StartDayExtension.tsx
+++ b/administration/src/cards/extensions/StartDayExtension.tsx
@@ -17,12 +17,8 @@ const StartDayForm = ({ value, setValue, isValid }: ExtensionComponentProps<Star
   return (
     <FormGroup label={t('startDayLabel')}>
       <CustomDatePicker
-        value={value.startDay?.toLocalDate()}
-        onChange={date => {
-          if (date !== null) {
-            setValue({ startDay: PlainDate.fromLocalDate(date) })
-          }
-        }}
+        value={value.startDay?.toLocalDate() ?? null}
+        onChange={date => setValue({ startDay: PlainDate.safeFromLocalDate(date) })}
         error={!isValid}
         minDate={minStartDay.toLocalDate()}
         textFieldSlotProps={{


### PR DESCRIPTION
### Short Description

The plainDate of the startDay was not constructed safely

### Proposed Changes

<!-- Describe this PR in more detail. -->

- use SafeFromLocalDate to safely construct plain date 
- add null for initial value as fallback to avoid controlled/uncontrolled error in the console

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. Login nuernberg project
2. Go to Karte erstellen
3. Click in startDay form and try to change the value
4. No error should be shown

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2239 
