### PR TITLE
Disable impeller engine

### DIFF
--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -72,6 +72,10 @@
             android:name="flutterEmbedding"
             android:value="2"
     />
+    <!-- Disable impeller, since it causes issues for some android devices -->
+    <meta-data
+            android:name="io.flutter.embedding.android.EnableImpeller"
+            android:value="false" />
   </application>
   <uses-feature android:name="android.hardware.location" android:required="false"/>
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>


### PR DESCRIPTION
### Short Description

Reported by @connium on some android devices the new impeller engine (enabled by default since flutter 3.29) can cause map rendering issues

https://github.com/maplibre/flutter-maplibre-gl/issues/562

<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

- update AndroidManifest.xml

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- slightly slower rendering
https://docs.flutter.dev/perf/impeller

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
