### PR TITLE
2494: Android page size

### DIFF
--- a/frontend/android/app/build.gradle.kts
+++ b/frontend/android/app/build.gradle.kts
@@ -27,12 +27,12 @@ android {
     val localProperties = gradleLocalProperties(projectDir, providers)
 
     namespace = "app.entitlementcard"
-    compileSdk = 35
+    compileSdk = 36
     ndkVersion = "28.1.13356709"
 
     defaultConfig {
-        minSdk = 21
-        targetSdk = 35
+        minSdk = 23
+        targetSdk = 36
         multiDexEnabled = true
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -853,10 +853,10 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: f536c5b8cadcf73d764bdce09c94744f06aa832264730f8971b21a60c5666826
+      sha256: "0b466a0a8a211b366c2e87f3345715faef9b6011c7147556ad22f37de6ba3173"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.10"
+    version: "6.0.11"
   mocktail:
     dependency: "direct dev"
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   permission_handler: ^11.3.0
   package_info_plus: ^8.3.1 # for about dialog
   # Cannot be updated to v7 due to https://github.com/juliansteenbakker/mobile_scanner/issues/1444
-  mobile_scanner: 6.0.10
+  mobile_scanner: 6.0.11
   fixnum: ^1.1.0
   # Locking this version due to this issue https://github.com/mogol/flutter_secure_storage/issues/762
   flutter_secure_storage: 9.0.0


### PR DESCRIPTION
### Short Description

Starting 1st of november google requires that all android apps using libraries with page size 16kb. Our camera scanner library still used a dependency of camerax which didn't meet this requirements.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- update `mobile_scanner` library
- update the sdk versions to meet the new requirements (android.camerax)

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
1. Create an emulator with 16kb page size
<img width="627" height="148" alt="image" src="https://github.com/user-attachments/assets/5f5be5e5-f23a-4f4f-a53e-827674108e2d" />

2. Build and run the app on it. Open camera and check that there are no crashes or error messages

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2494
