### PR TITLE
Fix build android job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,9 @@ jobs:
             - run:
                 command: bundle exec fastlane keystore
                 name: '[FL] Prepare Android Keystore'
+            - run:
+                command: sudo apt-get update && sudo apt-get install -y ninja-build
+                name: 'Install Ninja build system'
                 working_directory: android
             - run:
                 command: bundle exec fastlane android build version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE} build_config_name:<< parameters.build_config >>

--- a/.circleci/src/jobs/build_android.yml
+++ b/.circleci/src/jobs/build_android.yml
@@ -25,6 +25,9 @@ steps:
       command: bundle exec fastlane keystore
       working_directory: android
   - run:
+      name: Install Ninja build system
+      command: sudo apt-get update && sudo apt-get install -y ninja-build
+  - run:
       name: '[FL] Build'
       command: bundle exec fastlane android build version_name:${NEW_VERSION_NAME} version_code:${NEW_VERSION_CODE} build_config_name:<< parameters.build_config >>
       working_directory: android


### PR DESCRIPTION
### Short Description
Follow up for https://github.com/digitalfabrik/entitlementcard/pull/2287/files
This upgrade seems to break build_android job:
https://app.circleci.com/pipelines/github/digitalfabrik/entitlementcard/8823/workflows/9d5da712-aadb-4602-9fde-42b82110c9e9/jobs/57635?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary

### Proposed Changes
I guess this requires ninja-build to be installed first

### Side Effects
no?

### Testing
n/a

### Resolved Issues
n/a
