### PR TITLE
2630: Form input does not fit

### DIFF
--- a/administration/public/index.html
+++ b/administration/public/index.html
@@ -2,7 +2,7 @@
 <html lang="de">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     <meta name="theme-color" content="#000000" />
     <!-- Prevent index.html to be cached at all -->
     <meta http-equiv="pragma" content="no-cache" />


### PR DESCRIPTION
### Short Description

See issue description. Mind that this happens only on ios

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add maximum-scale to avoid zooming in (ios)

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Testing

1. Open application form or koblenz self service form in ios and click on an input field.
2. The browser should not zoom in the screen

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2630
