### PR TITLE
2855: Show no description available detail page

### DIFF
--- a/frontend/lib/store_widgets/detail/detail_content.dart
+++ b/frontend/lib/store_widgets/detail/detail_content.dart
@@ -43,10 +43,8 @@ class DetailContent extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            if (storeDescription != null) ...[
-              Text(storeDescription, style: theme.textTheme.bodyLarge),
-              Divider(thickness: 0.7, height: 48, color: theme.primaryColorLight),
-            ],
+            Text(storeDescription ?? t.store.noDescriptionAvailable, style: theme.textTheme.bodyLarge),
+            Divider(thickness: 0.7, height: 48, color: theme.primaryColorLight),
             Column(
               children: <Widget>[
                 ContactInfoRow(


### PR DESCRIPTION
### Short Description

Currently we don't show "no description" available info consistently in store list and store detail

### Proposed Changes

<!-- Describe this PR in more detail. -->

- show "no description available" also on detail page

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. Remove a description from a store
2. Check the detail page of the store in the app

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2855
