### PR TITLE
2629: Do not run coverage report for dependabot PRs

### DIFF
--- a/.github/workflows/administration-check.yaml
+++ b/.github/workflows/administration-check.yaml
@@ -5,7 +5,13 @@ on:
     branches:
       - main
     paths:
-      - 'administration/**'
+      - .prettierrc
+      - eslint.config-base.mjs
+      - graphql.config.yml
+      - package.json
+      - package-lock.json
+      - administration/**
+      - frontend/build-configs/**
 
 jobs:
   administration-check:


### PR DESCRIPTION
### Short Description

Clean up and slightly improve the Github Action PR workflow.

### Proposed Changes

- Improve formatting.
- Update to `actions/setup-node@v6`.
- Remove `actions/cache@v4` action, since `actions/setup-node@v6` already has this functionality.
- Add files to the workflow filter that may influence the `/administration` build.
- Do not run coverage reports for dependabot PRs.

### Side Effects

None

### Resolved Issues

Fixes: #2629
