### PR TITLE
2648: Add unique constraint to AcceptingStoreDescriptions

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/db/entities/AcceptingStoreDescription.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/db/entities/AcceptingStoreDescription.kt
@@ -9,6 +9,10 @@ object AcceptingStoreDescriptions : IntIdTable() {
     val storeId = reference("storeId", AcceptingStores)
     val description = varchar("description", 2500).nullable()
     val language = enumerationByName<LanguageCode>("language", 2).default(LanguageCode.DE)
+
+    init {
+        uniqueIndex(storeId, language)
+    }
 }
 
 class AcceptingStoreDescriptionEntity(id: EntityID<Int>) : IntEntity(id) {

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/db/migration/migrations/MigrationsRegistry.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/db/migration/migrations/MigrationsRegistry.kt
@@ -34,5 +34,6 @@ object MigrationsRegistry {
             V0029_Add_Application_Rejection_message(),
             V0030_Fold_Application_Withdrawal_Into_Status(),
             V0031_AddAcceptingStoreDescriptionsTable(),
+            V0032_AddUniqueIndexForAcceptingStoreDescriptionsTable(),
         )
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/db/migration/migrations/V0032_AddUniqueIndexForAcceptingStoreDescriptionsTable.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/db/migration/migrations/V0032_AddUniqueIndexForAcceptingStoreDescriptionsTable.kt
@@ -1,0 +1,16 @@
+package app.ehrenamtskarte.backend.db.migration.migrations
+
+import app.ehrenamtskarte.backend.db.migration.Migration
+import app.ehrenamtskarte.backend.db.migration.Statement
+
+@Suppress("ClassName")
+internal class V0032_AddUniqueIndexForAcceptingStoreDescriptionsTable : Migration() {
+    override val migrate: Statement = {
+        exec(
+            """
+            ALTER TABLE acceptingstoredescriptions ADD CONSTRAINT acceptingstoredescriptions_storeid_language_unique UNIQUE ("storeId", "language");
+            DROP INDEX "acceptingstoredescriptions_storeid_idx";
+            """.trimIndent(),
+        )
+    }
+}


### PR DESCRIPTION
### Short Description
Follow up for https://github.com/digitalfabrik/entitlementcard/pull/2706

I think we need a constraint for the AcceptingStoreDescriptions table to prevent the possibility of inserting multiple records for the same storeId & language.

### Proposed Changes
- add unique constraint for storeId and language columns
- drop the existing index for storeId as it is now redundant (postgres can use the new composite index for lookups on storeId).

### Side Effects
no

### Testing
We can verify that the store import is not broken, but I believe this change is very safe.

### Resolved Issues
Fixes: #
