### PR TITLE
2824: Render box not laid

### DIFF
--- a/frontend/lib/map/map/map.dart
+++ b/frontend/lib/map/map/map.dart
@@ -74,6 +74,7 @@ class _MapContainerState extends State<MapContainer> implements MapController {
 
     return Stack(
       children: [
+        // 2824: Use a filled layout container to avoid rendering issues until MapLibreMap container is fully rendered.
         Positioned.fill(
           child: MapLibreMap(
             initialCameraPosition: cameraPosition,


### PR DESCRIPTION
### Short Description

The root of this issue seems to be that the MapLibreContainer is rendered in a stack but has to Layout container until its fully rendered. This can cause issue on ios (KI answer)

Since i can not really reproduce the issue, i'm not sure that it fixes the problem but it sound reasonable and this Container does not harm. We can either keep the bug ticket open or wait until it escalates again after we deployed a new version with this "fix"

### Proposed Changes

<!-- Describe this PR in more detail. -->

- enforce map to be filled even before it was rendered by adding `Position.filled` 

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2824 
