### PR TITLE
2510: Withdrawn data are not deleted

### DIFF
--- a/administration/src/translations/de.json
+++ b/administration/src/translations/de.json
@@ -745,7 +745,7 @@
   "applicationApplicant": {
     "alreadyWithdrawn": "Der Antrag wurde bereits zurückgezogen.",
     "headline": "Ihr Antrag auf die Ehrenamtskarte Bayern vom {{date, datetime(dateStyle: 'medium'; timeStyle: 'short')}}",
-    "withdrawInformation": "Hier können Sie Ihren Antrag zurückziehen und Ihre Eingaben unwiderruflich löschen.",
+    "withdrawInformation": "Hier können Sie Ihren Antrag zurückziehen.",
     "withdrawApplication": "Antrag zurückziehen",
     "withdrawConfirmationTitle": "Antrag zurückziehen?",
     "withdrawConfirmationContent": "Möchten Sie Ihren Antrag zurückziehen?",


### PR DESCRIPTION
### Short Description

Since our current wording indicates that the data will be deleted automatically, which is not the case. We adjust the wording

### Proposed Changes

<!-- Describe this PR in more detail. -->

- adjust the wording for withdraw application data

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. Create an application for bayern (/beantragen)
2. Open the application via the provided mail link and check the text above the withdraw button

### Resolved Issues

Fixes: #2510
