### PR TITLE
2488: Disable freinet data transfer

### DIFF
--- a/administration/src/project-configs/bayern/config.ts
+++ b/administration/src/project-configs/bayern/config.ts
@@ -101,7 +101,7 @@ const config: ProjectConfig = {
     },
   },
   freinetCSVImportEnabled: true,
-  freinetDataTransferEnabled: true,
+  freinetDataTransferEnabled: false,
   cardCreation: true,
   selfServiceEnabled: false,
   storesManagement: {


### PR DESCRIPTION
### Short Description
Freinet data transfer should be temporarily disabled

### Proposed Changes
Set freinetDataTransferEnabled to false

### Side Effects
no

### Testing
Login as region admin to administration, check region settings /region
- "Freinet Datenübermittlung" should not be available
<img width="515" height="226" alt="image" src="https://github.com/user-attachments/assets/70b126d5-c23e-4a3e-8879-c518260069d3" />

### Resolved Issues
Fixes: #2488
