### PR TITLE
2480 implement custom callout component

### DIFF
--- a/administration/src/bp-modules/applications/ApplicationCard.tsx
+++ b/administration/src/bp-modules/applications/ApplicationCard.tsx
@@ -60,6 +60,7 @@ import { ApplicationStatusNote } from './components/ApplicationStatusNote'
 import { ApplicationIndicators } from './components/VerificationsIndicator'
 import type { Application } from './types'
 import { ApplicationToCsvError, exportApplicationToCsv } from './utils/exportApplicationToCsv'
+import { Callout } from '../../shared/components/Callout'
 
 const DeleteDialog = (props: {
   isOpen: boolean
@@ -372,13 +373,11 @@ const ApplicationCard = ({
 
       <AccordionDetails sx={{ position: 'relative' }}>
         <Stack sx={{ spacing: 2, alignItems: 'flex-start', gap: 2, marginLeft: 2, marginBottom: 2, marginRight: 2 }}>
-          {application.status === ApplicationStatus.Withdrawn && !!application.statusResolvedDate && (
-            <Box sx={{ bgcolor: theme.palette.warning.light, padding: 2 }}>
+          <Callout color="warning">
               {t('withdrawalMessage', { date: new Date(application.statusResolvedDate) })}
               <br />
               {t('deleteApplicationSoonPrompt')}
-            </Box>
-          )}
+          </Callout>
           {/* TODO: <JsonFieldView> does not emit a root element and thus, <Stack> would insert a gap here */}
           <Box>
             <JsonFieldView

--- a/administration/src/bp-modules/project-settings/PepperSettings.tsx
+++ b/administration/src/bp-modules/project-settings/PepperSettings.tsx
@@ -1,4 +1,4 @@
-import { Callout } from '@blueprintjs/core'
+
 import { TFunction } from 'i18next'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 import { useGetHashingPepperQuery } from '../../generated/graphql'
 import getQueryResult from '../../mui-modules/util/getQueryResult'
 import PasswordInput from '../PasswordInput'
+import { Callout } from '../../shared/components/Callout'
 
 const Container = styled.div`
   padding: 8px 0;
@@ -23,7 +24,7 @@ const PepperSettings = (): ReactElement => {
   const { t } = useTranslation('projectSettings')
   const errorComponent = (
     <Container>
-      <Callout intent='danger'> {t('noPepper')}</Callout>
+      <Callout color='error'>{t('noPepper')}</Callout>
     </Container>
   )
   const pepperQuery = useGetHashingPepperQuery()

--- a/administration/src/bp-modules/user-settings/ChangePasswordForm.tsx
+++ b/administration/src/bp-modules/user-settings/ChangePasswordForm.tsx
@@ -1,4 +1,4 @@
-import { Button, Callout, H2 } from '@blueprintjs/core'
+import { Button, H2 } from '@blueprintjs/core'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -63,7 +63,7 @@ const ChangePasswordForm = (): ReactElement => {
         <PasswordInput label={t('currentPassword')} value={currentPassword} setValue={setCurrentPassword} />
         <PasswordInput label={t('newPassword')} value={newPassword} setValue={setNewPassword} />
         <PasswordInput label={t('newPasswordConfirm')} value={repeatNewPassword} setValue={setRepeatNewPassword} />
-        {warnMessage === null ? null : <Callout intent='danger'>{warnMessage}</Callout>}
+        {warnMessage === null ? null : <Callout color='error'>{warnMessage}</Callout>
         <div style={{ textAlign: 'right', padding: '10px 0' }}>
           <Button text={t('changePassword')} intent='primary' type='submit' disabled={!valid} loading={loading} />
         </div>

--- a/administration/src/bp-modules/users/DeleteUserDialog.tsx
+++ b/administration/src/bp-modules/users/DeleteUserDialog.tsx
@@ -1,4 +1,4 @@
-import { Button, Callout, Checkbox, Classes, Dialog } from '@blueprintjs/core'
+import { Button, Checkbox, Classes, Dialog } from '@blueprintjs/core'
 import React, { ReactElement, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -7,6 +7,7 @@ import { WhoAmIContext } from '../../WhoAmIProvider'
 import getMessageFromApolloError from '../../errors/getMessageFromApolloError'
 import { Administrator, useDeleteAdministratorMutation } from '../../generated/graphql'
 import { useAppToaster } from '../AppToaster'
+import { Callout } from '../../shared/components/Callout'
 
 const DeleteUserDialog = ({
   selectedUser,
@@ -61,7 +62,7 @@ const DeleteUserDialog = ({
         <div className={Classes.DIALOG_BODY}>
           {t('deleteUserIrrevocableConfirmPrompt', { mail: selectedUser?.email })}
           {selectedUser?.id !== actingAdminId ? null : (
-            <Callout intent='danger' style={{ marginTop: '16px' }}>
+            <Callout color='error' sx={{ marginTop: 2 }}>
               <b>{t('deleteOwnAccountWarning')}</b> {t('deleteOwnAccountWarningExplanation')}
               <Checkbox required>{t('ownAccountWarningConfirmation')}</Checkbox>
             </Callout>

--- a/administration/src/bp-modules/users/EditUserDialog.tsx
+++ b/administration/src/bp-modules/users/EditUserDialog.tsx
@@ -1,4 +1,4 @@
-import { Button, Callout, Checkbox, Classes, Dialog, FormGroup, InputGroup } from '@blueprintjs/core'
+import { Button, Checkbox, Classes, Dialog, FormGroup, InputGroup } from '@blueprintjs/core'
 import React, { ReactElement, useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -10,6 +10,7 @@ import { useAppToaster } from '../AppToaster'
 import RegionSelector from './RegionSelector'
 import RoleHelpButton from './RoleHelpButton'
 import RoleSelector from './RoleSelector'
+import { Callout } from '../../shared/components/Callout'
 
 const RoleFormGroupLabel = styled.span`
   & span {
@@ -115,7 +116,7 @@ const EditUserDialog = ({
               <RegionSelector onSelect={region => setRegionId(region.id)} selectedId={regionId} />
             </FormGroup>
           )}
-          <Callout intent='primary'>
+          <Callout color='info'>
             {selectedUser?.id === me?.id ? (
               <>
                 {t('youCanChangeYourOwnPassword')}{' '}
@@ -135,7 +136,7 @@ const EditUserDialog = ({
             )}
           </Callout>
           {selectedUser?.id !== me?.id ? null : (
-            <Callout intent='danger' style={{ marginTop: '16px' }}>
+            <Callout color='error' sx={{ marginTop: 2 }}>
               <b>{t('youEditYourOwnAccount')} </b>
               {t('youMayCannotUndoThis')}
               <Checkbox required>{t('ownAccountWarningConfirmation')}</Checkbox>

--- a/administration/src/shared/components/Callout.tsx
+++ b/administration/src/shared/components/Callout.tsx
@@ -1,0 +1,26 @@
+import { Box, BoxProps } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { ReactNode } from 'react';
+
+interface CalloutProps {
+  children: ReactNode;
+  color?: 'warning' | 'error' | 'info' | 'success';
+  sx?: BoxProps['sx'];
+}
+
+export const Callout = ({ children, color = 'info', sx, ...props }: CalloutProps) => {
+  const theme = useTheme();
+  
+  return (
+    <Box
+      sx={{
+        bgcolor: theme.palette[color].light,
+        padding: 2,
+        ...sx
+      }}
+      {...props}
+    >
+      {children}
+    </Box>
+  );
+};


### PR DESCRIPTION
### Short Description

Implemented custom MUI Callout component to replace Blueprint.js Callout in EditUserDialog as part of MUI migration.

### Proposed Changes

- Created reusable Callout component in src/shared/components/Callout.tsx
- Replaced Blueprint.js Callout with custom component in EditUserDialog.tsx
- Updated props: intent='danger' → color='error', intent='primary' → color='info'

### Side Effects

- Blueprint.js Callout dependency can eventually be removed once all instances are migrated
- Future callout implementations across the app should use this new component for consistency


### Testing

- Verify callout styling matches original appearance
- Test EditUserDialog info and error callouts display correctly
- Confirm links and checkboxes work as expected

### Resolved Issues

 Fixes: #2480
