### PR TITLE
2664: Serve public ressources

### DIFF
--- a/administration/config/webpack.config.ts
+++ b/administration/config/webpack.config.ts
@@ -389,6 +389,13 @@ const createWebpackConfig = (webpackEnv: 'development' | 'production'): Configur
             to: `${distDirectory}/${config.projectName}`,
             transform: () => generateAppleAppSiteAssociation(config),
           })),
+          {
+            from: 'public',
+            to: distDirectory,
+            globOptions: {
+              ignore: ['**/index.html'],
+            },
+          },
         ],
       }),
     ].filter(Boolean),


### PR DESCRIPTION
### Short Description

See issue description

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Copy public ressources to build folder

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

`npm run build` then check `build` folder to include the files from `public folder`
1. Check download page logo loads - see issue description (for testing team only)

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2664
