### PR TITLE
Log store import result

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -10,7 +10,6 @@ local.properties
 src/main/resources/config/config.local.yml
 
 src/main/resources/freinet_url.txt
-src/main/resources/import/filtered_stores.csv
-src/main/resources/import/import_result.csv
+logs/
 
 rejectedStores.json

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -10,5 +10,7 @@ local.properties
 src/main/resources/config/config.local.yml
 
 src/main/resources/freinet_url.txt
+src/main/resources/import/filtered_stores.csv
+src/main/resources/import/import_result.csv
 
 rejectedStores.json

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/config/BackendConfiguration.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/config/BackendConfiguration.kt
@@ -35,7 +35,7 @@ data class ProjectConfig(
     val matomo: MatomoConfig?,
     val freinet: FreinetConfig?,
     val filteredStoresOutput: String?,
-    val importResultOutput: String?,
+    val importLogFilePath: String?,
 )
 
 data class ServerConfig(val dataDirectory: String, val host: String, val port: String)

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/config/BackendConfiguration.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/config/BackendConfiguration.kt
@@ -35,6 +35,7 @@ data class ProjectConfig(
     val matomo: MatomoConfig?,
     val freinet: FreinetConfig?,
     val filteredStoresOutput: String?,
+    val importResultOutput: String?,
 )
 
 data class ServerConfig(val dataDirectory: String, val host: String, val port: String)

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/import/stores/bayern/EhrenamtskarteBayern.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/import/stores/bayern/EhrenamtskarteBayern.kt
@@ -17,6 +17,8 @@ import app.ehrenamtskarte.backend.import.stores.pipelines.Pipeline
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpRequestRetry
 import org.slf4j.Logger
+import java.nio.file.Files
+import java.nio.file.Paths
 
 object EhrenamtskarteBayern : Pipeline {
     private val httpClient = HttpClient {
@@ -28,6 +30,11 @@ object EhrenamtskarteBayern : Pipeline {
     }
 
     override fun import(config: ImportConfig, logger: Logger, filteredStores: MutableList<FilteredStore>) {
+        // Create log folder if needed
+        listOfNotNull(config.project.filteredStoresOutput, config.project.importLogFilePath)
+            .mapNotNull { Paths.get(it).parent }
+            .forEach { Files.createDirectories(it) }
+
         Unit
             .addStep(DownloadLbe(config, logger, httpClient), logger) {
                 logger.info("== Download lbe data ==")

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/import/stores/bayern/EhrenamtskarteBayern.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/import/stores/bayern/EhrenamtskarteBayern.kt
@@ -12,6 +12,7 @@ import app.ehrenamtskarte.backend.import.stores.common.steps.FilterDuplicates
 import app.ehrenamtskarte.backend.import.stores.common.steps.SanitizeAddress
 import app.ehrenamtskarte.backend.import.stores.common.steps.SanitizeGeocode
 import app.ehrenamtskarte.backend.import.stores.common.steps.Store
+import app.ehrenamtskarte.backend.import.stores.common.steps.StoreImportResultCsvOutput
 import app.ehrenamtskarte.backend.import.stores.pipelines.Pipeline
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpRequestRetry
@@ -54,6 +55,9 @@ object EhrenamtskarteBayern : Pipeline {
             }
             .addStep(Store(config, logger), logger) {
                 logger.info("== Store remaining data to db ==")
+            }
+            .addStep(StoreImportResultCsvOutput(config), logger) {
+                logger.info("== Write CSV Import Result ==")
             }
     }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/import/stores/common/steps/Store.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/import/stores/common/steps/Store.kt
@@ -6,6 +6,7 @@ import app.ehrenamtskarte.backend.db.entities.Projects
 import app.ehrenamtskarte.backend.db.entities.RegionEntity
 import app.ehrenamtskarte.backend.db.repositories.AcceptingStoresRepository
 import app.ehrenamtskarte.backend.db.repositories.RegionsRepository
+import app.ehrenamtskarte.backend.graphql.stores.types.StoreImportReturnResultModel
 import app.ehrenamtskarte.backend.import.stores.ImportConfig
 import app.ehrenamtskarte.backend.import.stores.PipelineStep
 import app.ehrenamtskarte.backend.import.stores.common.types.AcceptingStore
@@ -20,8 +21,8 @@ import org.slf4j.Logger
  * Longitude, latitude and postal code of [AcceptingStore] must not be null.
  */
 class Store(config: ImportConfig, private val logger: Logger) :
-    PipelineStep<List<AcceptingStore>, Unit>(config) {
-    override fun execute(input: List<AcceptingStore>) {
+    PipelineStep<List<AcceptingStore>, StoreImportReturnResultModel>(config) {
+    override fun execute(input: List<AcceptingStore>): StoreImportReturnResultModel =
         transaction {
             val project = ProjectEntity.find { Projects.project eq config.project.id }.single()
             try {
@@ -63,13 +64,13 @@ class Store(config: ImportConfig, private val logger: Logger) :
                         Count stores untouched: $numStoresUntouched
                     """.trimIndent(),
                 )
+                StoreImportReturnResultModel(numStoresCreated, acceptingStoreIdsToRemove.size, numStoresUntouched)
             } catch (e: Exception) {
                 logger.error("Unknown exception while storing to db", e)
                 rollback()
                 throw e
             }
         }
-    }
 }
 
 private fun getRegionFromAcceptingStore(

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/import/stores/common/steps/StoreImportResultCsvOutput.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/import/stores/common/steps/StoreImportResultCsvOutput.kt
@@ -11,8 +11,10 @@ import java.time.LocalDate
 
 class StoreImportResultCsvOutput(config: ImportConfig) :
     PipelineStep<StoreImportReturnResultModel, StoreImportReturnResultModel>(config) {
+    private val logger = LoggerFactory.getLogger(StoreImportResultCsvOutput::class.java)
+
     override fun execute(input: StoreImportReturnResultModel): StoreImportReturnResultModel {
-        val outputPath = config.project.importResultOutput
+        val outputPath = config.project.importLogFilePath
         if (!outputPath.isNullOrBlank()) {
             writeCsvWithImportResult(outputPath, input)
         }
@@ -20,17 +22,17 @@ class StoreImportResultCsvOutput(config: ImportConfig) :
     }
 
     private fun writeCsvWithImportResult(outputPath: String, result: StoreImportReturnResultModel) {
-        val logger = LoggerFactory.getLogger(StoreImportResultCsvOutput::class.java)
         try {
-            val fileExists = Files.exists(Paths.get(outputPath))
+            val path = Paths.get(outputPath)
+            val isNewFile = !Files.exists(path)
             Files.newBufferedWriter(
-                Paths.get(outputPath),
+                path,
                 java.nio.file.StandardOpenOption.CREATE,
                 java.nio.file.StandardOpenOption.APPEND,
             ).use { writer ->
-                val format = CSVFormat.RFC4180.builder()
+                CSVFormat.RFC4180.builder()
                     .apply {
-                        if (!fileExists) {
+                        if (isNewFile) {
                             setHeader(
                                 "Date",
                                 "StoresTotal",
@@ -40,16 +42,15 @@ class StoreImportResultCsvOutput(config: ImportConfig) :
                             )
                         }
                     }
-                    .get()
-                format.print(writer).use { printer ->
-                    printer.printRecord(
-                        LocalDate.now(config.project.timezone),
-                        result.storesCreated + result.storesUntouched,
-                        result.storesCreated,
-                        result.storesDeleted,
-                        result.storesUntouched,
-                    )
-                }
+                    .get().print(writer).use { printer ->
+                        printer.printRecord(
+                            LocalDate.now(config.project.timezone),
+                            result.storesCreated + result.storesUntouched,
+                            result.storesCreated,
+                            result.storesDeleted,
+                            result.storesUntouched,
+                        )
+                    }
             }
         } catch (e: Exception) {
             logger.error("Error writing import result CSV:", e)

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/import/stores/common/steps/StoreImportResultCsvOutput.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/import/stores/common/steps/StoreImportResultCsvOutput.kt
@@ -1,0 +1,58 @@
+package app.ehrenamtskarte.backend.import.stores.common.steps
+
+import app.ehrenamtskarte.backend.graphql.stores.types.StoreImportReturnResultModel
+import app.ehrenamtskarte.backend.import.stores.ImportConfig
+import app.ehrenamtskarte.backend.import.stores.PipelineStep
+import org.apache.commons.csv.CSVFormat
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.time.LocalDate
+
+class StoreImportResultCsvOutput(config: ImportConfig) :
+    PipelineStep<StoreImportReturnResultModel, StoreImportReturnResultModel>(config) {
+    override fun execute(input: StoreImportReturnResultModel): StoreImportReturnResultModel {
+        val outputPath = config.project.importResultOutput
+        if (!outputPath.isNullOrBlank()) {
+            writeCsvWithImportResult(outputPath, input)
+        }
+        return input
+    }
+
+    private fun writeCsvWithImportResult(outputPath: String, result: StoreImportReturnResultModel) {
+        val logger = LoggerFactory.getLogger(StoreImportResultCsvOutput::class.java)
+        try {
+            val fileExists = Files.exists(Paths.get(outputPath))
+            Files.newBufferedWriter(
+                Paths.get(outputPath),
+                java.nio.file.StandardOpenOption.CREATE,
+                java.nio.file.StandardOpenOption.APPEND,
+            ).use { writer ->
+                val format = CSVFormat.RFC4180.builder()
+                    .apply {
+                        if (!fileExists) {
+                            setHeader(
+                                "Date",
+                                "StoresTotal",
+                                "StoresCreated",
+                                "StoresDeleted",
+                                "StoresUntouched",
+                            )
+                        }
+                    }
+                    .get()
+                format.print(writer).use { printer ->
+                    printer.printRecord(
+                        LocalDate.now(config.project.timezone),
+                        result.storesCreated + result.storesUntouched,
+                        result.storesCreated,
+                        result.storesDeleted,
+                        result.storesUntouched,
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            logger.error("Error writing import result CSV:", e)
+        }
+    }
+}

--- a/backend/src/main/resources/config/config.yml
+++ b/backend/src/main/resources/config/config.yml
@@ -22,7 +22,7 @@ projects:
   - id: bayern.ehrenamtskarte.app
     importUrl: https://www.ehrenamt.bayern.de/xml-json/app-daten.xml
     filteredStoresOutput: /var/archive-data/filtered_stores.csv
-    importResultOutput: /var/archive-data/import_result.csv
+    importLogFilePath: /var/archive-data/import_result.csv
     pipelineName: EhrenamtskarteBayern
     administrationBaseUrl: https://bayern.ehrenamtskarte.app
     administrationName: Ehrenamtskarte-Bayern-Verwaltung

--- a/backend/src/main/resources/config/config.yml
+++ b/backend/src/main/resources/config/config.yml
@@ -22,6 +22,7 @@ projects:
   - id: bayern.ehrenamtskarte.app
     importUrl: https://www.ehrenamt.bayern.de/xml-json/app-daten.xml
     filteredStoresOutput: /var/archive-data/filtered_stores.csv
+    importResultOutput: /var/archive-data/import_result.csv
     pipelineName: EhrenamtskarteBayern
     administrationBaseUrl: https://bayern.ehrenamtskarte.app
     administrationName: Ehrenamtskarte-Bayern-Verwaltung

--- a/docs/freinet-documentation.md
+++ b/docs/freinet-documentation.md
@@ -10,7 +10,21 @@ A single large XML file is hosted at [lbe.bayern.de](https://www.ehrenamt.bayern
 ```
 https://www.ehrenamt.bayern.de/xml-json/app-daten.xml
 ```
- 
+
+### Missing Stores
+We are applying some cleaning and filtering of the data, since there might be location information missing that leads to unresolved coordinates.
+Result: 
+```
+https://bayern.ehrenamtskarte.app/acceptance-stores/filtered_stores.csv
+```
+
+### Import Results
+Here we check how many stores were created/deleted/unchanged since with the last import.
+Result:
+```
+https://bayern.ehrenamtskarte.app/acceptance-stores/import_result.csv
+```
+
 The format is not formally specified. The field `p_eak_agentur_id` specifies the Stadt or Landkreis where the Akzeptanzstelle is located or managed.
 
 ## Freinet JSON API
@@ -21,7 +35,7 @@ The Agenturen are also available through a JSON API:
 https://freinet-online.de/files/api_bayerische_eak/agenturen.php?accessKey={access_key}
 ```
 
-The `{access_key}` can be requested from [@maxammann](https://github.com/maxammann).
+The `{access_key}` can be found in passbolt
 
 All Akzeptanzstellen are also available. First get the current "version":
 


### PR DESCRIPTION
### Short Description

Currently we have no information how many stores will be created or deleted each import run. Due to our favorites function (not in usage) it would be good to know how stable stores are in the database.

I just tested this to get an impression how many store will be recreated. Maybe this is not 100% needed

Here is the salt pr: https://git.tuerantuer.org/DF/salt/pulls/631

### Proposed Changes

<!-- Describe this PR in more detail. -->

 - update gitignore                                                                                                                                                                                                                                                                                                   
  - update docs
  - add import result logging                                                                                                                                                                                                                                                                                          
  - add output path  

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

- add `importResultOutput: src/main/resources/import/import_result.csv` to your `config.local.yml`
- run "DB import online data`
- check `import_result.csv`

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
