### PR TITLE
Fix android builds ninja cmake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,6 +278,10 @@ jobs:
                 precache: android
             - install_fastlane:
                 directory: android
+            - run:
+                command: |
+                    sudo apt-get update && sudo apt-get install -y ninja-build
+                name: Install Ninja
             - restore_cache:
                 keys:
                     - v1-gradle-{{ checksum "android/build.gradle.kts" }}-{{ checksum "android/app/build.gradle.kts" }}-{{ checksum "android/settings.gradle.kts" }}
@@ -355,6 +359,7 @@ jobs:
                     - nuernberg
                     - koblenz
                 type: enum
+        resource_class: m4pro.medium
         steps:
             - prepare_workspace
             - install_app_toolbelt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,8 +279,7 @@ jobs:
             - install_fastlane:
                 directory: android
             - run:
-                command: |
-                    sudo apt-get update && sudo apt-get install -y ninja-build
+                command: sudo apt-get update && sudo apt-get install -y ninja-build
                 name: Install Ninja
             - restore_cache:
                 keys:

--- a/.circleci/src/jobs/build_android.yml
+++ b/.circleci/src/jobs/build_android.yml
@@ -18,9 +18,8 @@ steps:
   - install_fastlane:
       directory: android
   - run:
-      command: |
-       sudo apt-get update && sudo apt-get install -y ninja-build
       name: Install Ninja
+      command: sudo apt-get update && sudo apt-get install -y ninja-build
   - restore_cache:
       keys:
         - v1-gradle-{{ checksum "android/build.gradle.kts" }}-{{ checksum "android/app/build.gradle.kts" }}-{{ checksum "android/settings.gradle.kts" }}

--- a/.circleci/src/jobs/build_android.yml
+++ b/.circleci/src/jobs/build_android.yml
@@ -17,6 +17,10 @@ steps:
       precache: android
   - install_fastlane:
       directory: android
+  - run:
+      command: |
+       sudo apt-get update && sudo apt-get install -y ninja-build
+      name: Install Ninja
   - restore_cache:
       keys:
         - v1-gradle-{{ checksum "android/build.gradle.kts" }}-{{ checksum "android/app/build.gradle.kts" }}-{{ checksum "android/settings.gradle.kts" }}

--- a/.circleci/src/jobs/build_ios.yml
+++ b/.circleci/src/jobs/build_ios.yml
@@ -1,5 +1,6 @@
 macos:
   xcode: 16.1.0
+resource_class: m4pro.medium
 parameters:
   build_config:
     description: "Name of the build config to use"

--- a/frontend/android/gradle.properties
+++ b/frontend/android/gradle.properties
@@ -1,4 +1,6 @@
-org.gradle.jvmargs=-Xmx2048M
+org.gradle.jvmargs=-Xmx4096m
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.parallel=true
+org.gradle.daemon=true
 # android.enableR8=true


### PR DESCRIPTION
### Short Description

New kotlin version requires ninja.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add ninja that are required for fastlane android builds
- added some gradle properties to speedup gradle build a bit
- adjusted macos ressource class to fix deprecation warning

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing

https://app.circleci.com/pipelines/github/digitalfabrik/entitlementcard/8843/workflows/c59259eb-089b-4761-9cd6-1a10978b271f

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
