### PR TITLE
2960: Fix bulk creation nuernberg

### DIFF
--- a/administration/src/cards/pdf/pdfFactory.ts
+++ b/administration/src/cards/pdf/pdfFactory.ts
@@ -45,6 +45,7 @@ export class PdfError extends Error {
 
 const fillContentAreas = async (
   page: PDFPage,
+  pageIndex: number,
   code: CreateCardsResult,
   card: Card,
   pdfConfig: PdfConfig,
@@ -93,7 +94,7 @@ const fillContentAreas = async (
   pdfConfig.elements?.form?.forEach(configOptions =>
     pdfFormElement(
       page,
-      configOptions.infoToFormFields(page.doc.getForm(), page.doc.getPageCount(), {
+      configOptions.infoToFormFields(page.doc.getForm(), pageIndex, {
         info: dynamicCode.value.info!,
         region,
         card,
@@ -151,6 +152,7 @@ export const generatePdf = async (
     for (let index = 0; index < codes.length; index++) {
       await fillContentAreas(
         templatePages[index],
+        index,
         codes[index],
         cards[index],
         projectConfig.pdf,


### PR DESCRIPTION
### Short Description

Currently we cannot create bulk card pdfs with address fields, since the iteration is broken

### Proposed Changes

<!-- Describe this PR in more detail. -->

- use `pageIndex` since pageCount delivers the total number of pages for each card that will be created (so every card the same value

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

Check bug description

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2960
