### PR TITLE
Add required attribute to email fields in user dialogs

### DIFF
--- a/administration/src/routes/users/components/CreateUserDialog.tsx
+++ b/administration/src/routes/users/components/CreateUserDialog.tsx
@@ -94,6 +94,7 @@ const CreateUserDialog = ({
           onChange={value => setEmail(value)}
           showError={!email || !isEmailValid(email)}
           errorMessage={t('noUserNameError')}
+          required
         />
         <RoleSelector selectedRole={role} onChange={setRole} />
 

--- a/administration/src/routes/users/components/EditUserDialog.tsx
+++ b/administration/src/routes/users/components/EditUserDialog.tsx
@@ -135,6 +135,7 @@ const EditUserDialog = ({
           onChange={value => setEmail(value)}
           showError={!email || !isEmailValid(email)}
           errorMessage={t('noUserNameError')}
+          required
         />
         <RoleSelector selectedRole={role} onChange={setRole} />
         {showRegionSelector ? (


### PR DESCRIPTION
## Summary
Fixes #2771

Add asterisk indicator to email fields in `CreateUserDialog` and `EditUserDialog` for consistency with other required fields like role selector and region selector.

Material-UI's FormControl automatically displays an asterisk for fields marked as `required`, so this change simply adds the `required` prop to the email input fields.

## Test plan
- [ ] Open the Create User dialog and verify the email field shows an asterisk
- [ ] Open the Edit User dialog and verify the email field shows an asterisk
- [ ] Verify the asterisk styling matches other required fields (role selector, region selector)

🤖 Generated with [Claude Code](https://claude.com/claude-code)