### PR TITLE
2480: Replace callout

### DIFF
--- a/administration/src/bp-modules/applications/components/ApplicationStatusNote.tsx
+++ b/administration/src/bp-modules/applications/components/ApplicationStatusNote.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable react/destructuring-assignment */
 import { CancelOutlined, CheckCircleOutlined, RemoveCircleOutline } from '@mui/icons-material'
-import { Stack, Typography } from '@mui/material'
+import { Typography } from '@mui/material'
 import { format } from 'date-fns'
 import { de } from 'date-fns/locale'
 import React, { ReactElement } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 import { ApplicationStatus } from '../../../generated/graphql'
+import AlertBox from '../../../mui-modules/base/AlertBox'
 
 const statusTranslationKey = (applicationStatus: ApplicationStatus, isAdminView: boolean): string | undefined => {
   switch (applicationStatus) {
@@ -63,24 +64,27 @@ export const ApplicationStatusNote = (p: {
   const showIcon = p.showIcon ?? true
 
   return (
-    <Stack direction='row' sx={{ justifyContent: 'flex-start', alignItems: 'bottom' }}>
-      {showIcon && <>{icon(p.status)}&ensp;</>}
-      <div>
-        {translationKey !== undefined && (
-          <Trans
-            t={t}
-            i18nKey={translationKey}
-            values={{
-              date: format(p.statusResolvedDate, 'dd. MMMM yyyy', { locale: de }),
-              time: format(p.statusResolvedDate, 'HH:mm', { locale: de }),
-              reason: p.reason !== undefined ? t('reason', { message: p.reason }) : '',
-            }}
-            components={{
-              resolution: <Typography component='span' fontWeight='bold' fontSize='inherit' color={color} />,
-            }}
-          />
-        )}
-      </div>
-    </Stack>
+    <AlertBox
+      sx={{ border: 'none', padding: 0, maxWidth: 'none' }}
+      customIcon={showIcon && <>{icon(p.status)}&ensp;</>}
+      description={
+        <div>
+          {translationKey !== undefined && (
+            <Trans
+              t={t}
+              i18nKey={translationKey}
+              values={{
+                date: format(p.statusResolvedDate, 'dd. MMMM yyyy', { locale: de }),
+                time: format(p.statusResolvedDate, 'HH:mm', { locale: de }),
+                reason: p.reason !== undefined ? t('reason', { message: p.reason }) : '',
+              }}
+              components={{
+                resolution: <Typography component='span' fontWeight='bold' fontSize='inherit' color={color} />,
+              }}
+            />
+          )}
+        </div>
+      }
+    />
   )
 }

--- a/administration/src/bp-modules/auth/ResetPasswordController.tsx
+++ b/administration/src/bp-modules/auth/ResetPasswordController.tsx
@@ -1,4 +1,4 @@
-import { Callout, Card, Classes, H2, H3, H4, InputGroup } from '@blueprintjs/core'
+import { Card, Classes, H2, H3, H4, InputGroup } from '@blueprintjs/core'
 import { Button, FormControl, FormLabel, Stack } from '@mui/material'
 import React, { ReactElement, useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -6,6 +6,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router'
 
 import getMessageFromApolloError from '../../errors/getMessageFromApolloError'
 import { useCheckPasswordResetLinkQuery, useResetPasswordMutation } from '../../generated/graphql'
+import AlertBox from '../../mui-modules/base/AlertBox'
 import getQueryResult from '../../mui-modules/util/getQueryResult'
 import { ProjectConfigContext } from '../../project-configs/ProjectConfigContext'
 import { useAppToaster } from '../AppToaster'
@@ -89,7 +90,13 @@ const ResetPasswordController = (): ReactElement => {
               <PasswordInput setValue={setRepeatNewPassword} value={repeatNewPassword} />
             </FormControl>
 
-            {warnMessage === null || !isDirty ? null : <Callout intent='danger'>{warnMessage}</Callout>}
+            {warnMessage === null || !isDirty ? null : (
+              <AlertBox
+                sx={{ my: 2, mx: 0, justifyContent: 'flex-start' }}
+                severity='error'
+                description={warnMessage}
+              />
+            )}
           </Stack>
 
           <div

--- a/administration/src/bp-modules/project-settings/PepperSettings.tsx
+++ b/administration/src/bp-modules/project-settings/PepperSettings.tsx
@@ -1,24 +1,15 @@
-import { Callout } from '@blueprintjs/core'
 import { Stack } from '@mui/material'
 import React, { ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
 
 import { useGetHashingPepperQuery } from '../../generated/graphql'
+import AlertBox from '../../mui-modules/base/AlertBox'
 import getQueryResult from '../../mui-modules/util/getQueryResult'
 import PasswordInput from '../PasswordInput'
 
-const Container = styled.div`
-  padding: 8px 0;
-`
-
 const PepperSettings = (): ReactElement => {
   const { t } = useTranslation('projectSettings')
-  const errorComponent = (
-    <Container>
-      <Callout intent='danger'> {t('noPepper')}</Callout>
-    </Container>
-  )
+  const errorComponent = <AlertBox sx={{ my: 2 }} severity='error' description={t('noPepper')} />
   const pepperQuery = useGetHashingPepperQuery()
   const result = getQueryResult(pepperQuery, errorComponent)
 

--- a/administration/src/bp-modules/user-settings/ChangePasswordForm.tsx
+++ b/administration/src/bp-modules/user-settings/ChangePasswordForm.tsx
@@ -1,4 +1,4 @@
-import { Callout, H2 } from '@blueprintjs/core'
+import { H2 } from '@blueprintjs/core'
 import { Button, FormControl, FormLabel, Stack } from '@mui/material'
 import React, { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { useWhoAmI } from '../../WhoAmIProvider'
 import getMessageFromApolloError from '../../errors/getMessageFromApolloError'
 import { useChangePasswordMutation } from '../../generated/graphql'
+import AlertBox from '../../mui-modules/base/AlertBox'
 import { useAppToaster } from '../AppToaster'
 import PasswordInput from '../PasswordInput'
 import validatePasswordInput from '../auth/validateNewPasswordInput'
@@ -75,7 +76,9 @@ const ChangePasswordForm = (): ReactElement => {
             <PasswordInput value={repeatNewPassword} setValue={setRepeatNewPassword} />
           </FormControl>
 
-          {warnMessage === null ? null : <Callout intent='danger'>{warnMessage}</Callout>}
+          {warnMessage === null ? null : (
+            <AlertBox sx={{ my: 2, mx: 0, justifyContent: 'flex-start' }} severity='error' description={warnMessage} />
+          )}
           <div style={{ textAlign: 'right' }}>
             <Button type='submit' disabled={!valid} loading={loading}>
               {t('changePassword')}

--- a/administration/src/mui-modules/base/AlertBox.tsx
+++ b/administration/src/mui-modules/base/AlertBox.tsx
@@ -1,9 +1,10 @@
 import { Alert, AlertColor, AlertTitle, Button, SxProps } from '@mui/material'
 import { Theme } from '@mui/system'
-import React, { ReactElement } from 'react'
+import React, { ReactElement, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 type AlertBoxProps = {
+  customIcon?: ReactNode
   sx?: SxProps<Theme>
   severity?: AlertColor
   title?: string
@@ -14,6 +15,7 @@ type AlertBoxProps = {
 
 const AlertBox = ({
   sx,
+  customIcon,
   severity = 'success',
   title,
   description,
@@ -26,12 +28,12 @@ const AlertBox = ({
     <Alert
       data-testid='alert-box'
       severity={severity}
+      icon={customIcon}
       variant='outlined'
       sx={{
         margin: 'auto',
         display: 'flex',
         justifyContent: 'space-around',
-        alignItems: 'center',
         maxWidth: '900px',
         '&': theme => ({
           [theme.breakpoints.down('md')]: {


### PR DESCRIPTION
### Short Description

<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

- adjust `AlertBox` to accept customIcon, 
- remove the center alignment of the icon #2549
- use AlertBox for ApplicationStatusNote
- replace `Callout` by `AlertBox`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. Check that for AlertBoxes the icon is now top aligned
2. Check `ApplicationStatusNote` for applications (reject, approve an application)
3. Its difficult to reproduce the replacement alertBox (can be tested only devs by forcing them to be shown)

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2480
Fixes: #2549
