### PR TITLE
2247: Force webpack to use ts node

### DIFF
--- a/administration/package.json
+++ b/administration/package.json
@@ -100,8 +100,8 @@
     "webpack-manifest-plugin": "^5.0.1"
   },
   "scripts": {
-    "start": "set -ae; REACT_APP_APPLICATION_COMMIT=$(./application_commit.sh); NODE_ENV=development webpack serve --config config/webpack.config.ts",
-    "build": "set -ae; REACT_APP_APPLICATION_COMMIT=$(./application_commit.sh); NODE_ENV=production webpack --config config/webpack.config.ts",
+    "start": "set -ae; REACT_APP_APPLICATION_COMMIT=$(./application_commit.sh); NODE_OPTIONS='--require ts-node/register' NODE_ENV=development webpack serve --config config/webpack.config.ts",
+    "build": "set -ae; REACT_APP_APPLICATION_COMMIT=$(./application_commit.sh); NODE_OPTIONS='--require ts-node/register' NODE_ENV=production webpack --config config/webpack.config.ts",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watchAll",


### PR DESCRIPTION
### Short Description

Make sure webpack-cli uses ts-node to process the config files under Node v24.

### Side Effects

None

### Testing

Make sure, `npm run start`  and ` npm run build`  works under Node v24

### Resolved Issues

Fixes: #2247 
