### PR TITLE
2457: Fix application note icon

### DIFF
--- a/administration/src/bp-modules/applications/components/ApplicationStatusNote.tsx
+++ b/administration/src/bp-modules/applications/components/ApplicationStatusNote.tsx
@@ -64,7 +64,7 @@ export const ApplicationStatusNote = (p: {
 
   return (
     <Stack direction='row' sx={{ justifyContent: 'flex-start', alignItems: 'bottom' }}>
-      {showIcon && `${icon(p.status)}&ensp;`}
+      {showIcon && <>{icon(p.status)}&ensp;</>}
       <div>
         {translationKey !== undefined && (
           <Trans


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->
Icon of Application status note is rendered as a string instead html icon component

### Proposed Changes

<!-- Describe this PR in more detail. -->

- wrap icon with fragment

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Open "Eingehende Anträge", process (accept or reject) application. check status note icon will be rendered correctly

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2457
