### PR TITLE
2260: Use sentry only for gradle production builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,7 +329,7 @@ jobs:
                 keys:
                     - v1-gradle-{{ checksum "build.gradle.kts" }}
             - run:
-                command: SENTRY_AUTH_TOKEN=$SENTRY_BACKEND_AUTH_TOKEN ./gradlew assemble
+                command: SENTRY_AUTH_TOKEN=$SENTRY_BACKEND_AUTH_TOKEN ./gradlew assemble -Denv=prod
                 name: Build backend
             - save_cache:
                 key: v1-gradle-{{ checksum "build.gradle.kts" }}

--- a/.circleci/src/jobs/build_backend.yml
+++ b/.circleci/src/jobs/build_backend.yml
@@ -22,7 +22,8 @@ steps:
       name: Build backend
       # Use `assemble` instead of `build` to not run tests
       # Provide sentry auth token for build.gradle.kts
-      command: SENTRY_AUTH_TOKEN=$SENTRY_BACKEND_AUTH_TOKEN ./gradlew assemble
+      # Use production environment to build with sentry
+      command: SENTRY_AUTH_TOKEN=$SENTRY_BACKEND_AUTH_TOKEN ./gradlew assemble -Denv=prod
   - save_cache:
       key: v1-gradle-{{ checksum "build.gradle.kts" }}
       paths:

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
  *
  * This generated file contains a sample Kotlin application project to get you started.
  */
+val isProductionEnvironment = System.getProperty("env") == "prod"
 
 plugins {
     alias(libs.plugins.com.google.protobuf)
@@ -86,15 +87,17 @@ ktlint {
     }
 }
 
-sentry {
-    // Generates a JVM (Java, Kotlin, etc.) source bundle and uploads your source code to Sentry.
-    // This enables source context, allowing you to see your source
-    // code as part of your stack traces in Sentry.
-    includeSourceContext = true
+if (isProductionEnvironment) {
+    sentry {
+        // Generates a JVM (Java, Kotlin, etc.) source bundle and uploads your source code to Sentry.
+        // This enables source context, allowing you to see your source
+        // code as part of your stack traces in Sentry.
+        includeSourceContext = true
 
-    org = "digitalfabrik"
-    projectName = "entitlementcard-backend"
-    authToken = System.getenv("SENTRY_AUTH_TOKEN")
+        org = "digitalfabrik"
+        projectName = "entitlementcard-backend"
+        authToken = System.getenv("SENTRY_AUTH_TOKEN")
+    }
 }
 
 sourceSets {


### PR DESCRIPTION
### Short Description

Currently `./gradlew assemble` will fail if we don't provide sentry auth token as environment variable.
For local dev, we don't need sentry at all, so we can exclude it also for the build

### Proposed Changes

<!-- Describe this PR in more detail. -->

- only use sentry config for production builds
- use production environment variable in build gradle
- add prod env variable to pipeline to build with sentry  

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

Check in the issue description
`build_backend` should still work
https://app.circleci.com/pipelines/github/digitalfabrik/entitlementcard/8587/workflows/0e8fb6e7-836a-4868-8aaa-7866949d2948

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2260
