### PR TITLE
1758: Change the location of the edit note button

### DIFF
--- a/administration/src/bp-modules/applications/ApplicationCard.tsx
+++ b/administration/src/bp-modules/applications/ApplicationCard.tsx
@@ -397,7 +397,7 @@ const ApplicationCard = ({
         </Stack>
       </AccordionSummary>
 
-      <AccordionDetails>
+      <AccordionDetails sx={{ position: 'relative' }}>
         <Stack sx={{ spacing: 2, alignItems: 'flex-start', gap: 2 }}>
           <Stack sx={{ gap: 2, flexGrow: 1, marginLeft: 2, marginBottom: 2, alignItems: 'flex-start' }}>
             {!!application.withdrawalDate && (
@@ -420,12 +420,6 @@ const ApplicationCard = ({
                 expandedRoot={false}
               />
             </Box>
-            <NoteDialogController
-              application={application}
-              isOpen={openNoteDialog}
-              onOpenNoteDialog={setOpenNoteDialog}
-              onChange={onChange}
-            />
           </Stack>
         </Stack>
 
@@ -487,6 +481,14 @@ const ApplicationCard = ({
             setRejectionDialogOpen(false)
           }}
         />
+        <Box sx={{ position: 'absolute', top: 0, right: theme.spacing(2), zIndex: 1 }}>
+          <NoteDialogController
+            application={application}
+            isOpen={openNoteDialog}
+            onOpenNoteDialog={setOpenNoteDialog}
+            onChange={onChange}
+          />
+        </Box>
       </AccordionDetails>
     </Accordion>
   )

--- a/administration/src/bp-modules/applications/JsonFieldArray.tsx
+++ b/administration/src/bp-modules/applications/JsonFieldArray.tsx
@@ -11,11 +11,6 @@ const ParentOfBorder = styled.div<{ $hierarchyIndex: number }>`
   border-color: #ddd;
   transition: 0.2s;
 
-  &:hover {
-    border-color: #999;
-    background-color: ${props => (props.$hierarchyIndex % 2 === 1 ? 'rgba(0,0,0,5%)' : 'white')};
-  }
-
   & > div {
     padding-left: 10px;
     border-left: 1px solid;


### PR DESCRIPTION
### Short Description
Change the position of the “Edit note” button in accordance with the design 📍 [here](https://www.figma.com/design/SDoGnXIjCCXpE1tAAJkRVc/entitlementcard?node-id=2519-1725&t=mzp7xTHZsyKeZfzX-1)

<img width="1018" height="183" alt="image" src="https://github.com/user-attachments/assets/b5957e73-37c3-4dcb-a484-27c9315e4e5d" />

<img width="1021" height="433" alt="image" src="https://github.com/user-attachments/assets/8fec5670-0c1b-4b13-8249-0ddc8c5d8509" />

### Proposed Changes
- move the button

### Side Effects
no?

### Testing
See https://github.com/digitalfabrik/entitlementcard/pull/2415

### Resolved Issues
Part of https://github.com/digitalfabrik/entitlementcard/pull/2415
