### PR TITLE
Fix android promotion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -796,6 +796,8 @@ jobs:
         steps:
             - prepare_workspace
             - install_app_toolbelt
+            - ruby/install:
+                version: "3.1"
             - install_fastlane
             - run:
                 command: bundle exec fastlane android playstore_promote build_config_name:<< parameters.build_config >>

--- a/.circleci/src/jobs/promote_android.yml
+++ b/.circleci/src/jobs/promote_android.yml
@@ -13,6 +13,8 @@ working_directory: ~/project/frontend/android
 steps:
   - prepare_workspace
   - install_app_toolbelt
+  - ruby/install:
+      version: '3.1'
   - install_fastlane
   - run:
       name: '[FL] Play Store Promotion'


### PR DESCRIPTION
### Short Description

We need this particular ruby version for android and fastlane

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add orbs to set particular ruby version for `promote_android`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

-

### Testing
https://app.circleci.com/pipelines/github/digitalfabrik/entitlementcard/9702/workflows/c4728f0d-2b4d-4327-acfa-b57fa392a7ea

Mind that the errors for promoting ios are normal, since it was already promoted before (initial promote all workflow) and is now "in Review" in the stores
So this pr can be merged event the workflow didn't succeed!

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
