### PR TITLE
2375: Fix print dialog

### DIFF
--- a/administration/src/bp-modules/applications/ApplicationsOverview.tsx
+++ b/administration/src/bp-modules/applications/ApplicationsOverview.tsx
@@ -43,6 +43,10 @@ const ApplicationList = styled.div`
   flex-direction: column;
   height: 100%;
   gap: 16px;
+  // This fixes a whitespace issue in print dialog when using motion #2375
+  @media print {
+    gap: 0;
+  }
 `
 
 const getEmptyApplicationsListStatusDescription = (activeBarItem: ApplicationStatusBarItemType, t: TFunction): string =>


### PR DESCRIPTION
### Short Description

Print dialog currently adds lots of whitespace before and after the application, depending on the scroll position of the list

### Proposed Changes

<!-- Describe this PR in more detail. -->

- remove gap for printing view

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. Go to "Eingehende Anträge"
2. Scroll down the application list
3. Click export pdf
4. Application shouldn't have whitespace before and after the application details

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2375 
