### PR TITLE
2761: Update Xcode 26.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,7 +350,7 @@ jobs:
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         macos:
-            xcode: 16.4.0
+            xcode: 26.2.0
         parameters:
             build_config:
                 description: Name of the build config to use
@@ -556,7 +556,7 @@ jobs:
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         macos:
-            xcode: 16.4.0
+            xcode: 26.2.0
         parameters:
             build_config:
                 enum:
@@ -829,7 +829,7 @@ jobs:
         environment:
             FASTLANE_SKIP_UPDATE_CHECK: true
         macos:
-            xcode: 16.4.0
+            xcode: 26.2.0
         parameters:
             build_config:
                 default: bayern

--- a/.circleci/src/jobs/build_ios.yml
+++ b/.circleci/src/jobs/build_ios.yml
@@ -1,5 +1,5 @@
 macos:
-  xcode: 16.4.0
+  xcode: 26.2.0
 resource_class: m4pro.medium
 parameters:
   build_config:

--- a/.circleci/src/jobs/deliver_ios.yml
+++ b/.circleci/src/jobs/deliver_ios.yml
@@ -7,7 +7,7 @@ parameters:
     description: Whether to deliver the build to production.
     type: boolean
 macos:
-  xcode: 16.4.0
+  xcode: 26.2.0
 resource_class: m4pro.medium
 environment:
   FASTLANE_SKIP_UPDATE_CHECK: true

--- a/.circleci/src/jobs/promote_ios.yml
+++ b/.circleci/src/jobs/promote_ios.yml
@@ -5,7 +5,7 @@ parameters:
     enum: [bayern, nuernberg, koblenz]
     default: bayern
 macos:
-  xcode: 16.4.0
+  xcode: 26.2.0
 resource_class: m4pro.medium
 environment:
   FASTLANE_SKIP_UPDATE_CHECK: true


### PR DESCRIPTION
### Short Description

We still use Xcode 16.4.0 to build ios apps

### Proposed Changes

<!-- Describe this PR in more detail. -->

- Update xcode circle ci images to latest

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing
https://app.circleci.com/pipelines/github/digitalfabrik/entitlementcard/10309/workflows/53e59f3e-2086-49c1-b2da-ff16feb797ac

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2761
