### PR TITLE
2522: Adjust application rejections note

### DIFF
--- a/administration/src/translations/de.json
+++ b/administration/src/translations/de.json
@@ -220,7 +220,7 @@
     "applicationApprove": "Antrag bestätigen",
     "applicationReject": "Antrag ablehnen",
     "applicationApprovedToastMessage": "Der Antrag wurde genehmigt.",
-    "applicationRejectedToastMessage": "Der Antrag wurde abgelehnt.",
+    "applicationRejectedToastMessage": "Der Antrag wurde abgelehnt. Der Antragsteller oder die Antragstellerin wurde per E-Mail informiert.",
     "incompleteApplicationDataTooltip": "Aus den Antragsdaten kann keine Karte erzeugt werden.",
     "rejectionDialogTitle": "Antrag ablehnen",
     "rejectionDialogMessage": "Bitte wählen Sie einen Ablehnungsgrund. Der/die Antragsteller/in wird über diesen anschließend via E-Mail informiert.",


### PR DESCRIPTION
### Short Description

Currently its not clear for the service user that the applicant will be informed about the rejection.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add a text to the toast

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

- go to "Eingehenden Aufträge" and reject an application

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2522
