### PR TITLE
2336: Misaligned card activation error

### DIFF
--- a/frontend/lib/activation/deeplink_activation.dart
+++ b/frontend/lib/activation/deeplink_activation.dart
@@ -189,14 +189,16 @@ class _WarningText extends StatelessWidget {
     if (status == DeepLinkActivationStatus.valid) {
       return Container();
     }
-    return Padding(
-        padding: EdgeInsets.symmetric(vertical: 8),
-        child: Column(
-          children: [
-            Icon(Icons.warning, color: theme.colorScheme.secondary),
-            Text(text, textAlign: TextAlign.center, style: theme.textTheme.bodyMedium)
-          ],
-        ));
+    return Center(
+      child: Padding(
+          padding: EdgeInsets.symmetric(vertical: 8),
+          child: Column(
+            children: [
+              Icon(Icons.warning, color: theme.colorScheme.secondary),
+              Text(text, textAlign: TextAlign.center, style: theme.textTheme.bodyMedium)
+            ],
+          )),
+    );
   }
 }
 


### PR DESCRIPTION
### Short Description

When the user opens an invalid deeplink, the error message container should be center even if the text length does not need the entire screen width

### Proposed Changes

<!-- Describe this PR in more detail. -->

- wrap error container with `Center` widget

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing (local)

1. `npx uri-scheme open ehrenamtbayern://bayern.ehrenamtskarte.app/activation/code# --ios`
2. Test same for `--android`

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2336
