### PR TITLE
2840: Revert removal of the deprecated physicalStoresById query

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/stores/AcceptingStoreQueryController.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/stores/AcceptingStoreQueryController.kt
@@ -4,6 +4,8 @@ import app.ehrenamtskarte.backend.config.BackendConfiguration
 import app.ehrenamtskarte.backend.db.entities.AcceptingStoreEntity
 import app.ehrenamtskarte.backend.db.repositories.AcceptingStoresRepository
 import app.ehrenamtskarte.backend.db.repositories.PhysicalStoresRepository
+import app.ehrenamtskarte.backend.graphql.shared.DEFAULT_PROJECT
+import app.ehrenamtskarte.backend.graphql.shared.types.IdsParams
 import app.ehrenamtskarte.backend.graphql.stores.types.AcceptingStore
 import app.ehrenamtskarte.backend.graphql.stores.types.AcceptingStoreV2
 import app.ehrenamtskarte.backend.graphql.stores.types.Coordinates
@@ -26,7 +28,7 @@ class AcceptingStoreQueryController(
     private val backendConfig: BackendConfiguration,
 ) {
     @Deprecated(
-        "Use acceptingStoreByPhysicalStoreIdInProject for localized descriptions. Should be able to safely remove in January 2028.",
+        "Use acceptingStoresByPhysicalStoreIdsInProject query for localized descriptions. Can be safely removed in January 2028.",
     )
     @GraphQLDescription("Returns list of all accepting stores in the given project queried by ids.")
     @QueryMapping
@@ -50,7 +52,15 @@ class AcceptingStoreQueryController(
         }
 
     @Deprecated(
-        "Use searchAcceptingStoresInProjectV2 for localized descriptions. Should be able to safely remove in January 2028.",
+        "Use acceptingStoresByPhysicalStoreIdsInProject query for localized descriptions. Can be safely removed in January 2028.",
+    )
+    @GraphQLDescription(
+        "Returns list of all accepting stores queried by ids in the eak bayern project.",
+    )
+    fun physicalStoresById(params: IdsParams) = physicalStoresByIdInProject(DEFAULT_PROJECT, params.ids)
+
+    @Deprecated(
+        "Use searchAcceptingStoresInProjectV2 query for localized descriptions. Can be safely removed in January 2028.",
     )
     @GraphQLDescription(
         "Search for accepting stores in the given project using searchText and categoryIds.",

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/stores/types/AcceptingStore.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/stores/types/AcceptingStore.kt
@@ -10,7 +10,7 @@ import org.springframework.graphql.data.method.annotation.SchemaMapping
 import org.springframework.stereotype.Controller
 import java.util.concurrent.CompletableFuture
 
-@Deprecated("Use AcceptingStoreV2 for localized descriptions. Should be able to safely remove in January 2028.")
+@Deprecated("Use AcceptingStoreV2 for localized descriptions. Can be safely removed in January 2028.")
 data class AcceptingStore(
     val id: Int,
     val name: String?,

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/stores/types/PhysicalStore.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/stores/types/PhysicalStore.kt
@@ -9,7 +9,7 @@ import org.springframework.graphql.data.method.annotation.SchemaMapping
 import org.springframework.stereotype.Controller
 import java.util.concurrent.CompletableFuture
 
-@Deprecated("Use AcceptingStoreV2 for localized descriptions. Should be able to safely remove in January 2028.")
+@Deprecated("Use AcceptingStoreV2 for localized descriptions. Can be safely removed in January 2028.")
 data class PhysicalStore(
     val id: Int,
     val storeId: Int,

--- a/specs/backend-api.graphql
+++ b/specs/backend-api.graphql
@@ -288,8 +288,10 @@ type Query {
   getUsersInProject: [Administrator!]!
   "Returns all administrators in a region. This query requires the role REGION_ADMIN or PROJECT_ADMIN."
   getUsersInRegion(regionId: Int!): [Administrator!]!
+  "Returns list of all accepting stores queried by ids in the eak bayern project."
+  physicalStoresById(params: IdsParamsInput!): [PhysicalStore]! @deprecated(reason : "Use acceptingStoresByPhysicalStoreIdsInProject query for localized descriptions. Can be safely removed in January 2028.")
   "Returns list of all accepting stores in the given project queried by ids."
-  physicalStoresByIdInProject(ids: [Int!]!, project: String!): [PhysicalStore]! @deprecated(reason : "Use acceptingStoreByPhysicalStoreIdInProject for localized descriptions. Should be able to safely remove in January 2028.")
+  physicalStoresByIdInProject(ids: [Int!]!, project: String!): [PhysicalStore]! @deprecated(reason : "Use acceptingStoresByPhysicalStoreIdsInProject query for localized descriptions. Can be safely removed in January 2028.")
   "Returns region data for specific region."
   regionByRegionId(regionId: Int!): Region!
   "Returns regions queried by ids in the given project."
@@ -299,7 +301,7 @@ type Query {
   "Return list of all regions in the given project."
   regionsInProject(project: String!): [Region!]!
   "Search for accepting stores in the given project using searchText and categoryIds."
-  searchAcceptingStoresInProject(params: SearchParamsInput!, project: String!): [AcceptingStore!]! @deprecated(reason : "Use searchAcceptingStoresInProjectV2 for localized descriptions. Should be able to safely remove in January 2028.")
+  searchAcceptingStoresInProject(params: SearchParamsInput!, project: String!): [AcceptingStore!]! @deprecated(reason : "Use searchAcceptingStoresInProjectV2 query for localized descriptions. Can be safely removed in January 2028.")
   "Search for accepting stores in the given project using searchText and categoryIds."
   searchAcceptingStoresInProjectV2(params: SearchParamsInput!, project: String!): [AcceptingStoreV2!]!
   "Returns whether there is a card in the given project with that hash registered for that this TOTP is currently valid, extendable and a timestamp of the last check"
@@ -585,6 +587,10 @@ input GoldenCardWorkAtDepartmentEntitlementInput {
 
 input GoldenCardWorkAtOrganizationsEntitlementInput {
   list: [WorkAtOrganizationInput!]!
+}
+
+input IdsParamsInput {
+  ids: [Int!]!
 }
 
 input NotificationSettingsInput {


### PR DESCRIPTION
### Short Description
We still have users with older versions of the application who are using the deprecated physicalStoresById query.
This query has been removed from the backend, resulting in exceptions in Sentry `RuntimeException: Validation error (UnknownType) : Unknown type „IdsParamsInput“`.

### Proposed Changes
- revert removal of the deprecated physicalStoresById query

### Side Effects
no

### Testing
n/a

### Resolved Issues
Fixes: #2840
