### PR TITLE
2294: Other options button

### DIFF
--- a/administration/src/bp-modules/applications/ApplicationCard.tsx
+++ b/administration/src/bp-modules/applications/ApplicationCard.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/destructuring-assignment */
 import { MutationResult } from '@apollo/client'
-import { CreditScore, Delete, ExpandMore, InfoOutline, Print, Warning } from '@mui/icons-material'
+import { CreditScore, Delete, ExpandMore, InfoOutline, PrintOutlined, Warning } from '@mui/icons-material'
 import {
   Accordion,
   AccordionDetails,
@@ -29,6 +29,7 @@ import {
   useApproveApplicationStatusMutation,
   useDeleteApplicationMutation,
 } from '../../generated/graphql'
+import BaseMenu, { MenuItemType } from '../../mui-modules/base/BaseMenu'
 import { ProjectConfigContext } from '../../project-configs/ProjectConfigContext'
 import type { ProjectConfig } from '../../project-configs/getProjectConfig'
 import formatDateWithTimezone from '../../util/formatDate'
@@ -97,7 +98,7 @@ const ButtonsCardPending = ({
         startIcon={<CreditScore />}
         disabled={disabled}
         onClick={onPrimaryButtonClick}>
-        {t('applicationApprove')}
+        <Typography variant='button'>{t('applicationApprove')}</Typography>
       </Button>
       <Button
         sx={{ display: 'none' }} // TODO: #1982
@@ -106,7 +107,7 @@ const ButtonsCardPending = ({
         color='error'
         disabled={disabled}
         onClick={onSecondaryButtonClick}>
-        {t('applicationReject')}
+        <Typography variant='button'>{t('applicationReject')}</Typography>
       </Button>
     </>
   )
@@ -134,7 +135,7 @@ const ButtonsCardApproved = ({
             disabled={primaryButtonHref === undefined}
             href={primaryButtonHref}
             startIcon={<CreditScore />}>
-            {cardAlreadyCreated ? t('createCardAgain') : t('createCard')}
+            <Typography variant='button'> {cardAlreadyCreated ? t('createCardAgain') : t('createCard')}</Typography>
           </Button>
         </span>
       </Tooltip>
@@ -233,6 +234,16 @@ const ApplicationCard = ({
     () => config.applicationFeature?.applicationJsonToPersonalData(jsonValueParsed),
     [config.applicationFeature, jsonValueParsed]
   )
+
+  const otherOptionsContainerWidth = 180
+  const otherOptionsItemHeight = 40
+  const menuItems: MenuItemType[] = [
+    {
+      name: t('exportPdf'),
+      onClick: () => onPrintApplicationById(application.id),
+      icon: <PrintOutlined sx={{ height: 24, marginRight: 1 }} />,
+    },
+  ]
 
   return (
     <Accordion
@@ -344,13 +355,12 @@ const ApplicationCard = ({
             />
           ) : undefined}
 
-          <Button
-            onClick={() => onPrintApplicationById(application.id)}
-            startIcon={<Print />}
-            variant='outlined'
-            color='inherit'>
-            {t('exportPdf')}
-          </Button>
+          <BaseMenu
+            menuItems={menuItems}
+            menuLabel={t('moreActionsButtonLabel')}
+            containerWidth={otherOptionsContainerWidth}
+            itemHeight={otherOptionsItemHeight}
+          />
         </Stack>
 
         <DeleteDialog

--- a/administration/src/bp-modules/applications/NoteDialogController.tsx
+++ b/administration/src/bp-modules/applications/NoteDialogController.tsx
@@ -1,6 +1,6 @@
 import { Tooltip } from '@blueprintjs/core'
 import { EditNote } from '@mui/icons-material'
-import { Button, styled } from '@mui/material'
+import { Button, Typography, styled } from '@mui/material'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -66,7 +66,7 @@ const NoteDialogController = ({
           onClick={() => onOpenNoteDialog(true)}
           startIcon={<EditNote />}
           sx={{ displayPrint: 'none' }}>
-          Notiz anzeigen
+          <Typography variant='button'>Notiz anzeigen</Typography>
         </Button>
       </Tooltip>
       {isOpen && (

--- a/administration/src/mui-modules/base/BaseMenu.tsx
+++ b/administration/src/mui-modules/base/BaseMenu.tsx
@@ -1,0 +1,72 @@
+/* eslint-disable react/destructuring-assignment */
+import { KeyboardArrowDown, KeyboardArrowUp } from '@mui/icons-material'
+import { Button, Menu, MenuItem, Typography } from '@mui/material'
+import React, { ReactElement, useState } from 'react'
+
+export type MenuItemType = {
+  name: string
+  onClick: () => void
+  icon: ReactElement
+}
+
+type BaseMenuProps = {
+  menuLabel: string
+  menuItems: MenuItemType[]
+  containerWidth: number
+  itemHeight: number
+}
+
+const BaseMenu = (props: BaseMenuProps): ReactElement => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const open = Boolean(anchorEl)
+  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+  const handleMenuClose = () => {
+    setAnchorEl(null)
+  }
+
+  const handleMenuItemClick = (onMenuItemClick: () => void) => {
+    onMenuItemClick()
+    handleMenuClose()
+  }
+
+  return (
+    <>
+      <Button
+        aria-controls={open ? 'base-menu' : undefined}
+        aria-haspopup='true'
+        aria-expanded={open ? 'true' : undefined}
+        variant='contained'
+        onClick={handleMenuOpen}
+        color='default'
+        endIcon={open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
+        sx={{ width: props.containerWidth, height: props.itemHeight }}>
+        <Typography variant='button'>{props.menuLabel}</Typography>
+      </Button>
+
+      <Menu
+        id='base-menu'
+        anchorEl={anchorEl}
+        sx={{ marginTop: 1 }}
+        slotProps={{ list: { sx: { padding: 0 } } }}
+        color='default'
+        open={open}
+        onClose={handleMenuClose}>
+        {props.menuItems.map(menuItem => (
+          <MenuItem
+            color='default'
+            key={menuItem.name}
+            onClick={() => handleMenuItemClick(menuItem.onClick)}
+            disableRipple
+            sx={{ width: props.containerWidth, height: props.itemHeight }}>
+            {menuItem.icon}
+            <Typography variant='button'>{menuItem.name}</Typography>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  )
+}
+
+export default BaseMenu

--- a/administration/src/mui-modules/base/__tests__/BaseMenu.test.tsx
+++ b/administration/src/mui-modules/base/__tests__/BaseMenu.test.tsx
@@ -1,0 +1,77 @@
+import { EditNote, PrintOutlined } from '@mui/icons-material'
+import { fireEvent, render } from '@testing-library/react'
+import React from 'react'
+
+import BaseMenu from '../BaseMenu'
+
+describe('BaseMenu', () => {
+  const mockMenuItems = [
+    {
+      name: 'Print PDF',
+      onClick: jest.fn(),
+      icon: <PrintOutlined />,
+    },
+    {
+      name: 'Edit Note',
+      onClick: jest.fn(),
+      icon: <EditNote />,
+    },
+  ]
+
+  const defaultProps = {
+    menuLabel: 'Test Menu',
+    menuItems: mockMenuItems,
+    containerWidth: 200,
+    itemHeight: 48,
+  }
+
+  it('should render menu button with correct label', () => {
+    const { getByRole } = render(<BaseMenu {...defaultProps} />)
+    const menuButton = getByRole('button', { name: 'Test Menu' })
+
+    expect(menuButton).toBeTruthy()
+  })
+
+  it('should open menu when button is clicked', () => {
+    const { getByRole } = render(<BaseMenu {...defaultProps} />)
+    const menuButton = getByRole('button', { name: 'Test Menu' })
+
+    fireEvent.click(menuButton)
+    const menu = getByRole('menu')
+
+    expect(menu).toBeTruthy()
+  })
+
+  it('should render all menu items when the menu is open', () => {
+    const { getByRole, getByText } = render(<BaseMenu {...defaultProps} />)
+    const menuButton = getByRole('button', { name: 'Test Menu' })
+
+    fireEvent.click(menuButton)
+
+    expect(getByText(mockMenuItems[0].name)).toBeTruthy()
+    expect(getByText(mockMenuItems[1].name)).toBeTruthy()
+  })
+
+  it('should call onClick handler when menu item is clicked', () => {
+    const { getByRole, getByText } = render(<BaseMenu {...defaultProps} />)
+    const menuButton = getByRole('button', { name: 'Test Menu' })
+
+    fireEvent.click(menuButton)
+    const menuItem = getByText('Print PDF')
+    fireEvent.click(menuItem)
+
+    expect(mockMenuItems[0].onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('should close menu after clicking menu item', () => {
+    const { getByRole, getByText, queryByRole } = render(<BaseMenu {...defaultProps} />)
+    const menuButton = getByRole('button', { name: 'Test Menu' })
+
+    fireEvent.click(menuButton)
+    const menuItem = getByText('Print PDF')
+    fireEvent.click(menuItem)
+
+    const menu = queryByRole('menu')
+    expect(menu).toBeNull()
+  })
+})

--- a/administration/src/mui-modules/theme.ts
+++ b/administration/src/mui-modules/theme.ts
@@ -34,6 +34,11 @@ export const theme = createTheme({
       lineHeight: 1.1,
       fontWeight: 600,
     },
+    button: {
+      fontSize: 14,
+      fontWeight: 600,
+      textTransform: 'none',
+    },
   },
   components: {
     MuiButton: {
@@ -66,6 +71,20 @@ export const theme = createTheme({
           },
         },
       },
+    },
+    MuiMenuItem: {
+      variants: [
+        {
+          props: { color: 'default' },
+          style: {
+            backgroundColor: '#EEEEEE',
+            color: '#5C6065',
+            '&:hover': {
+              backgroundColor: '#dddddd',
+            },
+          },
+        },
+      ],
     },
   },
 })

--- a/administration/src/util/translations/de.json
+++ b/administration/src/util/translations/de.json
@@ -206,7 +206,8 @@
     "applicationResolveNotice": "Dieser Antrag wurde am {{date}} um {{time}}",
     "applicationResolveApproved": "genehmigt",
     "applicationResolveRejected": "abgelehnt",
-    "incompleteApplicationDataTooltip": "Aus den Antragsdaten kann keine Karte erzeugt werden."
+    "incompleteApplicationDataTooltip": "Aus den Antragsdaten kann keine Karte erzeugt werden.",
+    "moreActionsButtonLabel": "Weitere Optionen"
   },
   "auth": {
     "administration": "Verwaltung",


### PR DESCRIPTION
### Short Description

Since we are reaching limits how many buttons/actions we can display next to each other, we introduce are more actions menu button
<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add base component `BaseMenu`, 
- add typography for button, 
- replace button labels by Typography element for ApplicationCard
- add required translations
- add unit test for `BaseMenu`
- move pdf print to other options menu

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. Start bavaria project
2. Go to "Anträge"
3. Open the application accordion "Mehr Anzeigen" and click on "Weitere Option"
4. PDF Print should be shown as an option
5. If you click the button pdf print should be shown
6. If you print/close the print menu, the "Weitere Option" menu should be closed

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2294
