### PR TITLE
2251: Prevent submitting with error

### DIFF
--- a/administration/src/mui-modules/application/ApplyController.tsx
+++ b/administration/src/mui-modules/application/ApplyController.tsx
@@ -42,7 +42,7 @@ const ApplyController = (): React.ReactElement | null => {
   const [addEakApplication, { loading: loadingSubmit }] = useAddEakApplicationMutation({
     onError: error => {
       const { title } = getMessageFromApolloError(error)
-      enqueueSnackbar(title, { variant: 'error' })
+      enqueueSnackbar(title, { variant: 'error', style: { whiteSpace: 'pre-line' }, autoHideDuration: 7200 })
     },
     onCompleted: ({ result }) => {
       if (result) {

--- a/administration/src/util/translations/de.json
+++ b/administration/src/util/translations/de.json
@@ -599,7 +599,7 @@
     "invalidApplicationConfirmationNoteSize": "Unzulässige Zeichenlänge der Notiz erreicht. Maximal sind {{maxSize}} Zeichen erlaubt.",
     "entitlementNotFound": "Wir konnten Ihre Angaben nicht im System finden.\nAus technischen Gründen stehen die Daten des Jobcenters Koblenz ab Mitte des folgenden Monats zur Verfügung.\nBitte überprüfen Sie Ihre Angaben und versuchen Sie es erneut.",
     "entitlementExpired": "Sie sind nicht länger berechtigt, einen KoblenzPass zu erstellen. Bitte kontaktieren Sie koblenzpass@stadt.koblenz.de für weitere Informationen.",
-    "mailNotSend": "Email konnte nicht an {{recipient}} gesendet werden.",
+    "mailNotSend": "E-Mail konnte nicht an {{recipient}} gesendet werden.\nBitte probieren Sie es zu einem späteren Zeitpunkt erneut.\nIhre Antragsdaten bleiben erhalten.",
     "passwordResetKeyExpired": "Die Gültigkeit ihres Links ist abgelaufen",
     "regionNotFound": "Diese Region existiert nicht.",
     "regionNotActivatedForApplication": "Für diese Region kann der zentrale Beantragungsprozess noch nicht genutzt werden, kontaktieren Sie bitte Ihre zuständige Behörde direkt.",


### PR DESCRIPTION
### Short Description

As a user i might not get any mail if during my application submit if the mail service has issues and i'm even not aware that the application was submitted. That can also result in duplicates if the application was submitted twice

### Proposed Changes

<!-- Describe this PR in more detail. -->

- wrap the `addEakApplication` function in a transaction
- adjust error message
- adjust style of error message

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing (local)

1. Adjust your local mail config to include an error
2. Restart backend service
3. Create an application that now should show an error when submitting
4. Check that the particular application will not be listed in "Eingehende Aufträge"

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2251
