### PR TITLE
3013: Improve notification settings

### DIFF
--- a/administration/src/routes/user-settings/components/NotificationSettings.tsx
+++ b/administration/src/routes/user-settings/components/NotificationSettings.tsx
@@ -13,11 +13,13 @@ import {
 } from '../../../graphql'
 import getQueryResult from '../../../util/getQueryResult'
 
+type NotificationState = { notificationOnApplication: boolean; notificationOnVerification: boolean }
+
 const NotificationSettings = (): ReactElement => {
   const { t } = useTranslation('userSettings')
   const { enqueueSnackbar } = useSnackbar()
-  const [pendingActivation, setPendingActivation] = useState<boolean | null>(null)
-  const [pendingVerification, setPendingVerification] = useState<boolean | null>(null)
+  const [pendingSettings, setPendingSettings] = useState<NotificationState | null>(null)
+  const [lastSaved, setLastSaved] = useState<NotificationState | null>(null)
   const [updateNotificationSettingsState, updateNotificationSettingsMutation] = useMutation(
     UpdateNotificationSettingsDocument,
   )
@@ -25,11 +27,11 @@ const NotificationSettings = (): ReactElement => {
     query: GetNotificationSettingsDocument,
   })
 
-  const savedSettings = notificationSettingsState.data?.notificationSettings
+  const baseSettings = lastSaved ?? notificationSettingsState.data?.notificationSettings
   const notificationOnApplication =
-    pendingActivation ?? savedSettings?.notificationOnApplication ?? false
+    pendingSettings?.notificationOnApplication ?? baseSettings?.notificationOnApplication ?? false
   const notificationOnVerification =
-    pendingVerification ?? savedSettings?.notificationOnVerification ?? false
+    pendingSettings?.notificationOnVerification ?? baseSettings?.notificationOnVerification ?? false
 
   const submit = async () => {
     const result = await updateNotificationSettingsMutation({
@@ -42,10 +44,11 @@ const NotificationSettings = (): ReactElement => {
     if (result.error) {
       const { title } = messageFromGraphQlError(result.error)
       enqueueSnackbar(title, { variant: 'error' })
-      setPendingActivation(null)
-      setPendingVerification(null)
+      setPendingSettings(null)
     } else {
       enqueueSnackbar(t('notificationUpdateSuccess'), { variant: 'success' })
+      setLastSaved({ notificationOnApplication, notificationOnVerification })
+      setPendingSettings(null)
     }
   }
 
@@ -69,14 +72,18 @@ const NotificationSettings = (): ReactElement => {
       >
         <BaseCheckbox
           checked={notificationOnApplication}
-          onChange={checked => setPendingActivation(checked)}
+          onChange={checked =>
+            setPendingSettings({ notificationOnApplication: checked, notificationOnVerification })
+          }
           label={<Typography>{t('newApplications')}</Typography>}
           hasError={false}
           errorMessage={undefined}
         />
         <BaseCheckbox
           checked={notificationOnVerification}
-          onChange={checked => setPendingVerification(checked)}
+          onChange={checked =>
+            setPendingSettings({ notificationOnApplication, notificationOnVerification: checked })
+          }
           label={<Typography>{t('newVerifications')}</Typography>}
           hasError={false}
           errorMessage={undefined}

--- a/administration/src/routes/user-settings/components/NotificationSettings.tsx
+++ b/administration/src/routes/user-settings/components/NotificationSettings.tsx
@@ -1,6 +1,6 @@
 import { Button, Typography } from '@mui/material'
 import { useSnackbar } from 'notistack'
-import { ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useMutation, useQuery } from 'urql'
 
@@ -16,8 +16,8 @@ import getQueryResult from '../../../util/getQueryResult'
 const NotificationSettings = (): ReactElement => {
   const { t } = useTranslation('userSettings')
   const { enqueueSnackbar } = useSnackbar()
-  const [receiveEmailForActivation, setReceiveEmailForActivation] = useState<boolean>(false)
-  const [receiveEmailForVerification, setReceiveEmailForVerification] = useState<boolean>(false)
+  const [pendingActivation, setPendingActivation] = useState<boolean | null>(null)
+  const [pendingVerification, setPendingVerification] = useState<boolean | null>(null)
   const [updateNotificationSettingsState, updateNotificationSettingsMutation] = useMutation(
     UpdateNotificationSettingsDocument,
   )
@@ -25,36 +25,29 @@ const NotificationSettings = (): ReactElement => {
     query: GetNotificationSettingsDocument,
   })
 
-  const reset = () => {
-    const state = notificationSettingsState.data?.notificationSettings
-
-    if (state) {
-      setReceiveEmailForActivation(state.notificationOnApplication)
-      setReceiveEmailForVerification(state.notificationOnVerification)
-    }
-  }
+  const savedSettings = notificationSettingsState.data?.notificationSettings
+  const notificationOnApplication =
+    pendingActivation ?? savedSettings?.notificationOnApplication ?? false
+  const notificationOnVerification =
+    pendingVerification ?? savedSettings?.notificationOnVerification ?? false
 
   const submit = async () => {
     const result = await updateNotificationSettingsMutation({
       notificationSettings: {
-        notificationOnApplication: receiveEmailForActivation,
-        notificationOnVerification: receiveEmailForVerification,
+        notificationOnApplication,
+        notificationOnVerification,
       },
     })
 
     if (result.error) {
       const { title } = messageFromGraphQlError(result.error)
       enqueueSnackbar(title, { variant: 'error' })
-      reset()
+      setPendingActivation(null)
+      setPendingVerification(null)
     } else {
       enqueueSnackbar(t('notificationUpdateSuccess'), { variant: 'success' })
     }
   }
-
-  useEffect(() => {
-    reset()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [notificationSettingsState])
 
   const notificationQueryResult = getQueryResult(
     notificationSettingsState,
@@ -75,15 +68,15 @@ const NotificationSettings = (): ReactElement => {
         }}
       >
         <BaseCheckbox
-          checked={receiveEmailForActivation}
-          onChange={checked => setReceiveEmailForActivation(checked)}
+          checked={notificationOnApplication}
+          onChange={checked => setPendingActivation(checked)}
           label={<Typography>{t('newApplications')}</Typography>}
           hasError={false}
           errorMessage={undefined}
         />
         <BaseCheckbox
-          checked={receiveEmailForVerification}
-          onChange={checked => setReceiveEmailForVerification(checked)}
+          checked={notificationOnVerification}
+          onChange={checked => setPendingVerification(checked)}
           label={<Typography>{t('newVerifications')}</Typography>}
           hasError={false}
           errorMessage={undefined}


### PR DESCRIPTION
### Short Description

I refactored the `NotificationSettings` to avoid `useEffect` that updates the state to avoid linting error

### Proposed Changes

<!-- Describe this PR in more detail. -->

- introduce null in state to reset on error, remove useEffect hook

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Testing

1. Login as a region admin/region manager for bayern
2. Click on the avatar icon in the righ upper corner
3. Go to Benutzereinstellungen
4. Select and Deselect the checkbox in "Benachrichtigungen" and Save
5. Reload the page and ensure that the your selections are saved

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3013 
