### PR TITLE
2787: Check invalid mail edit user

### DIFF
--- a/administration/src/routes/users/components/CreateUserDialog.tsx
+++ b/administration/src/routes/users/components/CreateUserDialog.tsx
@@ -63,7 +63,8 @@ const CreateUserDialog = ({
 
   const showRegionSelector =
     regionIdOverride === null && role !== null && rolesWithRegion.includes(role)
-  const userCreationDisabled = !email || role === null || (showRegionSelector && regionId === null)
+  const userCreationDisabled =
+    !email || role === null || (showRegionSelector && regionId === null) || !isEmailValid(email)
   return (
     <ConfirmDialog
       open={isOpen}

--- a/administration/src/routes/users/components/EditUserDialog.tsx
+++ b/administration/src/routes/users/components/EditUserDialog.tsx
@@ -90,7 +90,8 @@ const EditUserDialog = ({
     !email ||
     role === null ||
     (showRegionSelector && regionId === null) ||
-    notificationShownAndNotConfirmed
+    notificationShownAndNotConfirmed ||
+    !isEmailValid(email)
 
   const editUserAlertDescription = (
     <>


### PR DESCRIPTION
### Short Description

There is no email validation for enabling the create/ edit user button

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add valid mail checks

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. Login as Project Admin or Region Admin
2. Go to "Benutzer verwalten"
3. Create a new user or edit an existing user.
4. Use a non valid mail address missing @ or/and missing domain
5. User can not be created or edited

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2787
