### PR TITLE
2005: added aria-label for SelectForm

### DIFF
--- a/administration/src/routes/beantragen/components/primitive-inputs/SelectForm.tsx
+++ b/administration/src/routes/beantragen/components/primitive-inputs/SelectForm.tsx
@@ -1,5 +1,5 @@
 import { FormControl, InputLabel, MenuItem, Select } from '@mui/material'
-import React, { useContext, useState } from 'react'
+import React, { useContext, useId, useState } from 'react'
 
 import FormAlert from '../../../../components/FormAlert'
 import { ShortTextInput } from '../../../../generated/graphql'
@@ -33,23 +33,23 @@ const SelectForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
   Component: ({ state, setState, label, options }: FormComponentProps<State, AdditionalProps, Options>) => {
     const [touched, setTouched] = useState(false)
     const { showAllErrors, disableAllInputs } = useContext(FormContext)
+    const labelId = useId()
+
     const validationResult = SelectForm.validate(state, options)
     const isInvalid = validationResult.type === 'error'
 
     return (
       <FormControl fullWidth variant='standard' required style={{ margin: '4px 0' }} error={touched && isInvalid}>
-        <InputLabel>{label}</InputLabel>
+        <InputLabel id={labelId}>{label}</InputLabel>
         <Select
-          inputProps={{
-            'aria-label': label,
-          }}
+          labelId={labelId}
           disabled={disableAllInputs}
           value={state.selectedValue}
           label={label}
           onBlur={() => setTouched(true)}
           onChange={e => setState(() => ({ selectedValue: e.target.value, manuallySelected: true }))}>
           {options.items.map(item => (
-            <MenuItem key={item.label} value={item.value} aria-label={item.label}>
+            <MenuItem key={item.label} value={item.value}>
               {item.label}
             </MenuItem>
           ))}


### PR DESCRIPTION
### Short Description

Added aria-label property for Select Inputs

### Proposed Changes

All select inputs now have an aria-label property with the same value as the visual label. Furthermore, the select options have an aria-label with the respective value.

### Side Effects

None expected

### Testing

- Check that the Select Inputs on `/beantragen` route have a suitable aria-label.
- Check that the Lighthouse report does not show any problem with a11y of select inputs

### Resolved Issues

Fixes: #2005 
