### PR TITLE
2627: Add missing gh release promotion to workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1296,6 +1296,11 @@ workflows:
             - promote_server:
                 context:
                     - credentials-ehrenamtskarte
+            - promote_github_release:
+                context:
+                    - deliverino
+                requires:
+                    - promote_server
         when: << pipeline.parameters.run_promotion_backend_administration >>
     promotion_frontend:
         jobs:
@@ -1317,5 +1322,11 @@ workflows:
                             - bayern
                             - nuernberg
                             - koblenz
+            - promote_github_release:
+                context:
+                    - deliverino
+                requires:
+                    - promote_android
+                    - promote_ios
         when: << pipeline.parameters.run_promotion_frontend >>
 

--- a/.circleci/src/workflows/promotion_backend_administration.yml
+++ b/.circleci/src/workflows/promotion_backend_administration.yml
@@ -3,3 +3,8 @@ jobs:
   - promote_server:
       context:
         - credentials-ehrenamtskarte
+  - promote_github_release:
+      context:
+        - deliverino
+      requires:
+        - promote_server

--- a/.circleci/src/workflows/promotion_frontend.yml
+++ b/.circleci/src/workflows/promotion_frontend.yml
@@ -12,3 +12,9 @@ jobs:
           build_config: [bayern, nuernberg, koblenz]
       context:
         - tuerantuer-apple
+  - promote_github_release:
+      context:
+        - deliverino
+      requires:
+        - promote_android
+        - promote_ios


### PR DESCRIPTION
### Short Description

See issue description

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add promote github release to backend_administration and frontend promotion workflows

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2627
