### PR TITLE
2397: Fix retry

### DIFF
--- a/administration/src/mui-modules/base/AlertBox.tsx
+++ b/administration/src/mui-modules/base/AlertBox.tsx
@@ -33,7 +33,7 @@ const AlertBox = ({
       variant='outlined'
       action={
         onAction ? (
-          <Button color='inherit' size='small' onClick={onAction}>
+          <Button color='inherit' size='small' onClick={() => onAction()}>
             {actionButtonLabel || t('retry')}
           </Button>
         ) : undefined

--- a/administration/src/mui-modules/util/getQueryResult.tsx
+++ b/administration/src/mui-modules/util/getQueryResult.tsx
@@ -27,11 +27,13 @@ const getQueryResult = <Data, Variables extends OperationVariables>(
     const { title, description } = getMessageFromApolloError(error)
     return {
       successful: false,
-      component: errorComponent ?? <AlertBox title={title} description={description} onAction={refetch} />,
+      component: errorComponent ?? (
+        <AlertBox title={title} description={description} onAction={refetch} severity='error' />
+      ),
     }
   }
   if (data === undefined) {
-    return { successful: false, component: <AlertBox onAction={refetch} /> }
+    return { successful: false, component: <AlertBox onAction={refetch} severity='error' /> }
   }
   return { successful: true, data }
 }


### PR DESCRIPTION
### Short Description

Currently we are facing errors if retry was executed for an request using `AlertBox`

### Proposed Changes

<!-- Describe this PR in more detail. -->

- execute `onAction` with arrow function
- pass `severity: 'error'`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

- open this route to get an erroneous request : http://localhost:3000/antrag-einsehen/hjh
- check the network tab for requests or backend service (devs)

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2397
