### PR TITLE
2999: Implement db connection pooling

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -112,6 +112,7 @@ dependencies {
     implementation(libs.springframework.boot.starter.mail)
     implementation(libs.springframework.boot.starter.web)
     implementation(libs.springframework.boot.starter.graphql)
+    implementation(libs.zaxxer.hickaricp)
 
     runtimeOnly(libs.postgresql.postgresql)
 

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -80,3 +80,4 @@ springframework-boot-testcontainers = { module = "org.springframework.boot:sprin
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers" }
 testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainers" }
+zaxxer-hickaricp = { module = "com.zaxxer:HikariCP", version = "7.0.2" }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/db/Database.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/db/Database.kt
@@ -11,16 +11,18 @@ import app.ehrenamtskarte.backend.db.setup.insertOrUpdateProjects
 import app.ehrenamtskarte.backend.db.setup.insertOrUpdateRegions
 import app.ehrenamtskarte.backend.graphql.auth.types.Role
 import app.ehrenamtskarte.backend.graphql.freinet.util.FreinetAgenciesLoader
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
 import org.jetbrains.exposed.v1.core.DatabaseConfig
 import org.jetbrains.exposed.v1.core.StdOutSqlLogger
 import org.jetbrains.exposed.v1.core.statements.StatementType
 import org.jetbrains.exposed.v1.jdbc.Database.Companion.connect
 import org.jetbrains.exposed.v1.jdbc.transactions.TransactionManager
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import org.postgresql.ds.PGSimpleDataSource
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
+import java.util.Properties
 
 object Database {
     fun executeSqlResource(path: String) {
@@ -71,17 +73,24 @@ object Database {
         log: Boolean = true,
     ): org.jetbrains.exposed.v1.jdbc.Database =
         connect(
-            datasource = PGSimpleDataSource().apply {
-                setUrl(config.postgres.url)
-                user = config.postgres.user
-                password = config.postgres.password
-                setProperty("reWriteBatchedInserts", "true")
-            },
-            setupConnection = {
-                // Set session time zone to UTC, to make timestamps work properly in every configuration.
-                // Note(michael-markl): I believe this is Postgres specific syntax.
-                it.prepareStatement("SET TIME ZONE 'UTC';").executeUpdate()
-            },
+            datasource = HikariDataSource(
+                HikariConfig().apply {
+                    dataSourceClassName = "org.postgresql.ds.PGSimpleDataSource"
+                    username = config.postgres.user
+                    password = config.postgres.password
+                    maximumPoolSize = 8
+                    // Lazily initialize the connection pool
+                    initializationFailTimeout = -1
+                    isAutoCommit = false
+                    maxLifetime = 1000 * 60 * 8 // 8 minutes
+                    // Set session time zone to UTC, to make timestamps work properly in every configuration.
+                    connectionInitSql = "SET TIME ZONE 'UTC'"
+                    dataSourceProperties = Properties().apply {
+                        setProperty("url", config.postgres.url)
+                        setProperty("reWriteBatchedInserts", "true")
+                    }
+                },
+            ),
             databaseConfig = DatabaseConfig.invoke {
                 // Nested transactions are helpful for applying migrations in subtransactions.
                 useNestedTransactions = true

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/db/Database.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/db/Database.kt
@@ -82,7 +82,7 @@ object Database {
                     // Lazily initialize the connection pool
                     initializationFailTimeout = -1
                     isAutoCommit = false
-                    maxLifetime = 1000 * 60 * 8 // 8 minutes
+                    maxLifetime = 1000 * 60 * 8 // 8 minutes - default psql idle timeout is 10 minutes.
                     // Set session time zone to UTC, to make timestamps work properly in every configuration.
                     connectionInitSql = "SET TIME ZONE 'UTC'"
                     dataSourceProperties = Properties().apply {


### PR DESCRIPTION
### Short Description

Our current implementation with PGSimpleDataSource opens a new physical TCP connection to PostgreSQL for every request and closes it afterwards. Under concurrent load — especially with virtual threads, which make high concurrency trivially cheap — this can quickly exhaust PostgreSQL's max_connections limit, causing the server to hang. HikariCP maintains a fixed pool of reusable connections, so requests beyond the pool size queue instead of opening new database connections. This bounds the load on PostgreSQL regardless of how many concurrent requests are in flight.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add HicariCP plugin
- adjust datasource

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Testing

N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2999
