### PR TITLE
2267: Use '/' as public URL instead of localhost

### DIFF
--- a/administration/config/getPaths.ts
+++ b/administration/config/getPaths.ts
@@ -33,14 +33,10 @@ const getPaths = () => {
   // https://github.com/facebook/create-react-app/issues/637
   const appDirectory = fs.realpathSync(process.cwd())
   const resolveApp = (relativePath: string) => path.resolve(appDirectory, relativePath)
-
-  // We use the ` PUBLIC_URL ` environment variable or "homepage" field to infer
-  // "public path" at which the app is served.
+  // We use the `PUBLIC_URL` environment variable to infer the "public path" at which the app is served.
   // Webpack needs to know it to put the right <script> hrefs into HTML even in
   // single-page apps that may serve index.html for nested URLs like /todos/42.
-  // We can't use a relative path in HTML because we don't want to load something
-  // like /todos/42/static/js/bundle.7289d.js. We have to know the root.
-  const publicUrlOrPath = process.env.PUBLIC_URL || 'http://localhost:3000/'
+  const publicUrlOrPath = process.env.PUBLIC_URL || '/'
 
   const buildPath = process.env.BUILD_PATH || 'build'
   return {


### PR DESCRIPTION
### Short Description

Use '/' as the root path for referencing any (JS) assets.

Fixes a bug introduced in #2219 .

### Testing

Build the production app and verify that the index.html references the JS asset with "/" instead of "http://localhost:3000/".

### Resolved Issues

Fixes: #2267 
