### PR TITLE
2745: Checkbox hover indicator is misplaced

### DIFF
--- a/administration/src/components/AlertBox.tsx
+++ b/administration/src/components/AlertBox.tsx
@@ -25,7 +25,6 @@ const AlertBox = ({
   actionButtonLabel,
 }: AlertBoxProps): ReactElement => {
   const { t } = useTranslation('errors')
-  const fullWidthStyles = fullWidth ? { margin: 0, maxWidth: 'none' } : {}
 
   return (
     <Alert
@@ -43,8 +42,16 @@ const AlertBox = ({
             margin: '5px',
           },
         }),
-        ...fullWidthStyles,
+        ...(fullWidth ? { margin: 0, maxWidth: 'none' } : {}),
         ...sx,
+      }}
+      slotProps={{
+        // Inhibits clipping of <CheckBox> hover indicators
+        message: {
+          sx: {
+            overflow: 'visible',
+          },
+        },
       }}
       action={
         onAction ? (

--- a/administration/src/components/BaseCheckbox.tsx
+++ b/administration/src/components/BaseCheckbox.tsx
@@ -27,10 +27,8 @@ const BaseCheckbox = ({
   <FormGroup>
     <FormControl required={required} error={hasError} disabled={disabled}>
       <FormControlLabel
-        sx={{ marginTop: 0.5, marginX: 0 }}
         control={
           <Checkbox
-            sx={{ pl: 0 }}
             required={required}
             checked={checked}
             onBlur={onBlur}

--- a/administration/src/components/BaseCheckbox.tsx
+++ b/administration/src/components/BaseCheckbox.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControl, FormControlLabel, FormGroup } from '@mui/material'
+import { Checkbox, FormControl, FormControlLabel } from '@mui/material'
 import React, { ReactElement } from 'react'
 
 import FormAlert from './FormAlert'
@@ -24,24 +24,22 @@ const BaseCheckbox = ({
   hasError,
   errorMessage,
 }: BaseCheckboxProps): ReactElement => (
-  <FormGroup>
-    <FormControl required={required} error={hasError} disabled={disabled}>
-      <FormControlLabel
-        control={
-          <Checkbox
-            required={required}
-            checked={checked}
-            onBlur={onBlur}
-            onChange={e => {
-              onChange(e.target.checked)
-            }}
-          />
-        }
-        label={label}
-      />
-      {hasError && <FormAlert errorMessage={errorMessage} />}
-    </FormControl>
-  </FormGroup>
+  <FormControl required={required} error={hasError} disabled={disabled}>
+    <FormControlLabel
+      control={
+        <Checkbox
+          required={required}
+          checked={checked}
+          onBlur={onBlur}
+          onChange={e => {
+            onChange(e.target.checked)
+          }}
+        />
+      }
+      label={label}
+    />
+    {hasError && <FormAlert errorMessage={errorMessage} />}
+  </FormControl>
 )
 
 export default BaseCheckbox

--- a/administration/src/routes/users/components/EditUserDialog.tsx
+++ b/administration/src/routes/users/components/EditUserDialog.tsx
@@ -1,5 +1,5 @@
 import { Edit } from '@mui/icons-material'
-import { Link, Stack, Typography } from '@mui/material'
+import { Link, Stack } from '@mui/material'
 import { useSnackbar } from 'notistack'
 import React, { ReactElement, useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -151,7 +151,7 @@ const EditUserDialog = ({
             severity='error'
             title={t('youEditYourOwnAccount')}
             description={
-              <Typography component='div'>
+              <>
                 {t('youMayCannotUndoThis')}
                 <BaseCheckbox
                   label={t('ownAccountWarningConfirmation')}
@@ -161,7 +161,7 @@ const EditUserDialog = ({
                   hasError={false}
                   errorMessage={undefined}
                 />
-              </Typography>
+              </>
             }
           />
         ) : null}


### PR DESCRIPTION
### Short Description

Fixes the hover indicator of `<BaseCheckBox>`.

### Proposed Changes

- Fixes styling of  `<BaseCheckBox>`.
- Removes form group in `<BaseCheckBox>`. This component is used to group _multiple_ form elements into a group.
- Removes a redundant typography component in `<EditUserDialog>`.

### Side Effects

None

### Testing

- Login to http://localhost:3000
  - Test form components with checkboxes, e.g. user settings, notification settings.
- Bayern: test http://localhost:3000/beantragen
- Koblenz: test http://localhost:3000/erstellen
 

### Resolved Issues

Fixes: #2745
