### PR TITLE
1760: Add left and bottom axis lines to cards statistics

### DIFF
--- a/administration/src/bp-modules/statistics/components/StatisticsBarChart.tsx
+++ b/administration/src/bp-modules/statistics/components/StatisticsBarChart.tsx
@@ -1,6 +1,6 @@
 import { NonIdealState } from '@blueprintjs/core'
 import { Alert, Box, Typography } from '@mui/material'
-import { ResponsiveBar } from '@nivo/bar'
+import { BarCustomLayerProps, ResponsiveBar } from '@nivo/bar'
 import React, { ReactElement, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -16,6 +16,33 @@ const BarContainer = styled.div<{ height: number }>`
 type StatisticsBarChartProps = {
   statistic: CardStatisticsResultModel
 }
+
+const CustomAxisLines = ({ innerWidth, innerHeight }: BarCustomLayerProps<CardStatisticsResultModel>) => (
+  <>
+    {/* Bottom Axis Line */}
+    <line
+      x1={0}
+      x2={innerWidth}
+      y1={innerHeight}
+      y2={innerHeight}
+      style={{
+        stroke: '#000',
+        strokeWidth: 1,
+      }}
+    />
+    {/* Left Axis Line */}
+    <line
+      x1={0}
+      x2={0}
+      y1={20}
+      y2={innerHeight}
+      style={{
+        stroke: '#000',
+        strokeWidth: 1,
+      }}
+    />
+  </>
+)
 
 const StatisticsBarChart = ({ statistic }: StatisticsBarChartProps): ReactElement => {
   const { cardStatistics } = useContext(ProjectConfigContext)
@@ -68,15 +95,12 @@ const StatisticsBarChart = ({ statistic }: StatisticsBarChartProps): ReactElemen
           tickValues: 0,
           legendPosition: 'start',
         }}
-        axisBottom={
-          statistic.cardsCreated !== 0
-            ? {
-                tickSize: 6,
-                tickPadding: 8,
-              }
-            : null
-        }
+        axisBottom={{
+          tickSize: 6,
+          tickPadding: 8,
+        }}
         axisLeft={null}
+        layers={['grid', 'axes', 'bars', CustomAxisLines, 'markers', 'legends', 'annotations']}
         theme={{
           axis: { legend: { text: { fontSize: 14, fontWeight: 500, fontFamily: 'Roboto' } } },
           text: { fontSize: 12, fontFamily: 'Roboto' },

--- a/administration/src/bp-modules/statistics/components/StatisticsBarChart.tsx
+++ b/administration/src/bp-modules/statistics/components/StatisticsBarChart.tsx
@@ -17,12 +17,15 @@ type StatisticsBarChartProps = {
   statistic: CardStatisticsResultModel
 }
 
+const CHART_MARGIN = 30
+const OVERLAP_HEIGHT = 10
+
 const CustomAxisLines = ({ innerWidth, innerHeight }: BarCustomLayerProps<CardStatisticsResultModel>) => (
   <>
     {/* Bottom Axis Line */}
     <line
       x1={0}
-      x2={innerWidth}
+      x2={innerWidth + OVERLAP_HEIGHT}
       y1={innerHeight}
       y2={innerHeight}
       style={{
@@ -34,7 +37,7 @@ const CustomAxisLines = ({ innerWidth, innerHeight }: BarCustomLayerProps<CardSt
     <line
       x1={0}
       x2={0}
-      y1={20}
+      y1={CHART_MARGIN - OVERLAP_HEIGHT}
       y2={innerHeight}
       style={{
         stroke: '#000',
@@ -82,7 +85,7 @@ const StatisticsBarChart = ({ statistic }: StatisticsBarChartProps): ReactElemen
         tooltip={StatisticsBarTooltip}
         keys={statisticKeys}
         indexBy='region'
-        margin={{ top: 30, right: 30, bottom: 30, left: 30 }}
+        margin={{ top: CHART_MARGIN, right: CHART_MARGIN, bottom: CHART_MARGIN, left: CHART_MARGIN }}
         innerPadding={4.0}
         padding={0.2}
         enableGridY={false}


### PR DESCRIPTION
### Short Description
I tried to add left and bottom axis lines to cards statistics according to the design
https://www.figma.com/design/SDoGnXIjCCXpE1tAAJkRVc/entitlementcard?node-id=1003-6294&t=bmDIoa0F2pLbxZgv-0

### Proposed Changes
Add CustomAxisLines

<img width="539" height="232" alt="image" src="https://github.com/user-attachments/assets/88850597-35ea-4902-8e5e-d29bf6ccc8a1" />

### Side Effects
no?

### Testing
see https://github.com/digitalfabrik/entitlementcard/pull/2331

### Resolved Issues
Part of https://github.com/digitalfabrik/entitlementcard/pull/2331
