### PR TITLE
1983: Send application rejected mail

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,9 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/administration/administration.iml" filepath="$PROJECT_DIR$/administration/administration.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/backend.iml" filepath="$PROJECT_DIR$/.idea/modules/backend.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/backend.main.iml" filepath="$PROJECT_DIR$/.idea/modules/backend.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/backend.test.iml" filepath="$PROJECT_DIR$/.idea/modules/backend.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/entitlementcard.iml" filepath="$PROJECT_DIR$/.idea/entitlementcard.iml" />
       <module fileurl="file://$PROJECT_DIR$/frontend/.idea/frontend.iml" filepath="$PROJECT_DIR$/frontend/.idea/frontend.iml" />
     </modules>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,9 +3,6 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/administration/administration.iml" filepath="$PROJECT_DIR$/administration/administration.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/backend.iml" filepath="$PROJECT_DIR$/.idea/modules/backend.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/backend.main.iml" filepath="$PROJECT_DIR$/.idea/modules/backend.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/backend.test.iml" filepath="$PROJECT_DIR$/.idea/modules/backend.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/entitlementcard.iml" filepath="$PROJECT_DIR$/.idea/entitlementcard.iml" />
       <module fileurl="file://$PROJECT_DIR$/frontend/.idea/frontend.iml" filepath="$PROJECT_DIR$/frontend/.idea/frontend.iml" />
     </modules>

--- a/administration/src/bp-modules/applications/ApplicationCard.tsx
+++ b/administration/src/bp-modules/applications/ApplicationCard.tsx
@@ -496,7 +496,9 @@ const ApplicationCard = ({
           open={rejectionDialogOpen}
           loading={rejectStatusResult.loading}
           onConfirm={message => {
-            rejectStatus({ variables: { applicationId: application.id, rejectionMessage: message } })
+            rejectStatus({
+              variables: { project: config.projectId, applicationId: application.id, rejectionMessage: message },
+            })
           }}
           onCancel={() => {
             setRejectionDialogOpen(false)

--- a/administration/src/graphql/applications/rejectApplicationStatus.graphql
+++ b/administration/src/graphql/applications/rejectApplicationStatus.graphql
@@ -1,5 +1,9 @@
-mutation rejectApplicationStatus($applicationId: Int!, $rejectionMessage: String!) {
-  application: rejectApplicationStatus(applicationId: $applicationId, rejectionMessage: $rejectionMessage) {
+mutation rejectApplicationStatus($applicationId: Int!, $project: String!, $rejectionMessage: String!) {
+  application: rejectApplicationStatus(
+    applicationId: $applicationId
+    project: $project
+    rejectionMessage: $rejectionMessage
+  ) {
     status
     statusResolvedDate
     rejectionMessage

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/EakApplicationMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/EakApplicationMutationService.kt
@@ -8,8 +8,8 @@ import app.ehrenamtskarte.backend.application.database.repos.ApplicationReposito
 import app.ehrenamtskarte.backend.application.webservice.schema.create.Application
 import app.ehrenamtskarte.backend.application.webservice.schema.view.ApplicationView
 import app.ehrenamtskarte.backend.application.webservice.utils.ApplicationHandler
-import app.ehrenamtskarte.backend.application.webservice.utils.ApplicationJsonExtensions.getApplicantEmail
-import app.ehrenamtskarte.backend.application.webservice.utils.ApplicationJsonExtensions.getApplicantName
+import app.ehrenamtskarte.backend.application.webservice.utils.getApplicantEmail
+import app.ehrenamtskarte.backend.application.webservice.utils.getApplicantName
 import app.ehrenamtskarte.backend.auth.getAdministrator
 import app.ehrenamtskarte.backend.auth.service.Authorizer
 import app.ehrenamtskarte.backend.auth.service.Authorizer.mayDeleteApplicationsInRegion

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/utils/ApplicationJsonExtensions.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/utils/ApplicationJsonExtensions.kt
@@ -6,31 +6,29 @@ import app.ehrenamtskarte.backend.common.utils.findValueByPath
 import app.ehrenamtskarte.backend.exception.webservice.exceptions.ApplicationDataIncompleteException
 import com.fasterxml.jackson.databind.JsonNode
 
-object ApplicationJsonExtensions {
-    fun ApplicationEntity.getApplicantFirstName(): String =
-        this.getPersonalDataNode().findValueByName("forenames")
-            ?: throw ApplicationDataIncompleteException()
+fun ApplicationEntity.getApplicantFirstName(): String =
+    this.getPersonalDataNode().findValueByName("forenames")
+        ?: throw ApplicationDataIncompleteException()
 
-    fun ApplicationEntity.getApplicantLastName(): String =
-        this.getPersonalDataNode().findValueByName("surname")
-            ?: throw ApplicationDataIncompleteException()
+fun ApplicationEntity.getApplicantLastName(): String =
+    this.getPersonalDataNode().findValueByName("surname")
+        ?: throw ApplicationDataIncompleteException()
 
-    fun ApplicationEntity.getApplicantDateOfBirth(): String =
-        this.getPersonalDataNode().findValueByName("dateOfBirth")
-            ?: throw ApplicationDataIncompleteException()
+fun ApplicationEntity.getApplicantDateOfBirth(): String =
+    this.getPersonalDataNode().findValueByName("dateOfBirth")
+        ?: throw ApplicationDataIncompleteException()
 
-    fun ApplicationEntity.getApplicantName(): String {
-        val forenames = this.getApplicantFirstName()
-        val surname = this.getApplicantLastName()
+fun ApplicationEntity.getApplicantName(): String {
+    val forenames = this.getApplicantFirstName()
+    val surname = this.getApplicantLastName()
 
-        return listOfNotNull(forenames, surname).filter { it.isNotBlank() }.joinToString(" ")
-    }
-
-    fun ApplicationEntity.getApplicantEmail(): String =
-        this.getPersonalDataNode().findValueByName("emailAddress")
-            ?: throw ApplicationDataIncompleteException()
-
-    fun ApplicationEntity.getPersonalDataNode(): JsonNode =
-        this.parseJsonValue().findValueByPath("application", "personalData")
-            ?: throw ApplicationDataIncompleteException()
+    return listOfNotNull(forenames, surname).filter { it.isNotBlank() }.joinToString(" ")
 }
+
+fun ApplicationEntity.getApplicantEmail(): String =
+    this.getPersonalDataNode().findValueByName("emailAddress")
+        ?: throw ApplicationDataIncompleteException()
+
+fun ApplicationEntity.getPersonalDataNode(): JsonNode =
+    this.parseJsonValue().findValueByPath("application", "personalData")
+        ?: throw ApplicationDataIncompleteException()

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/utils/ApplicationJsonExtensions.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/application/webservice/utils/ApplicationJsonExtensions.kt
@@ -1,0 +1,36 @@
+package app.ehrenamtskarte.backend.application.webservice.utils
+
+import app.ehrenamtskarte.backend.application.database.ApplicationEntity
+import app.ehrenamtskarte.backend.common.utils.findValueByName
+import app.ehrenamtskarte.backend.common.utils.findValueByPath
+import app.ehrenamtskarte.backend.exception.webservice.exceptions.ApplicationDataIncompleteException
+import com.fasterxml.jackson.databind.JsonNode
+
+object ApplicationJsonExtensions {
+    fun ApplicationEntity.getApplicantFirstName(): String =
+        this.getPersonalDataNode().findValueByName("forenames")
+            ?: throw ApplicationDataIncompleteException()
+
+    fun ApplicationEntity.getApplicantLastName(): String =
+        this.getPersonalDataNode().findValueByName("surname")
+            ?: throw ApplicationDataIncompleteException()
+
+    fun ApplicationEntity.getApplicantDateOfBirth(): String =
+        this.getPersonalDataNode().findValueByName("dateOfBirth")
+            ?: throw ApplicationDataIncompleteException()
+
+    fun ApplicationEntity.getApplicantName(): String {
+        val forenames = this.getApplicantFirstName()
+        val surname = this.getApplicantLastName()
+
+        return listOfNotNull(forenames, surname).filter { it.isNotBlank() }.joinToString(" ")
+    }
+
+    fun ApplicationEntity.getApplicantEmail(): String =
+        this.getPersonalDataNode().findValueByName("emailAddress")
+            ?: throw ApplicationDataIncompleteException()
+
+    fun ApplicationEntity.getPersonalDataNode(): JsonNode =
+        this.parseJsonValue().findValueByPath("application", "personalData")
+            ?: throw ApplicationDataIncompleteException()
+}

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/freinet/webservice/FreinetApplicationMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/freinet/webservice/FreinetApplicationMutationService.kt
@@ -1,16 +1,17 @@
 package app.ehrenamtskarte.backend.freinet.webservice
 
-import app.ehrenamtskarte.backend.application.database.repos.ApplicationRepository
+import app.ehrenamtskarte.backend.application.database.ApplicationEntity
+import app.ehrenamtskarte.backend.application.webservice.utils.ApplicationJsonExtensions.getApplicantDateOfBirth
+import app.ehrenamtskarte.backend.application.webservice.utils.ApplicationJsonExtensions.getApplicantFirstName
+import app.ehrenamtskarte.backend.application.webservice.utils.ApplicationJsonExtensions.getApplicantLastName
+import app.ehrenamtskarte.backend.application.webservice.utils.ApplicationJsonExtensions.getPersonalDataNode
 import app.ehrenamtskarte.backend.auth.getAdministrator
 import app.ehrenamtskarte.backend.auth.service.Authorizer
 import app.ehrenamtskarte.backend.common.utils.devWarn
-import app.ehrenamtskarte.backend.common.utils.findValueByName
-import app.ehrenamtskarte.backend.common.utils.findValueByPath
 import app.ehrenamtskarte.backend.common.webservice.context
 import app.ehrenamtskarte.backend.exception.service.NotFoundException
 import app.ehrenamtskarte.backend.exception.service.NotImplementedException
 import app.ehrenamtskarte.backend.exception.service.UnauthorizedException
-import app.ehrenamtskarte.backend.exception.webservice.exceptions.ApplicationDataIncompleteException
 import app.ehrenamtskarte.backend.freinet.database.repos.FreinetAgencyRepository
 import app.ehrenamtskarte.backend.freinet.exceptions.FreinetFoundMultiplePersonsException
 import app.ehrenamtskarte.backend.freinet.exceptions.FreinetPersonDataInvalidException
@@ -34,16 +35,14 @@ class FreinetApplicationMutationService {
     ): Boolean {
         val context = dfe.graphQlContext.context
         val admin = context.getAdministrator()
-        val projectConfig = context.backendConfiguration.getProjectConfig(
-            project,
-        )
+        val projectConfig = context.backendConfiguration.getProjectConfig(project)
 
         if (projectConfig.freinet == null) {
             throw NotImplementedException()
         }
 
         return transaction {
-            val application = ApplicationRepository.findByIds(listOf(applicationId)).firstOrNull()
+            val application = ApplicationEntity.findById(applicationId)
                 ?: throw NotFoundException("Application not found")
 
             val regionId = application.regionId.value
@@ -57,21 +56,13 @@ class FreinetApplicationMutationService {
                 ?.takeIf { it.dataTransferActivated }
                 ?: return@transaction false
 
-            val jsonValue = application.parseJsonValue()
-            val personalDataNode = jsonValue.findValueByPath("application", "personalData")
-                ?: throw ApplicationDataIncompleteException()
-
-            val firstName = personalDataNode.findValueByName("forenames").orEmpty()
-            val lastName = personalDataNode.findValueByName("surname").orEmpty()
-            val dateOfBirth = personalDataNode.findValueByName("dateOfBirth").orEmpty()
+            val firstName = application.getApplicantFirstName()
+            val lastName = application.getApplicantLastName()
+            val dateOfBirth = application.getApplicantDateOfBirth()
 
             val freinetApi = FreinetApi(projectConfig.freinet.host, freinetAgency.apiAccessKey, freinetAgency.agencyId)
 
-            val persons = freinetApi.searchPersons(
-                firstName,
-                lastName,
-                dateOfBirth,
-            )
+            val persons = freinetApi.searchPersons(firstName, lastName, dateOfBirth)
 
             when {
                 persons.size() > 1 -> {
@@ -83,7 +74,7 @@ class FreinetApplicationMutationService {
                         firstName,
                         lastName,
                         dateOfBirth,
-                        personalDataNode,
+                        application.getPersonalDataNode(),
                         admin.email,
                     )
 

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/freinet/webservice/FreinetApplicationMutationService.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/freinet/webservice/FreinetApplicationMutationService.kt
@@ -1,10 +1,10 @@
 package app.ehrenamtskarte.backend.freinet.webservice
 
 import app.ehrenamtskarte.backend.application.database.ApplicationEntity
-import app.ehrenamtskarte.backend.application.webservice.utils.ApplicationJsonExtensions.getApplicantDateOfBirth
-import app.ehrenamtskarte.backend.application.webservice.utils.ApplicationJsonExtensions.getApplicantFirstName
-import app.ehrenamtskarte.backend.application.webservice.utils.ApplicationJsonExtensions.getApplicantLastName
-import app.ehrenamtskarte.backend.application.webservice.utils.ApplicationJsonExtensions.getPersonalDataNode
+import app.ehrenamtskarte.backend.application.webservice.utils.getApplicantDateOfBirth
+import app.ehrenamtskarte.backend.application.webservice.utils.getApplicantFirstName
+import app.ehrenamtskarte.backend.application.webservice.utils.getApplicantLastName
+import app.ehrenamtskarte.backend.application.webservice.utils.getPersonalDataNode
 import app.ehrenamtskarte.backend.auth.getAdministrator
 import app.ehrenamtskarte.backend.auth.service.Authorizer
 import app.ehrenamtskarte.backend.common.utils.devWarn

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/mail/Mailer.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/mail/Mailer.kt
@@ -405,4 +405,36 @@ object Mailer {
             message,
         )
     }
+
+    fun sendApplicationRejectedMail(
+        backendConfig: BackendConfiguration,
+        projectConfig: ProjectConfig,
+        applicantName: String,
+        applicantAddress: String,
+        rejectionMessage: String,
+    ) {
+        val subject = "Ihr Antrag wurde abgelehnt"
+        val message = emailBody {
+            p { +"Sehr geehrte/r $applicantName," }
+            p {
+                +"vielen Dank für Ihren Antrag und Ihr Interesse an der Bayerischen Ehrenamtskarte. "
+                +"Wir danken Ihnen für das Engagement und die Zeit, die Sie zum Wohle der Gemeinschaft einbringen. "
+                +"Ihr Einsatz ist von großem Wert und verdient Anerkennung. "
+                +"In diesem Fall ist es leider nicht möglich, dass Sie die Bayerische Ehrenamtskarte erhalten:"
+            }
+            p { +rejectionMessage }
+            finalInformationParagraph(projectConfig)
+        }
+        try {
+            sendMail(
+                backendConfig,
+                projectConfig.smtp,
+                projectConfig.administrationName,
+                applicantAddress,
+                subject,
+                message,
+            )
+        } catch (_: MailNotSentException) {
+        }
+    }
 }

--- a/specs/backend-api.graphql
+++ b/specs/backend-api.graphql
@@ -168,7 +168,7 @@ type Mutation {
   "Import accepting stores via csv"
   importAcceptingStores(dryRun: Boolean!, project: String!, stores: [CSVAcceptingStoreInput!]!): StoreImportReturnResultModel!
   "Reject an application"
-  rejectApplicationStatus(applicationId: Int!, rejectionMessage: String!): ApplicationView!
+  rejectApplicationStatus(applicationId: Int!, project: String!, rejectionMessage: String!): ApplicationView!
   "Reset the administrator's password"
   resetPassword(email: String!, newPassword: String!, passwordResetKey: String!, project: String!): Boolean!
   "Send application and card information to Freinet"


### PR DESCRIPTION
### Short Description
Send an email to applicant for an Ehrenamtskarte Bayern if their application is rejected

### Proposed Changes
- add sending email to rejectApplicationStatus mutation
- bugfix: if the application has already been approved - the rejectApplicationStatus mutation returned a successful response and a rejectionMessage was added to the application. I added an exception for the case when the request has already been processed.
- add ApplicationJsonExtensions util and clean up FreinetApplicationMutationService a bit

### Side Effects
no?

### Testing
- create an application
- login as region admin, reject the created application
- check that the corresponding email has been sent to the applicant

### Resolved Issues
Fixes: #1983
