### PR TITLE
2742: API user should not be able to configure notifications

### DIFF
--- a/administration/src/routes/user-settings/UserSettingsController.tsx
+++ b/administration/src/routes/user-settings/UserSettingsController.tsx
@@ -17,10 +17,13 @@ const UserSettingsController = (): ReactElement => {
         alignItems: 'center',
         padding: 2,
         gap: 2,
-        overflow: 'auto'
-    }}
+        overflow: 'auto',
+      }}
     >
-      <RenderGuard allowedRoles={[Role.RegionAdmin, Role.RegionManager]} condition={!!applicationFeature}>
+      <RenderGuard
+        allowedRoles={[Role.RegionAdmin, Role.RegionManager]}
+        condition={!!applicationFeature}
+      >
         <NotificationSettings />
       </RenderGuard>
       <ChangePasswordForm />


### PR DESCRIPTION
### Short Description
API user should not be able to configure notifications.

### Proposed Changes
- Add RenderGuard to display NotificationSettings

### Side Effects
no

### Testing
1. Login under different roles (project admin, region admin, region manager, api user) to bayern administration
2. Go to 'Benutzereinstelluingen' --> only region admin and region manager should be able to configure notifications

<img width="515" height="305" alt="image" src="https://github.com/user-attachments/assets/62857e35-e0d0-42d0-8c95-387d6dd1c588" />

### Resolved Issues
Fixes: #2742
