### PR TITLE
Speed up the backend startup

### DIFF
--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/db/setup/Freinet.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/db/setup/Freinet.kt
@@ -3,11 +3,10 @@ package app.ehrenamtskarte.backend.db.setup
 import app.ehrenamtskarte.backend.db.entities.FreinetAgenciesEntity
 import app.ehrenamtskarte.backend.db.entities.RegionEntity
 import app.ehrenamtskarte.backend.graphql.freinet.types.FreinetApiAgency
-import org.jetbrains.exposed.v1.jdbc.SizedIterable
 
 fun insertOrUpdateFreinetRegionInformation(
     agency: FreinetApiAgency,
-    dbFreinetRegionInformation: SizedIterable<FreinetAgenciesEntity>,
+    dbFreinetRegionInformation: Iterable<FreinetAgenciesEntity>,
     regionEntity: RegionEntity,
 ) {
     val dbAgency = dbFreinetRegionInformation.find { it.agencyId == agency.agencyId }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/db/setup/Regions.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/db/setup/Regions.kt
@@ -13,40 +13,40 @@ import app.ehrenamtskarte.backend.graphql.shared.NUERNBERG_PASS_PROJECT
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
 fun insertOrUpdateRegions(agencies: List<FreinetApiAgency>, config: BackendConfiguration) {
-    val projects = ProjectEntity.all()
-    val dbRegions = RegionEntity.all()
-    val dbFreinetRegionInformation = FreinetAgenciesEntity.all()
-
-    fun createOrUpdateRegion(
-        regionProjectId: String,
-        regionName: String,
-        regionPrefix: String,
-        regionKey: String,
-        regionWebsite: String,
-        regionActivatedForApplication: Boolean,
-    ) {
-        val project = projects.firstOrNull { it.project == regionProjectId }
-            ?: throw Error("Required project '$regionProjectId' not found!")
-        val region = dbRegions.singleOrNull { it.projectId == project.id }
-        if (region == null) {
-            RegionEntity.new {
-                projectId = project.id
-                name = regionName
-                prefix = regionPrefix
-                regionIdentifier = regionKey
-                website = regionWebsite
-                activatedForApplication = regionActivatedForApplication
-            }
-        } else {
-            region.name = regionName
-            region.prefix = regionPrefix
-            region.website = regionWebsite
-            region.regionIdentifier = regionKey
-            region.activatedForApplication = regionActivatedForApplication
-        }
-    }
-
     transaction {
+        val projects = ProjectEntity.all().toList()
+        val dbRegions = RegionEntity.all().toList()
+        val dbFreinetRegionInformation = FreinetAgenciesEntity.all().toList()
+
+        fun createOrUpdateRegion(
+            regionProjectId: String,
+            regionName: String,
+            regionPrefix: String,
+            regionKey: String,
+            regionWebsite: String,
+            regionActivatedForApplication: Boolean,
+        ) {
+            val project = projects.firstOrNull { it.project == regionProjectId }
+                ?: throw Error("Required project '$regionProjectId' not found!")
+            val region = dbRegions.singleOrNull { it.projectId == project.id }
+            if (region == null) {
+                RegionEntity.new {
+                    projectId = project.id
+                    name = regionName
+                    prefix = regionPrefix
+                    regionIdentifier = regionKey
+                    website = regionWebsite
+                    activatedForApplication = regionActivatedForApplication
+                }
+            } else {
+                region.name = regionName
+                region.prefix = regionPrefix
+                region.website = regionWebsite
+                region.regionIdentifier = regionKey
+                region.activatedForApplication = regionActivatedForApplication
+            }
+        }
+
         val eakProject = projects.firstOrNull { it.project == EAK_BAYERN_PROJECT }
             ?: throw Error("Required project '$EAK_BAYERN_PROJECT' not found!")
         val eakRegions = EAK_BAYERN_REGIONS.toMutableList()


### PR DESCRIPTION
### Short Description
Since our administration module starts very quickly now, the slow startup of the backend module is quite annoying.
This is partially caused by the initial data setup in the database (loading regions etc).

### Proposed Changes
I adjusted the `insertOrUpdateRegions` function:
The code was iterating over `SizedIterables` (`RegionEntity.all()` and `FreinetAgenciesEntity.all()`) inside a loop, triggering a separate SQL SELECT statement for every single region.
Now I changed the data fetching to eagerly load entities using `.toList()` before the processing loop.

This reduces the number of generated queries and saves a few seconds at startup.

### Side Effects
no

### Testing

**Dev only**: check the backend startup time

### Resolved Issues
n/a
