### PR TITLE
2555: Logout during card creation

### DIFF
--- a/administration/src/bp-modules/UserMenu.tsx
+++ b/administration/src/bp-modules/UserMenu.tsx
@@ -2,11 +2,12 @@ import { EditSquare, Logout, Settings } from '@mui/icons-material'
 import { Avatar, Box, Button, Divider, IconButton, Menu, Stack, Typography } from '@mui/material'
 import React, { ReactElement, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
-import { NavLink, useNavigate } from 'react-router'
+import { NavLink } from 'react-router'
 
 import { AuthContext } from '../AuthProvider'
 import { useWhoAmI } from '../WhoAmIProvider'
 import { Role } from '../generated/graphql'
+import useNavigateWithCallback from '../hooks/useNavigateWithCallback'
 import RenderGuard from '../mui-modules/components/RenderGuard'
 import { ProjectConfigContext } from '../project-configs/ProjectConfigContext'
 import roleToText from './users/utils/roleToText'
@@ -16,12 +17,10 @@ const UserMenu = (): ReactElement => {
   const { signOut } = useContext(AuthContext)
   const { t } = useTranslation('misc')
   const projectConfig = useContext(ProjectConfigContext)
-  const navigate = useNavigate()
+
   const [anchorElUser, setAnchorElUser] = React.useState<null | HTMLElement>(null)
-  const signOutAndRedirect = () => {
-    signOut()
-    navigate('/')
-  }
+  const navigateAndSignOut = useNavigateWithCallback(signOut)
+
   const handleOpenUserMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorElUser(event.currentTarget)
   }
@@ -89,7 +88,7 @@ const UserMenu = (): ReactElement => {
             fullWidth
             variant='text'
             startIcon={<Logout />}
-            onClick={signOutAndRedirect}>
+            onClick={() => navigateAndSignOut('/')}>
             {t('logout')}
           </Button>
         </Stack>

--- a/administration/src/hooks/useNavigateWithCallback.ts
+++ b/administration/src/hooks/useNavigateWithCallback.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router'
+
+const useNavigateWithCallback = (callback: () => void): ((path: string) => void) => {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [navigating, setNavigating] = useState(false)
+  const [initialPath, setInitialPath] = useState(location.pathname)
+
+  useEffect(() => {
+    if (navigating && location.pathname !== initialPath) {
+      callback()
+      setNavigating(false)
+    }
+  }, [location, navigating, callback, initialPath])
+
+  return (path: string) => {
+    setInitialPath(location.pathname)
+    setNavigating(true)
+    navigate(path)
+  }
+}
+
+export default useNavigateWithCallback


### PR DESCRIPTION
### Short Description

Apparently redirect and signOut do not work when `useBlockNavigation`
Therefore i created a custom hook which first ensures that the navigation has to be finished that, before doing the signOut in a callback. That triggers the prompt correctly.

### Proposed Changes

<!-- Describe this PR in more detail. -->
- add custom hook
- use customHook to ensure the prompt will be triggered onSignout

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

Check the bug description

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2555