### PR TITLE
2983: Fix deeplinks

### DIFF
--- a/administration/src/cards/pdf/pdfFactory.ts
+++ b/administration/src/cards/pdf/pdfFactory.ts
@@ -131,6 +131,11 @@ export const generatePdf = async (
     targetDocument.setTitle(projectConfig.pdf.title)
     targetDocument.setAuthor(projectConfig.pdf.issuer)
 
+    // copyPages must be called once per card.
+    // Per https://github.com/Hopding/pdf-lib/issues/422, copying the same page multiple times in
+    // one call is expected to share object references (incl. Annots), causing all pages to end up
+    // with the same deep link annotation. Separate calls each create a fresh Copier that
+    // independently copies all referenced objects, giving every page its own Annots array.
     const templatePages: PDFPage[] = []
     for (let i = 0; i < codes.length; i++) {
       const [page] = await targetDocument.copyPages(templateDocument, [0])

--- a/administration/src/cards/pdf/pdfFactory.ts
+++ b/administration/src/cards/pdf/pdfFactory.ts
@@ -131,12 +131,11 @@ export const generatePdf = async (
     targetDocument.setTitle(projectConfig.pdf.title)
     targetDocument.setAuthor(projectConfig.pdf.issuer)
 
-    const templatePages = await targetDocument.copyPages(
-      templateDocument,
-      Array.from({ length: codes.length }, () => 0),
-    )
+    const templatePages: PDFPage[] = []
     for (let i = 0; i < codes.length; i++) {
-      targetDocument.addPage(templatePages[i])
+      const [page] = await targetDocument.copyPages(templateDocument, [0])
+      targetDocument.addPage(page)
+      templatePages.push(page)
     }
 
     const [fontRegular, fontBold] = await Promise.all([


### PR DESCRIPTION
### Short Description

This issue is a bit complicated and relies on what different types of page data there are in the pdf structure.
#### Content stream vs. Annotations
- Content stream: stores drawing commands (lines, rectangles, text). Each copied page gets its own fresh content stream. So drawRectangle (QR code) and drawText write into the page's own stream and stay isolated.    
--> not affected                                                                                              
Annots array: stores link annotations as entries in a shared PDFArray object referenced by a PDFRef. This is what addAnnot writes to. 
--> affected
<!-- Describe this PR in one or two sentences. -->

### Proposed Changes

<!-- Describe this PR in more detail. -->

- enforce new cache by card to fix pdf annotations by calling `copyPage` per card

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Testing

1. Create multiple cards for bavaria (either over the form or bulk creation)
2. Open the pdf
3. Check that the deeplinks (hover on qr code) are different

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2983
