### PR TITLE
2610: Fix overlapping label in the "Arbeitsstunden pro Woche" field

### DIFF
--- a/administration/src/mui-modules/application/primitive-inputs/NumberForm.tsx
+++ b/administration/src/mui-modules/application/primitive-inputs/NumberForm.tsx
@@ -14,7 +14,13 @@ const NumberForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
   initialState: { type: 'NumberForm', value: '' },
   getArrayBufferKeys: () => [],
   validate: ({ value }, options) => {
-    const number = parseFloat(value)
+    if (value === '') {
+      return { type: 'error', message: i18next.t('applicationForms:fieldRequiredError') }
+    }
+    if (value.endsWith('.')) {
+      return { type: 'error', message: i18next.t('applicationForms:noValidNumberError') }
+    }
+    const number = Number(value)
     const { min, max } = options
     if (Number.isNaN(number)) {
       return { type: 'error', message: i18next.t('applicationForms:noValidNumberError') }
@@ -41,14 +47,18 @@ const NumberForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
         variant='standard'
         fullWidth
         style={{ margin: '4px 0', minWidth }}
-        type='number'
+        type='text'
+        inputMode='decimal'
         label={label}
         required
         disabled={disableAllInputs}
         error={(showAllErrors || touched) && isInvalid}
         value={state.value}
         onBlur={() => setTouched(true)}
-        onChange={e => setState(() => ({ type: 'NumberForm', value: e.target.value }))}
+        onChange={e => {
+          const sanitizedValue = e.target.value.replace(/\s/g, '')
+          setState(() => ({ type: 'NumberForm', value: sanitizedValue }))
+        }}
         helperText={<FormAlert errorMessage={touched && isInvalid ? validationResult.message : undefined} />}
         slotProps={{
           htmlInput: { inputMode: 'numeric', min: options.min, max: options.max },


### PR DESCRIPTION
### Short Description

Fix overlapping label in the field
<img width="776" height="164" alt="Image" src="https://github.com/user-attachments/assets/1291fde6-6fcd-46bd-ad3a-857825d9a231" />

### Proposed Changes
- change the field type to text
- add additional checks to the field validation

### Side Effects
no?

### Testing

1. Go to application form '/beantragen'
2. Fill the form, select "Ich engagiere mich ehrenamtlich seit mindestens zwei Jahren freiwillig mindestens fünf Stunden pro Woche oder bei Projektarbeiten mindestens 250 Stunden jährlich"
3. Check the behavior of the "Arbeitsstunden pro Woche" field - valid & invalid input

### Resolved Issues
Fixes: #2610
