### PR TITLE
2586: Fix app bar background

### DIFF
--- a/administration/src/bp-modules/NavigationBar.tsx
+++ b/administration/src/bp-modules/NavigationBar.tsx
@@ -1,4 +1,4 @@
-import { AppBar, Divider, Link, Stack, SvgIcon, Toolbar, Typography } from '@mui/material'
+import { AppBar, Divider, Link, Stack, SvgIcon, Toolbar, Typography, useTheme } from '@mui/material'
 import React, { ReactElement, useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -10,11 +10,12 @@ import UserMenu from './UserMenu'
 
 const NavigationBar = (): ReactElement => {
   const { t } = useTranslation('misc')
+  const theme = useTheme()
   const config = useContext(ProjectConfigContext)
   const { region } = useWhoAmI().me
 
   return (
-    <AppBar position='sticky' color='transparent'>
+    <AppBar position='sticky' sx={{ backgroundColor: theme.palette.common.white }}>
       <Toolbar
         sx={theme => ({
           flexWrap: 'wrap',
@@ -26,10 +27,12 @@ const NavigationBar = (): ReactElement => {
           <EntitlementIcon />
         </SvgIcon>
         <Link
-          color='inherit'
           href='/'
           underline='none'
-          sx={{ '&:hover': { textDecoration: 'none', color: 'inherit' } }}
+          sx={{
+            '&:hover': { textDecoration: 'none', color: theme.palette.common.black },
+            color: theme.palette.common.black,
+          }}
           marginX={1.5}>
           <Stack>
             <Typography variant='body2' component='span'>


### PR DESCRIPTION
### Short Description

On the data privacy page the side content seem to overlap over the app bar if you scroll to bottom.

<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

- set background color for App-Bar
- set color to custom color to link

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. resize your browser window to have vertical scroll bar
2. Go to 'region/data-privacy-policy'
3. Scroll to bottom
4. Content should not overlap the navigation bar

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2586
