### PR TITLE
2176 Replace `react-flip-move` with `motion`

### DIFF
--- a/administration/package.json
+++ b/administration/package.json
@@ -33,7 +33,6 @@
     "notistack": "^3.0.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-flip-move": "^3.0.5",
     "react-i18next": "^15.5.2",
     "react-router": "^7.6.1",
     "styled-components": "^5.3.11",

--- a/administration/package.json
+++ b/administration/package.json
@@ -28,6 +28,7 @@
     "graphql": "^16.11.0",
     "i18next": "^23.16.8",
     "localforage": "^1.10.0",
+    "motion": "^12.18.1",
     "normalize.css": "^8.0.1",
     "notistack": "^3.0.2",
     "react": "^18.3.1",

--- a/administration/src/bp-modules/applications/ApplicationsOverview.tsx
+++ b/administration/src/bp-modules/applications/ApplicationsOverview.tsx
@@ -1,15 +1,14 @@
 import { AutoAwesome } from '@mui/icons-material'
 import { Container } from '@mui/material'
 import { TFunction } from 'i18next'
+import { AnimatePresence, motion } from 'motion/react'
 import React, { ReactElement, useMemo, useState } from 'react'
-import FlipMove from 'react-flip-move'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import NonIdealState from '../../mui-modules/NonIdealState'
 import StandaloneCenter from '../StandaloneCenter'
 import ApplicationCard from './ApplicationCard'
-import type { ApplicationCardProps } from './ApplicationCard'
 import ApplicationStatusBar from './ApplicationStatusBar'
 import usePrintApplication from './hooks/usePrintApplication'
 import { ApplicationStatusBarItemType, ApplicationVerificationStatus, GetApplicationsType } from './types'
@@ -38,22 +37,13 @@ export const barItems: ApplicationStatusBarItemType[] = [
   },
 ]
 
-const ApplicationList = styled(FlipMove)`
+const ApplicationList = styled.div`
   display: flex;
   flex-grow: 1;
   flex-direction: column;
   height: 100%;
   gap: 16px;
 `
-
-// Necessary for FlipMove, as it cannot handle functional components
-// eslint-disable-next-line react/prefer-stateless-function
-export class ApplicationViewComponent extends React.Component<ApplicationCardProps> {
-  render(): ReactElement {
-    const { application } = this.props
-    return <ApplicationCard key={application.id} {...this.props} />
-  }
-}
 
 const getEmptyApplicationsListStatusDescription = (activeBarItem: ApplicationStatusBarItemType, t: TFunction): string =>
   activeBarItem.status !== undefined ? `${t(activeBarItem.title).toLowerCase()}en` : ''
@@ -88,20 +78,28 @@ const ApplicationsOverview = ({ applications }: { applications: GetApplicationsT
       />
       {filteredApplications.length > 0 ? (
         <ApplicationList>
-          {filteredApplications.map(application => (
-            <ApplicationViewComponent
-              isSelectedForPrint={application.id === applicationIdForPrint}
-              key={application.id}
-              application={application}
-              onPrintApplicationById={printApplicationById}
-              onDelete={() => setUpdatedApplications(updatedApplications.filter(a => a !== application))}
-              onChange={changed =>
-                setUpdatedApplications(
-                  updatedApplications.map(original => (original.id === changed.id ? changed : original))
-                )
-              }
-            />
-          ))}
+          <AnimatePresence initial={false}>
+            {filteredApplications.map(application => (
+              <motion.div
+                key={application.id}
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: 'auto', opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.2, ease: 'easeOut' }}>
+                <ApplicationCard
+                  isSelectedForPrint={application.id === applicationIdForPrint}
+                  application={application}
+                  onPrintApplicationById={printApplicationById}
+                  onDelete={() => setUpdatedApplications(updatedApplications.filter(a => a !== application))}
+                  onChange={changed =>
+                    setUpdatedApplications(
+                      updatedApplications.map(original => (original.id === changed.id ? changed : original))
+                    )
+                  }
+                />
+              </motion.div>
+            ))}
+          </AnimatePresence>
         </ApplicationList>
       ) : (
         <StandaloneCenter>

--- a/administration/src/bp-modules/cards/AddCardsForm.tsx
+++ b/administration/src/bp-modules/cards/AddCardsForm.tsx
@@ -1,5 +1,6 @@
+import { AnimatePresence, motion } from 'motion/react'
+import type { MotionNodeAnimationOptions } from 'motion/react'
 import React, { ReactElement, useCallback, useContext, useRef } from 'react'
-import FlipMove from 'react-flip-move'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
@@ -9,7 +10,7 @@ import { ProjectConfigContext } from '../../project-configs/ProjectConfigContext
 import AddCardForm from './AddCardForm'
 import CardFormButton from './CardFormButton'
 
-const FormsWrapper = styled(FlipMove)`
+const FormsWrapper = styled.div`
   flex-wrap: wrap;
   flex-grow: 1;
   flex-direction: row;
@@ -34,6 +35,13 @@ const FormColumn = styled.div`
   box-sizing: border-box;
 `
 
+const animationProperties: MotionNodeAnimationOptions = {
+  initial: { opacity: 0, scale: 0 },
+  animate: { opacity: 1, scale: 1 },
+  exit: { opacity: 0, scale: 0 },
+  transition: { duration: 0.3 },
+}
+
 type CreateCardsFormProps = {
   region: Region
   cards: Card[]
@@ -55,7 +63,7 @@ const AddCardsForm = ({ region, cards, setCards, updateCard }: CreateCardsFormPr
   const addForm = useCallback(() => {
     const card = initializeCard(projectConfig.card, region)
     setCards([...cards, card])
-    scrollToBottom()
+    setTimeout(scrollToBottom, 200)
   }, [cards, projectConfig.card, region, setCards])
 
   const removeCard = (oldCard: Card) => {
@@ -64,24 +72,25 @@ const AddCardsForm = ({ region, cards, setCards, updateCard }: CreateCardsFormPr
 
   return (
     <Scrollable>
-      <FormsWrapper
-        onFinishAll={() => {
-          scrollToBottom()
-        }}>
-        {cards.map((card, index) => (
-          <FormColumn key={card.id}>
-            <AddCardForm
-              card={card}
-              onRemove={() => removeCard(card)}
-              updateCard={updatedCard => updateCard(updatedCard, index)}
-            />
+      <FormsWrapper>
+        <AnimatePresence initial={false}>
+          {cards.map((card, index) => (
+            <motion.div {...animationProperties} key={card.id.toString()}>
+              <FormColumn>
+                <AddCardForm
+                  card={card}
+                  onRemove={() => removeCard(card)}
+                  updateCard={updatedCard => updateCard(updatedCard, index)}
+                />
+              </FormColumn>
+            </motion.div>
+          ))}
+          <FormColumn key='AddButton'>
+            <CardFormButton text={t('addCard')} icon='add' onClick={addForm} />
           </FormColumn>
-        ))}
-        <FormColumn key='AddButton'>
-          <CardFormButton text={t('addCard')} icon='add' onClick={addForm} />
-        </FormColumn>
+          <div ref={bottomRef} />
+        </AnimatePresence>
       </FormsWrapper>
-      <div ref={bottomRef} />
     </Scrollable>
   )
 }

--- a/administration/src/bp-modules/cards/AddCardsForm.tsx
+++ b/administration/src/bp-modules/cards/AddCardsForm.tsx
@@ -11,12 +11,12 @@ import AddCardForm from './AddCardForm'
 import CardFormButton from './CardFormButton'
 
 const FormsWrapper = styled.div`
-  flex-wrap: wrap;
-  flex-grow: 1;
-  flex-direction: row;
-  display: flex;
-  justify-content: space-evenly;
-  align-items: center;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fill, 400px);
+  justify-content: center;
+  justify-items: flex-start;
+  align-items: flex-start;
 `
 
 const Scrollable = styled.div`
@@ -24,14 +24,12 @@ const Scrollable = styled.div`
   flex-grow: 1;
   flex-direction: column;
   flex-basis: 0;
-  padding: 10px;
-  width: 100%;
+  padding: 24px;
   overflow: auto;
 `
 
 const FormColumn = styled.div`
   width: 400px;
-  margin: 10px;
   box-sizing: border-box;
 `
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,6 @@
         "notistack": "^3.0.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-flip-move": "^3.0.5",
         "react-i18next": "^15.5.2",
         "react-router": "^7.6.1",
         "styled-components": "^5.3.11",
@@ -20313,16 +20312,6 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "license": "MIT"
-    },
-    "node_modules/react-flip-move": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.5.tgz",
-      "integrity": "sha512-Mf4XpbkUNZy9eu80iXXFIjToDvw+bnHxmKHVoositbMpV87O/EQswnXUqVovRHoTx/F+4dE+p//PyJnAT7OtPA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.3.x",
-        "react-dom": ">=16.3.x"
-      }
     },
     "node_modules/react-i18next": {
       "version": "15.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "graphql": "^16.11.0",
         "i18next": "^23.16.8",
         "localforage": "^1.10.0",
+        "motion": "^12.18.1",
         "normalize.css": "^8.0.1",
         "notistack": "^3.0.2",
         "react": "^18.3.1",
@@ -14373,6 +14374,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.18.1.tgz",
+      "integrity": "sha512-6o4EDuRPLk4LSZ1kRnnEOurbQ86MklVk+Y1rFBUKiF+d2pCdvMjWVu0ZkyMVCTwl5UyTH2n/zJEJx+jvTYuxow==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.18.1",
+        "motion-utils": "^12.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -18286,6 +18314,47 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.18.1.tgz",
+      "integrity": "sha512-w1ns2hWQ4COhOvnZf4rg4mW0Pl36mzcShpgt0fSfI6qJxKUbi3kHho/HSKeJFRoY0TO1m5/7C8lG1+Li0uC9Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.18.1.tgz",
+      "integrity": "sha512-dR/4EYT23Snd+eUSLrde63Ws3oXQtJNw/krgautvTfwrN/2cHfCZMdu6CeTxVfRRWREW3Fy1f5vobRDiBb/q+w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.18.1.tgz",
+      "integrity": "sha512-az26YDU4WoDP0ueAkUtABLk2BIxe28d8NH1qWT8jPGhPyf44XTdDUh8pDk9OPphaSrR9McgpcJlgwSOIw/sfkA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",


### PR DESCRIPTION
### Short Description

Replace package `react-flip-move` with [motion](https://github.com/motiondivision/motion) (formerly known as `framer-motion`) for animating lists.

### Side Effects

None

### Testing

- Visit http://localhost:3000/cards/add to add and remove card items
- Visit http://localhost:3000/applications and delete applications

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2176
