### PR TITLE
Use mattermost environment variable over context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1266,7 +1266,6 @@ workflows:
         jobs:
             - promote_android:
                 context:
-                    - mattermost
                     - tuerantuer-google-play
                 matrix:
                     parameters:
@@ -1276,7 +1275,6 @@ workflows:
                             - koblenz
             - promote_ios:
                 context:
-                    - mattermost
                     - tuerantuer-apple
                 matrix:
                     parameters:
@@ -1305,7 +1303,6 @@ workflows:
         jobs:
             - promote_android:
                 context:
-                    - mattermost
                     - tuerantuer-google-play
                 matrix:
                     parameters:
@@ -1315,7 +1312,6 @@ workflows:
                             - koblenz
             - promote_ios:
                 context:
-                    - mattermost
                     - tuerantuer-apple
                 matrix:
                     parameters:

--- a/.circleci/src/workflows/promotion_all.yml
+++ b/.circleci/src/workflows/promotion_all.yml
@@ -5,14 +5,12 @@ jobs:
         parameters:
           build_config: [bayern, nuernberg, koblenz]
       context:
-        - mattermost
         - tuerantuer-google-play
   - promote_ios:
       matrix:
         parameters:
           build_config: [bayern, nuernberg, koblenz]
       context:
-        - mattermost
         - tuerantuer-apple
   - promote_server:
       context:

--- a/.circleci/src/workflows/promotion_frontend.yml
+++ b/.circleci/src/workflows/promotion_frontend.yml
@@ -5,12 +5,10 @@ jobs:
         parameters:
           build_config: [bayern, nuernberg, koblenz]
       context:
-        - mattermost
         - tuerantuer-google-play
   - promote_ios:
       matrix:
         parameters:
           build_config: [bayern, nuernberg, koblenz]
       context:
-        - mattermost
         - tuerantuer-apple


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
At a few places the `mattermost` context was used while in most place the environment variable was used directly.
This PR changes it to consistently use the env variable directly.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Use mattermost environment variable over context

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: N/A
