### PR TITLE
2266: Fix backend restart post installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -867,6 +867,9 @@ parameters:
     run_delivery_production_frontend:
         default: false
         type: boolean
+    run_packaging_backend_administration:
+        default: false
+        type: boolean
     run_promotion_all:
         default: false
         type: boolean
@@ -1254,6 +1257,25 @@ workflows:
                     - deliver_android
                     - deliver_ios
         when: << pipeline.parameters.run_delivery_production_frontend >>
+    packaging_backend_administration:
+        jobs:
+            - bump_version:
+                context:
+                    - deliverino
+                    - bump_version
+                platforms: web
+                prepare_delivery: false
+            - check_backend
+            - build_backend:
+                context:
+                    - credentials-ehrenamtskarte
+                requires:
+                    - check_backend
+            - pack_backend:
+                requires:
+                    - bump_version
+                    - build_backend
+        when: << pipeline.parameters.run_packaging_backend_administration >>
     promotion_all:
         jobs:
             - promote_android:

--- a/.circleci/src/@common.yml
+++ b/.circleci/src/@common.yml
@@ -34,3 +34,6 @@ parameters:
   run_promotion_all:
     default: false
     type: boolean
+  run_packaging_backend_administration:
+    default: false
+    type: boolean

--- a/.circleci/src/workflows/packaging_backend_administration.yml
+++ b/.circleci/src/workflows/packaging_backend_administration.yml
@@ -1,0 +1,34 @@
+# This is just for testing purposes if changes on pack_deb.sh were performed
+when: << pipeline.parameters.run_packaging_backend_administration >>
+jobs:
+  - bump_version:
+      prepare_delivery: false
+      platforms: web
+      context:
+        - deliverino
+#  - pack_martin:
+#      requires:
+#        - bump_version
+#  - pack_meta:
+#      requires:
+        - bump_version
+
+#  - check_administration
+#  - build_administration:
+#      requires:
+#        - bump_version
+#        - check_administration
+#  - pack_administration:
+#      requires:
+#        - build_administration
+
+  - check_backend
+  - build_backend:
+      context:
+        - credentials-ehrenamtskarte
+      requires:
+        - check_backend
+  - pack_backend:
+      requires:
+        - bump_version
+        - build_backend

--- a/scripts/pack_deb.sh
+++ b/scripts/pack_deb.sh
@@ -70,8 +70,7 @@ if [[ -n "$tarfile" ]]; then
     chmod 0755 "$postinstfile"
     echo "useradd -r backend" >> "$postinstfile"
     echo "sudo -u backend /opt/ehrenamtskarte/backend/bin/backend migrate" >> "$postinstfile"
-   # TODO https://github.com/digitalfabrik/entitlementcard/issues/2266
-   # echo "systemctl restart eak-backend.service" >> "$postinstfile"
+    echo "service eak-backend restart" >> "$postinstfile"
 fi
 if [[ -n "$servicefile" ]]; then
     echo "Copying $servicefile …"


### PR DESCRIPTION
### Short Description

During the last release it turned out that the service restart in our post installation does not work because `systemctl` is unknown.
This indeed only happens in our ci because `systemd` was not installed during `install_backend` (`check_backend_health`)

<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

- instead of using `systemctl` the service can also be restarted with `service eak-backend restart`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

Check that the pipeline succeeds
https://app.circleci.com/pipelines/github/digitalfabrik/entitlementcard/8721/workflows/040e50b4-bb52-4288-a8e5-94e0c5d1078a

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2266
