### PR TITLE
2851: Handle bad request

### DIFF
--- a/administration/src/errors/defaultErrorMap.ts
+++ b/administration/src/errors/defaultErrorMap.ts
@@ -4,6 +4,9 @@ import i18next from '../translations/i18n'
 import type { GraphQLErrorMessage } from './getMessageFromApolloError'
 
 const defaultErrorMap = (error: ApolloError): GraphQLErrorMessage => {
+  if (error.message.includes('400')) {
+    return { title: i18next.t('errors:invalidRequestFormat') }
+  }
   if (error.message.includes('401')) {
     return { title: i18next.t('errors:notAuthorized') }
   }

--- a/administration/src/translations/de.json
+++ b/administration/src/translations/de.json
@@ -670,6 +670,7 @@
     "serverNotAvailable": "Server nicht erreichbar.",
     "unknown": "Etwas ist schief gelaufen.",
     "unknownError": "Ein Fehler ist aufgetreten.",
+    "invalidRequestFormat": "Ihre Anfrage konnte nicht verarbeitet werden",
     "notAuthorized": "Fehlende Berechtigung",
     "notAuthorizedDescription": "Sie sind nicht berechtigt, diesen Bereich einzusehen.",
     "notAuthorizedToSeeApplications": "Sie sind nicht berechtigt, Anträge einzusehen.",

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/application/multipart/MultipartGraphQLHandler.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/application/multipart/MultipartGraphQLHandler.kt
@@ -1,6 +1,7 @@
 package app.ehrenamtskarte.backend.graphql.application.multipart
 
 import app.ehrenamtskarte.backend.graphql.shared.substitute
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.slf4j.LoggerFactory
@@ -80,7 +81,13 @@ class MultipartGraphQLHandler(
                 }
             }
             mapper.readValue(mapper.treeAsTokens(operationsNode))
-        } catch (e: Exception) {
+        } catch (e: IllegalArgumentException) {
+            logger.debug("Failed to process multipart request", e)
+            return badRequestResponse("Invalid multipart request format")
+        } catch (e: IllegalStateException) {
+            logger.debug("Failed to process multipart request", e)
+            return badRequestResponse("Invalid multipart request format")
+        } catch (e: JsonProcessingException) {
             logger.debug("Failed to process multipart request", e)
             return badRequestResponse("Invalid multipart request format")
         }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/application/multipart/MultipartGraphQLHandler.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/application/multipart/MultipartGraphQLHandler.kt
@@ -3,6 +3,7 @@ package app.ehrenamtskarte.backend.graphql.application.multipart
 import app.ehrenamtskarte.backend.graphql.shared.substitute
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
 import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.graphql.MediaTypes.APPLICATION_GRAPHQL_RESPONSE
@@ -38,6 +39,7 @@ import org.springframework.web.servlet.function.ServerResponse
 class MultipartGraphQLHandler(
     private val graphQlHandler: WebGraphQlHandler,
 ) {
+    private val logger = LoggerFactory.getLogger(MultipartGraphQLHandler::class.java)
     private val idGenerator: IdGenerator = AlternativeJdkIdGenerator()
     private val mapper = jacksonObjectMapper()
 
@@ -53,7 +55,9 @@ class MultipartGraphQLHandler(
 
         val mapPart = partsMap["map"] ?: return badRequestResponse("Missing required 'map' field in multipart request")
         val mapNode = mapPart.inputStream.use {
-            runCatching { mapper.readValue<Map<String, List<String>>>(it) }.getOrNull()
+            runCatching { mapper.readValue<Map<String, List<String>>>(it) }
+                .onFailure { e -> logger.debug("Failed to parse 'map' field in multipart request", e) }
+                .getOrNull()
         } ?: return badRequestResponse("Invalid 'map' field format in multipart request")
 
         // Collect uploaded files
@@ -76,7 +80,8 @@ class MultipartGraphQLHandler(
                 }
             }
             mapper.readValue(mapper.treeAsTokens(operationsNode))
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            logger.debug("Failed to process multipart request", e)
             return badRequestResponse("Invalid multipart request format")
         }
 

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/application/multipart/MultipartGraphQLHandler.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/application/multipart/MultipartGraphQLHandler.kt
@@ -28,6 +28,7 @@ import org.springframework.web.servlet.function.ServerResponse
  * 3. Inserts the corresponding `fileIndex` into the JSON payload according to each file reference
  *    (e.g. `{"name":"certificate","type":"Attachment","value":{"fileIndex":0}}`).
  * 4. Forwards the reconstructed GraphQL request to the standard [WebGraphQlHandler] for execution.
+ * 5. Handle Multipart request format issues with BadRequest (400) to avoid exception flood.
  *
  * This implementation serves as a compatibility workaround to enable file uploads in GraphQL
  * within Spring Boot applications.
@@ -40,40 +41,44 @@ class MultipartGraphQLHandler(
     private val idGenerator: IdGenerator = AlternativeJdkIdGenerator()
     private val mapper = jacksonObjectMapper()
 
-    @Throws(GraphQLMultipartParseException::class)
     fun handleMultipartRequest(serverRequest: ServerRequest): ServerResponse {
         val request = serverRequest.servletRequest()
 
         // Collect all parts
         val partsMap = request.parts.associateBy { it.name }
 
+        // Validate required parts
         val operationsNode = partsMap["operations"]?.inputStream?.use { mapper.readTree(it) }
-            ?: throw GraphQLMultipartParseException("Missing 'operations' node")
+            ?: return badRequestResponse("Missing required 'operations' field in multipart request")
 
-        val mapNode = partsMap["map"]?.inputStream?.use { mapper.readValue<Map<String, List<String>>>(it) }
-            ?: throw GraphQLMultipartParseException("Missing 'map' node")
+        val mapPart = partsMap["map"] ?: return badRequestResponse("Missing required 'map' field in multipart request")
+        val mapNode = mapPart.inputStream.use {
+            runCatching { mapper.readValue<Map<String, List<String>>>(it) }.getOrNull()
+        } ?: return badRequestResponse("Invalid 'map' field format in multipart request")
 
         // Collect uploaded files
         val files = request.parts.filter { mapNode.containsKey(it.name) }
 
-        // Substitute file references into the GraphQL variables
-        mapNode.forEach { (key, paths) ->
-            if (key == "operations" || key == "map") {
-                throw GraphQLMultipartParseException("Invalid file key: '$key'")
-            }
+        // Substitute file references and deserialize payload — client input, so bad format returns 400
+        val payload: Map<String, Any> = try {
+            mapNode.forEach { (key, paths) ->
+                if (key == "operations" || key == "map") {
+                    return badRequestResponse("Invalid file key: '$key' - reserved field names")
+                }
 
-            val fileIndex = files.indexOfFirst { it.name == key }
-            if (fileIndex == -1) {
-                throw GraphQLMultipartParseException("Part with key '$key' not found")
-            }
+                val fileIndex = files.indexOfFirst { it.name == key }
+                if (fileIndex == -1) {
+                    return badRequestResponse("Referenced file '$key' not found in multipart request")
+                }
 
-            paths.forEach { path ->
-                operationsNode.substitute(path, fileIndex, mapper)
+                paths.forEach { path ->
+                    operationsNode.substitute(path, fileIndex, mapper)
+                }
             }
+            mapper.readValue(mapper.treeAsTokens(operationsNode))
+        } catch (_: Exception) {
+            return badRequestResponse("Invalid multipart request format")
         }
-
-        // Deserialize the final payload
-        val payload: Map<String, Any> = mapper.readValue(mapper.treeAsTokens(operationsNode))
 
         // Copy cookies to the GraphQL request
         val targetCookies = LinkedMultiValueMap<String, HttpCookie>().apply {
@@ -115,6 +120,23 @@ class MultipartGraphQLHandler(
         return ServerResponse.async(future)
     }
 
+    private fun badRequestResponse(errorMessage: String): ServerResponse {
+        val errorBody = mapOf(
+            "errors" to listOf(
+                mapOf(
+                    "message" to "Invalid GraphQL request format",
+                    "extensions" to mapOf(
+                        "code" to "INVALID_MULTIPART_REQUEST",
+                        "details" to errorMessage,
+                    ),
+                ),
+            ),
+        )
+        return ServerResponse.badRequest()
+            .contentType(APPLICATION_JSON)
+            .body(errorBody)
+    }
+
     companion object {
         private val SUPPORTED_MEDIA_TYPES = listOf(APPLICATION_GRAPHQL_RESPONSE, APPLICATION_JSON)
 
@@ -123,6 +145,3 @@ class MultipartGraphQLHandler(
                 ?: APPLICATION_JSON
     }
 }
-
-class GraphQLMultipartParseException(message: String, cause: Throwable? = null) :
-    RuntimeException(message, cause)


### PR DESCRIPTION
### Short Description

We are currently handling and logging all MultiPartGraphqlErrors internally.
This is flooding our server logs.
Instead we might handle this as 400 BadRequest, since all issues that might happen here will be triggered by an issued request,

### Proposed Changes

<!-- Describe this PR in more detail. -->

- return a bad request if the MultiPartRequest is invalid
- show an error message in the frontend to the user ("Ihre Anfrage konnte nicht verarbeitet werden")

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Testing

I'm not really sure how to properly test it. I just sent an invalid request via curl
Example (Missing operation):
```
curl -v -X POST \
  -F "map={\"file\":[\"variables.attachment\"]}" \
  http://localhost:8000
```
You should get a 400 instead of a 500
### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
