### PR TITLE
2538: Fix error message activated on another device

### DIFF
--- a/frontend/assets/koblenz/l10n/override_de.json
+++ b/frontend/assets/koblenz/l10n/override_de.json
@@ -8,7 +8,7 @@
     "applyDescription": "Sie haben noch keinen KoblenzPass? Hier können Sie den KoblenzPass mit Ihrem Aktenzeichen aktivieren.",
     "cardExpired": "Ihr KoblenzPass ist abgelaufen. Unter \"Weitere Aktionen\" können Sie Ihren KoblenzPass verlängern oder einen neuen KoblenzPass beantragen.",
     "cardExpiredBeforeActivation": "Ihr KoblenzPass ist bereits abgelaufen und kann nicht mehr aktiviert werden. Bitte erstellen Sie ihn erneut, falls Sie weiterhin berechtigt sind.",
-    "cardInvalid": "Ihr KoblenzPass wurde nicht gefunden. Bitte erstellen Sie ihn erneut, falls Sie weiterhin berechtigt sind.",
+    "cardInvalid": "Ihr KoblenzPass ist ungültig. Er wurde entweder widerrufen oder auf einem anderen Gerät aktiviert",
     "cardNotYetValid": "Der Gültigkeitszeitraum Ihres KoblenzPasses hat noch nicht begonnen.",
     "checkFailed": "Ihr KoblenzPass konnte nicht auf seine Gültigkeit geprüft werden. Bitte stellen Sie sicher, dass eine Internetverbindung besteht und versuchen Sie es erneut.",
     "codeRevoked": "Dieser KoblenzPass konnte nicht aktiviert werden, da er gesperrt wurde.",

--- a/frontend/assets/l10n/app_de.json
+++ b/frontend/assets/l10n/app_de.json
@@ -97,7 +97,7 @@
     "cardAlreadyActivated": "Der eingescannte QRCode wurde bereits aktiviert.",
     "cardExpired": "Ihre Karte ist abgelaufen. Unter \"Weitere Aktionen\" können Sie einen Antrag auf Verlängerung stellen.",
     "cardExpiredBeforeActivation": "Ihre Karte ist bereits abgelaufen und kann nicht mehr aktiviert werden. Bitte beantragen Sie sie erneut.",
-    "cardInvalid": "Ihre Karte wurde nicht gefunden. Bitte beantragen Sie sie erneut.",
+    "cardInvalid": "Ihre Karte ist ungültig. Sie wurde entweder widerrufen oder auf einem anderen Gerät aktiviert.",
     "cardNotYetValid": "Der Gültigkeitszeitraum Ihrer Karte hat noch nicht begonnen.",
     "checkFailed": "Ihre Karte konnte nicht auf ihre Gültigkeit geprüft werden. Bitte stellen Sie sicher, dass eine Internetverbindung besteht und prüfen Sie erneut.",
     "checkRequired": "Prüfung nötig",

--- a/frontend/assets/l10n/app_en.json
+++ b/frontend/assets/l10n/app_en.json
@@ -97,7 +97,7 @@
     "cardAlreadyActivated": "The scanned QR code has already been activated.",
     "cardExpired": "Your card has expired. You can apply for renewal under \"More actions\"",
     "cardExpiredBeforeActivation": "Your card has already expired and can no longer be activated. Please submit a new application.",
-    "cardInvalid": "Your card was not found. Please apply for it again.",
+    "cardInvalid": "Your card is invalid. It has either been revoked or activated on another device.",
     "cardNotYetValid": "The validity period of your card has not yet started.",
     "checkFailed": "Your card could not be verified. Please make sure you have an internet connection and try again.",
     "checkRequired": "Verification necessary",

--- a/frontend/assets/nuernberg/l10n/override_de.json
+++ b/frontend/assets/nuernberg/l10n/override_de.json
@@ -7,7 +7,7 @@
     "applyDescription": "Sie haben noch keinen Nürnberg-Pass? Hier können Sie Ihren Nürnberg-Pass beantragen.",
     "cardExpired": "Ihr Pass ist abgelaufen. Unter \"Weitere Aktionen\" können Sie einen Antrag auf Verlängerung stellen.",
     "cardExpiredBeforeActivation": "Ihr Pass ist bereits abgelaufen und kann nicht mehr aktiviert werden. Bitte beantragen Sie ihn erneut.",
-    "cardInvalid": "Ihr Pass wurde nicht gefunden. Bitte beantragen Sie ihn erneut.",
+    "cardInvalid": "Ihr Pass ist ungültig. Er wurde entweder widerrufen oder auf einem anderen Gerät aktiviert.",
     "cardNotYetValid": "Der Gültigkeitszeitraum Ihres Passes hat noch nicht begonnen.",
     "checkFailed": "Ihr Pass konnte nicht auf ihre Gültigkeit geprüft werden. Bitte stellen Sie sicher, dass eine Internetverbindung besteht und prüfen Sie erneut.",
     "codeRevoked": "Dieser Pass konnte nicht aktiviert werden, da er widerrufen wurde.",

--- a/frontend/assets/nuernberg/l10n/override_en.json
+++ b/frontend/assets/nuernberg/l10n/override_en.json
@@ -7,7 +7,7 @@
     "applyDescription": "You do not yet have a Nürnberg-Pass? Here you can apply for your Nürnberg-Pass.",
     "cardExpired": "Your pass has expired. You can apply for renewal under \"More actions\"",
     "cardExpiredBeforeActivation": "Your pass has already expired and can no longer be activated. Please apply for it again.",
-    "cardInvalid": "Your pass was not found. Please apply for it again.",
+    "cardInvalid": "Your pass is invalid. It has either been revoked or activated on another device.",
     "cardNotYetValid": "The validity period of your pass has not yet started.",
     "checkFailed": "Your pass could not be verified. Please make sure you have an internet connection and try again.",
     "codeRevoked": "This pass could not be activated as it has been revoked.",


### PR DESCRIPTION
### Short Description

Due to some error handling adjustments, we show a wrong error message to the user, when a card was activated on another because and becomes invalid on the old device

### Proposed Changes

<!-- Describe this PR in more detail. -->

- adjust error message for `invalidCard`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. Activate a card on device a
2. Activate the same card on device b
3. If you reopen device a, you should get a message that your card is invalid, because it was revoked or may be activated on another device

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2538 
