### PR TITLE
1738:  Checked for isMandatory for each extension and added an asterisk

### DIFF
--- a/administration/src/bp-modules/cards/ImportCardsRequirementsText.tsx
+++ b/administration/src/bp-modules/cards/ImportCardsRequirementsText.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react'
+import React, { ReactElement, useContext, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
+import { ProjectConfigContext } from '../../project-configs/ProjectConfigContext'
 import { ENTRY_LIMIT, FILE_SIZE_LIMIT_MEGA_BYTES } from './constants'
 
 const RequirementsList = styled.ul`
@@ -18,7 +19,23 @@ const ImportCardsRequirementsText = ({
   csvHeaders,
   isFreinetFormat = false,
 }: ImportCardsRequirementsProps): ReactElement => {
+  const projectConfig = useContext(ProjectConfigContext)
+  const { card: cardConfig } = projectConfig
   const { t } = useTranslation('cards')
+
+  const requiredHeaders = useMemo(() => {
+    const headers = [cardConfig.nameColumnName, cardConfig.expiryColumnName]
+    cardConfig.extensions.forEach((extension, index) => {
+      const header = cardConfig.extensionColumnNames[index]
+      if (extension.isMandatory && header) {
+        headers.push(header)
+      }
+    })
+    return headers
+  }, [cardConfig])
+
+  const decoratedHeaders = csvHeaders.map(header => (requiredHeaders.includes(header) ? `${header}*` : header))
+
   return (
     <RequirementsList>
       <li>{t('maxFileSize', { maxFileSize: FILE_SIZE_LIMIT_MEGA_BYTES })}</li>
@@ -26,7 +43,7 @@ const ImportCardsRequirementsText = ({
       <li>
         {t('maxNumberOfEntries')}: {ENTRY_LIMIT}
       </li>
-      <li>{isFreinetFormat ? t('minColumnsForFreinet') : `${t('columnFormat')}:  ${csvHeaders.join(', ')}`}</li>
+      <li>{isFreinetFormat ? t('minColumnsForFreinet') : `${t('columnFormat')}:  ${decoratedHeaders.join(', ')}`}</li>
       <li>{t('dateFormatHint')}</li>
     </RequirementsList>
   )

--- a/administration/src/bp-modules/stores/StoresCSVInput.tsx
+++ b/administration/src/bp-modules/stores/StoresCSVInput.tsx
@@ -163,7 +163,7 @@ const StoresCsvInput = ({ setAcceptingStores, fields, setIsLoadingCoordinates }:
     <InputContainer
       title={t('selectAFile')}
       icon={<Icon intent='warning' size={NonIdealStateIconSize.STANDARD} icon='upload' />}
-      description={<StoresRequirementsText header={headers} />}
+      description={<StoresRequirementsText header={fields} />}
       action={
         <StoreImportInputContainer>
           <input

--- a/administration/src/bp-modules/stores/StoresRequirementsText.tsx
+++ b/administration/src/bp-modules/stores/StoresRequirementsText.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement } from 'react'
+import React, { ReactElement, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
+import { StoresFieldConfig } from '../../project-configs/getProjectConfig'
 import { FILE_SIZE_LIMIT_MEGA_BYTES } from './constants'
 
 const RequirementsList = styled.ul`
@@ -10,17 +11,18 @@ const RequirementsList = styled.ul`
 `
 
 type ImportCardsRequirementsProps = {
-  header: string[]
+  header: StoresFieldConfig[]
 }
 
 const StoresRequirementsText = ({ header }: ImportCardsRequirementsProps): ReactElement => {
+  const headers = useMemo(() => header.map(field => (field.isMandatory ? `${field.name}*` : `${field.name}`)), [header])
   const { t } = useTranslation('stores')
   return (
     <RequirementsList>
       <li>{t('maxFileSize', { maxFileSize: FILE_SIZE_LIMIT_MEGA_BYTES })} </li>
       <li>{t('fileFormat')}</li>
       <li>
-        {t('neededColumns')} {header.join(', ')}
+        {t('neededColumns')} {headers.join(', ')}
       </li>
     </RequirementsList>
   )


### PR DESCRIPTION
### Short Description

The CSV card import description is ambiguous. The mentioned column format does not inform the user whether the column is actually required or optional.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- I went for the asterisk option.
- From cardConfig I took `nameColumnName` and `expiryColumnName` these two are mandatory headers then added to them any isMandetory extentions from true from `cardConfig.extensions`.
- Added asterisk to required headers.
- I did the same for stores at `StoresRequirementsText.tsx`.

### Side Effects

None.

### Testing

go to:
- http://localhost:3000/cards/import (bayern), (nuernberg).
- http://localhost:3000/stores/import (koblenz), (nuernberg)

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1738 
