### PR TITLE
2943: Current user edit fix

### DIFF
--- a/administration/src/routes/users/components/EditUserDialog.tsx
+++ b/administration/src/routes/users/components/EditUserDialog.tsx
@@ -49,9 +49,8 @@ const EditUserDialog = ({
       onClose()
       if (me?.id === selectedUser?.id) {
         refetchMe()
-      } else {
-        onSuccess()
       }
+      onSuccess()
     },
   })
 


### PR DESCRIPTION
### Short Description

Currently the user table will not be updated after the current user was edited.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- also execute onSuccess for the current user to update the user table

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

See issue instructions

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2943
