### PR TITLE
3069: Refactor `Matomo` class

### DIFF
--- a/.idea/entitlementcard.iml
+++ b/.idea/entitlementcard.iml
@@ -7,6 +7,11 @@
       <excludeFolder url="file://$MODULE_DIR$/.idea/libraries" />
       <excludeFolder url="file://$MODULE_DIR$/.idea/modules" />
       <excludeFolder url="file://$MODULE_DIR$/.idea/queries" />
+      <excludeFolder url="file://$MODULE_DIR$/backend/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/backend/.kotlin" />
+      <excludeFolder url="file://$MODULE_DIR$/backend/build" />
+      <excludeFolder url="file://$MODULE_DIR$/backend/data/applications" />
+      <excludeFolder url="file://$MODULE_DIR$/backend/logs" />
     </content>
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/.idea/runConfigurations/Generate_GraphQL_specs.xml
+++ b/.idea/runConfigurations/Generate_GraphQL_specs.xml
@@ -23,8 +23,11 @@
     </ExternalSystemSettings>
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
     <DebugAllEnabled>false</DebugAllEnabled>
     <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
     <method v="2" />
   </configuration>
 </component>

--- a/.idea/runConfigurations/Test_backend.xml
+++ b/.idea/runConfigurations/Test_backend.xml
@@ -17,8 +17,11 @@
     </ExternalSystemSettings>
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
     <DebugAllEnabled>false</DebugAllEnabled>
     <RunAsTest>true</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
     <method v="2" />
   </configuration>
 </component>

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -108,7 +108,6 @@ dependencies {
     implementation(libs.jetbrains.exposed.dao)
     implementation(libs.jetbrains.exposed.jdbc)
     implementation(libs.jetbrains.exposed.java.time)
-    implementation(libs.jetbrains.kotlin.stdlib)
     implementation(libs.jetbrains.kotlin.reflect)
     implementation(libs.jetbrains.kotlinx.coroutines.reactor)
     implementation(libs.jetbrains.kotlinx.html.jvm)

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/config/BackendConfiguration.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/config/BackendConfiguration.kt
@@ -68,14 +68,12 @@ data class BackendConfiguration(
     fun getProjectConfig(project: String): ProjectConfig =
         projects.find { it.id == project } ?: throw ProjectNotFoundException(project)
 
-    fun sanityCheckMatomoConfig(): BackendConfiguration {
-        val matomoConfig = projects.mapNotNull { it.matomo }
-        if (matomoConfig.size != matomoConfig.distinctBy { it.siteId }.count()) {
-            throw Error(
-                "There are at least two matomo configs with the same siteId. This seems to be a copy/paste error.",
-            )
+    fun sanityCheckMatomoConfig() {
+        val matomoConfigs = projects.mapNotNull { it.matomo }
+
+        if (matomoConfigs.size != matomoConfigs.distinctBy { it.siteId }.count()) {
+            throw Error("There are at least two matomo configs with the same siteId")
         }
-        return this
     }
 
     companion object {
@@ -85,12 +83,13 @@ data class BackendConfiguration(
             // Allows unknown (potentially future) config options.
             // Without this parsing a config fails if a property is defined that is missing
             // from the BackendConfiguration class. We might want to be able to load configs that contain configuration
-            // for future features, therefore we want to allow unknown properties.
+            // for future features. Therefore, we want to allow unknown properties.
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             .build()
 
         fun load(url: URL): BackendConfiguration =
-            url.openStream().use { mapper.readValue(it, BackendConfiguration::class.java) }
-                .sanityCheckMatomoConfig()
+            url.openStream().use { mapper.readValue(it, BackendConfiguration::class.java) }.also {
+                it.sanityCheckMatomoConfig()
+            }
     }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardMutationController.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardMutationController.kt
@@ -158,8 +158,9 @@ class CardMutationController(
         @GraphQLIgnore @ContextValue request: HttpServletRequest,
         dfe: DataFetchingEnvironment,
     ): CardCreationResultModel {
-        val config = backendConfiguration.getProjectConfig(project)
-        if (!config.selfServiceEnabled) {
+        val projectConfig = backendConfiguration.getProjectConfig(project)
+
+        if (!projectConfig.selfServiceEnabled) {
             throw NotImplementedException("Self-Service is not enabled in the project")
         }
 
@@ -216,8 +217,7 @@ class CardMutationController(
         }
 
         matomo.trackCreateCards(
-            backendConfiguration,
-            config,
+            projectConfig = projectConfig,
             request,
             dfe.field.name,
             userEntitlements.regionId.value,
@@ -303,8 +303,7 @@ class CardMutationController(
 
         if (regionId != null) {
             matomo.trackCreateCards(
-                backendConfiguration,
-                projectConfig,
+                projectConfig = projectConfig,
                 request,
                 dfe.field.name,
                 regionId,
@@ -384,8 +383,7 @@ class CardMutationController(
             return@t CardActivationResultModel(ActivationState.success, encodedTotpSecret)
         }
         matomo.trackActivation(
-            backendConfiguration,
-            projectConfig,
+            projectConfig = projectConfig,
             request,
             dfe.field.name,
             cardHash,

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardMutationController.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardMutationController.kt
@@ -394,7 +394,7 @@ class CardMutationController(
             request = request,
             query = dfe.field.name,
             cardEntity = cardEntity,
-            successful = activationResult.activationState == ActivationState.success,
+            cardActivationState = activationResult.activationState,
         )
 
         return activationResult

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardMutationController.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardMutationController.kt
@@ -62,6 +62,7 @@ import kotlin.io.encoding.Base64
 class CardMutationController(
     private val backendConfiguration: BackendConfiguration,
     private val mailerService: Mailer,
+    private val matomo: Matomo,
 ) {
     private val logger: Logger = LoggerFactory.getLogger(CardMutationController::class.java)
 
@@ -214,7 +215,7 @@ class CardMutationController(
             )
         }
 
-        Matomo.trackCreateCards(
+        matomo.trackCreateCards(
             backendConfiguration,
             config,
             request,
@@ -301,7 +302,7 @@ class CardMutationController(
         val regionId = authContext.admin.regionId?.value
 
         if (regionId != null) {
-            Matomo.trackCreateCards(
+            matomo.trackCreateCards(
                 backendConfiguration,
                 projectConfig,
                 request,
@@ -382,7 +383,7 @@ class CardMutationController(
             )
             return@t CardActivationResultModel(ActivationState.success, encodedTotpSecret)
         }
-        Matomo.trackActivation(
+        matomo.trackActivation(
             backendConfiguration,
             projectConfig,
             request,

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardMutationController.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardMutationController.kt
@@ -467,19 +467,16 @@ private const val cost = 10
 fun hashActivationSecret(rawActivationSecret: ByteArray): ByteArray =
     BCrypt.withDefaults().hash(cost, rawActivationSecret)
 
-@Synchronized
-private fun generateTotpSecret(): ByteArray {
-    // https://tools.ietf.org/html/rfc6238#section-3 - R3 (TOTP uses HTOP)
-    // https://tools.ietf.org/html/rfc4226#section-4 - R6 (How long should a shared secret be?
-    // -> 160bit)
-    // https://tools.ietf.org/html/rfc4226#section-7.5 - Random Generation (How to generate a
-    // secret? -> Random))))
-    val algorithm = TimeBasedOneTimePasswordGenerator.TOTP_ALGORITHM_HMAC_SHA256
-    val keyGenerator = KeyGenerator.getInstance(algorithm)
-    keyGenerator.init(TOTP_SECRET_LENGTH * 8)
-
-    return keyGenerator.generateKey().encoded
-}
+/**
+ * https://tools.ietf.org/html/rfc6238#section-3 - R3 (TOTP uses HOTP)
+ * https://tools.ietf.org/html/rfc4226#section-4 - R6 (How long should a shared secret be? -> 160bit)
+ * https://tools.ietf.org/html/rfc4226#section-7.5 - Random Generation
+ */
+private fun generateTotpSecret(): ByteArray =
+    KeyGenerator.getInstance(TimeBasedOneTimePasswordGenerator.TOTP_ALGORITHM_HMAC_SHA256).run {
+        init(TOTP_SECRET_LENGTH * 8)
+        generateKey().encoded
+    }
 
 private fun verifyActivationSecret(rawActivationSecret: ByteArray, activationSecretHash: ByteArray): Boolean =
     BCrypt.verifyer().verify(rawActivationSecret, activationSecretHash).verified

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardMutationController.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardMutationController.kt
@@ -331,64 +331,72 @@ class CardMutationController(
         val rawActivationSecret = Base64.decode(activationSecretBase64)
 
         // Avoid race conditions when activating a card.
-        val activationResult = transaction(transactionIsolation = TRANSACTION_REPEATABLE_READ) t@{
+        val (cardEntity, activationResult) = transaction(transactionIsolation = TRANSACTION_REPEATABLE_READ) {
             this.maxAttempts = 1
 
-            val card = CardRepository.findByHash(project, cardHash)
-            val activationSecretHash = card?.activationSecretHash
+            val cardEntity = CardRepository.findByHash(project, cardHash)
+            val activationSecretHash = cardEntity?.activationSecretHash
 
-            if (card == null || activationSecretHash == null) {
-                logger.info(
-                    "$remoteIp failed to activate card, card not found with cardHash:$cardInfoHashBase64",
-                )
-                return@t CardActivationResultModel(ActivationState.not_found)
+            when {
+                cardEntity == null || activationSecretHash == null -> {
+                    logger.info(
+                        "$remoteIp failed to activate card, card not found with cardHash:$cardInfoHashBase64",
+                    )
+                    Pair(cardEntity, CardActivationResultModel(ActivationState.not_found))
+                }
+
+                !verifyActivationSecret(rawActivationSecret, activationSecretHash) -> {
+                    logger.info(
+                        "$remoteIp failed to activate card with id:${cardEntity.id} and overwrite: $overwrite",
+                    )
+                    Pair(cardEntity, CardActivationResultModel(ActivationState.wrong_secret))
+                }
+
+                CardVerifier.isExpired(cardEntity.expirationDay, projectConfig.timezone) -> {
+                    logger.info(
+                        "$remoteIp failed to activate card with id:${cardEntity.id} and overwrite: " +
+                            "$overwrite because card is expired",
+                    )
+                    Pair(cardEntity, CardActivationResultModel(ActivationState.expired))
+                }
+
+                cardEntity.revoked -> {
+                    logger.info(
+                        "$remoteIp failed to activate card with id:${cardEntity.id} and overwrite: " +
+                            "$overwrite because card is revoked",
+                    )
+                    Pair(cardEntity, CardActivationResultModel(ActivationState.revoked))
+                }
+
+                !overwrite && cardEntity.totpSecret != null -> {
+                    logger.info(
+                        "Card with id:${cardEntity.id} did not overwrite card from $remoteIp",
+                    )
+                    Pair(cardEntity, CardActivationResultModel(ActivationState.did_not_overwrite_existing))
+                }
+
+                else -> {
+                    val totpSecret = generateTotpSecret()
+                    val encodedTotpSecret = Base64.encode(totpSecret)
+
+                    CardRepository.activate(cardEntity, totpSecret)
+
+                    logger.info(
+                        "Card with id:${cardEntity.id} and overwrite: $overwrite was activated from $remoteIp",
+                    )
+                    Pair(cardEntity, CardActivationResultModel(ActivationState.success, encodedTotpSecret))
+                }
             }
-
-            if (!verifyActivationSecret(rawActivationSecret, activationSecretHash)) {
-                logger.info(
-                    "$remoteIp failed to activate card with id:${card.id} and overwrite: $overwrite",
-                )
-                return@t CardActivationResultModel(ActivationState.wrong_secret)
-            }
-
-            if (CardVerifier.isExpired(card.expirationDay, projectConfig.timezone)) {
-                logger.info(
-                    "$remoteIp failed to activate card with id:${card.id} and overwrite: " +
-                        "$overwrite because card is expired",
-                )
-                return@t CardActivationResultModel(ActivationState.expired)
-            }
-
-            if (card.revoked) {
-                logger.info(
-                    "$remoteIp failed to activate card with id:${card.id} and overwrite: " +
-                        "$overwrite because card is revoked",
-                )
-                return@t CardActivationResultModel(ActivationState.revoked)
-            }
-
-            if (!overwrite && card.totpSecret != null) {
-                logger.info(
-                    "Card with id:${card.id} did not overwrite card from $remoteIp",
-                )
-                return@t CardActivationResultModel(ActivationState.did_not_overwrite_existing)
-            }
-
-            val totpSecret = generateTotpSecret()
-            val encodedTotpSecret = Base64.encode(totpSecret)
-            CardRepository.activate(card, totpSecret)
-            logger.info(
-                "Card with id:${card.id} and overwrite: $overwrite was activated from $remoteIp",
-            )
-            return@t CardActivationResultModel(ActivationState.success, encodedTotpSecret)
         }
+
         matomo.trackActivation(
             projectConfig = projectConfig,
-            request,
-            dfe.field.name,
-            cardHash,
-            activationResult.activationState == ActivationState.success,
+            request = request,
+            query = dfe.field.name,
+            cardEntity = cardEntity,
+            successful = activationResult.activationState == ActivationState.success,
         )
+
         return activationResult
     }
 

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardQueryController.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardQueryController.kt
@@ -2,6 +2,7 @@ package app.ehrenamtskarte.backend.graphql.cards
 
 import app.ehrenamtskarte.backend.config.BackendConfiguration
 import app.ehrenamtskarte.backend.db.entities.CodeType
+import app.ehrenamtskarte.backend.db.repositories.CardRepository
 import app.ehrenamtskarte.backend.graphql.cards.types.CardVerificationModel
 import app.ehrenamtskarte.backend.graphql.cards.types.CardVerificationResultModel
 import app.ehrenamtskarte.backend.graphql.cards.utils.CardVerifier
@@ -10,6 +11,7 @@ import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.generator.annotations.GraphQLIgnore
 import graphql.schema.DataFetchingEnvironment
 import jakarta.servlet.http.HttpServletRequest
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.springframework.graphql.data.method.annotation.Argument
 import org.springframework.graphql.data.method.annotation.ContextValue
 import org.springframework.graphql.data.method.annotation.QueryMapping
@@ -33,16 +35,16 @@ class CardQueryController(
     ): CardVerificationResultModel {
         val projectConfig = backendConfiguration.getProjectConfig(project)
         val cardHash = Base64.getDecoder().decode(card.cardInfoHashBase64)
-
+        val cardEntity = transaction { CardRepository.findByHash(projectConfig.id, cardHash) }
         val isValid = when (card.codeType) {
             CodeType.STATIC ->
                 card.totp == null &&
                     CardVerifier.verifyStaticCard(project, cardHash, projectConfig.timezone)
+
             CodeType.DYNAMIC ->
                 card.totp != null &&
                     CardVerifier.verifyDynamicCard(project, cardHash, card.totp, projectConfig.timezone)
         }
-
         val verificationResult = CardVerificationResultModel(
             isValid,
             CardVerifier.isExtendable(project, cardHash),
@@ -50,12 +52,13 @@ class CardQueryController(
 
         matomo.trackVerification(
             projectConfig = projectConfig,
-            request,
-            dfe.field.name,
-            cardHash,
-            card.codeType,
-            verificationResult.valid,
+            request = request,
+            query = dfe.field.name,
+            card = cardEntity,
+            codeType = card.codeType,
+            successful = verificationResult.valid,
         )
+
         return verificationResult
     }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardQueryController.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardQueryController.kt
@@ -38,12 +38,14 @@ class CardQueryController(
         val cardEntity = transaction { CardRepository.findByHash(projectConfig.id, cardHash) }
         val isValid = when (card.codeType) {
             CodeType.STATIC ->
-                card.totp == null &&
-                    CardVerifier.verifyStaticCard(project, cardHash, projectConfig.timezone)
+                cardEntity != null &&
+                    card.totp == null &&
+                    CardVerifier.verifyStaticCard(cardEntity, projectConfig.timezone)
 
             CodeType.DYNAMIC ->
-                card.totp != null &&
-                    CardVerifier.verifyDynamicCard(project, cardHash, card.totp, projectConfig.timezone)
+                cardEntity != null &&
+                    card.totp != null &&
+                    CardVerifier.verifyDynamicCard(cardEntity, card.totp, projectConfig.timezone)
         }
         val verificationResult = CardVerificationResultModel(
             isValid,

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardQueryController.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardQueryController.kt
@@ -19,6 +19,7 @@ import java.util.Base64
 @Controller
 class CardQueryController(
     private val backendConfiguration: BackendConfiguration,
+    private val matomo: Matomo,
 ) {
     @GraphQLDescription(
         "Returns whether there is a card in the given project with that hash registered for that this TOTP is currently valid, extendable and a timestamp of the last check",
@@ -47,7 +48,7 @@ class CardQueryController(
             CardVerifier.isExtendable(project, cardHash),
         )
 
-        Matomo.trackVerification(
+        matomo.trackVerification(
             backendConfiguration,
             projectConfig,
             request,

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardQueryController.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/CardQueryController.kt
@@ -49,8 +49,7 @@ class CardQueryController(
         )
 
         matomo.trackVerification(
-            backendConfiguration,
-            projectConfig,
+            projectConfig = projectConfig,
             request,
             dfe.field.name,
             cardHash,

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/utils/CardVerifier.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/cards/utils/CardVerifier.kt
@@ -1,5 +1,6 @@
 package app.ehrenamtskarte.backend.graphql.cards.utils
 
+import app.ehrenamtskarte.backend.db.entities.CardEntity
 import app.ehrenamtskarte.backend.db.entities.UserEntitlementsEntity
 import app.ehrenamtskarte.backend.db.repositories.CardRepository
 import com.eatthepath.otp.TimeBasedOneTimePasswordGenerator
@@ -16,20 +17,16 @@ val TIME_STEP: Duration = Duration.ofSeconds(30)
 const val TOTP_LENGTH = 6
 
 object CardVerifier {
-    fun verifyStaticCard(project: String, cardHash: ByteArray, timezone: ZoneId): Boolean {
-        val card = transaction { CardRepository.findByHash(project, cardHash) } ?: return false
-        return !isExpired(card.expirationDay, timezone) &&
-            isYetValid(card.startDay, timezone) &&
-            !card.revoked
-    }
+    fun verifyStaticCard(cardEntity: CardEntity, timezone: ZoneId): Boolean =
+        !isExpired(cardEntity.expirationDay, timezone) &&
+            isYetValid(cardEntity.startDay, timezone) &&
+            !cardEntity.revoked
 
-    fun verifyDynamicCard(project: String, cardHash: ByteArray, totp: Int, timezone: ZoneId): Boolean {
-        val card = transaction { CardRepository.findByHash(project, cardHash) } ?: return false
-        return !isExpired(card.expirationDay, timezone) &&
-            isYetValid(card.startDay, timezone) &&
-            !card.revoked &&
-            isTotpValid(totp, card.totpSecret)
-    }
+    fun verifyDynamicCard(cardEntity: CardEntity, totp: Int, timezone: ZoneId): Boolean =
+        !isExpired(cardEntity.expirationDay, timezone) &&
+            isYetValid(cardEntity.startDay, timezone) &&
+            !cardEntity.revoked &&
+            isTotpValid(totp, cardEntity.totpSecret)
 
     fun isExpired(expirationDay: Long?, timezone: ZoneId): Boolean =
         expirationDay != null && !isOnOrBeforeToday(daysSinceEpochToDate(expirationDay), timezone)

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/stores/AcceptingStoreQueryController.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/stores/AcceptingStoreQueryController.kt
@@ -86,7 +86,6 @@ class AcceptingStoreQueryController(
                 .map { AcceptingStore.fromDbEntity(it) }
         }
         matomo.trackSearch(
-            config = backendConfig,
             projectConfig = projectConfig,
             request = request,
             query = dfe.field.name,
@@ -119,7 +118,6 @@ class AcceptingStoreQueryController(
                 .map { AcceptingStoreV2.fromDbEntity(it) }
         }
         matomo.trackSearch(
-            config = backendConfig,
             projectConfig = projectConfig,
             request = request,
             query = dfe.field.name,

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/stores/AcceptingStoreQueryController.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/stores/AcceptingStoreQueryController.kt
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Controller
 @Controller
 class AcceptingStoreQueryController(
     private val backendConfig: BackendConfiguration,
+    private val matomo: Matomo,
 ) {
     @Deprecated(
         "Use acceptingStoresByPhysicalStoreIdsInProject query for localized descriptions. Can be safely removed in January 2028.",
@@ -84,7 +85,7 @@ class AcceptingStoreQueryController(
             ).with(AcceptingStoreEntity::descriptions)
                 .map { AcceptingStore.fromDbEntity(it) }
         }
-        Matomo.trackSearch(
+        matomo.trackSearch(
             config = backendConfig,
             projectConfig = projectConfig,
             request = request,
@@ -117,7 +118,7 @@ class AcceptingStoreQueryController(
             ).with(AcceptingStoreEntity::descriptions)
                 .map { AcceptingStoreV2.fromDbEntity(it) }
         }
-        Matomo.trackSearch(
+        matomo.trackSearch(
             config = backendConfig,
             projectConfig = projectConfig,
             request = request,

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
@@ -18,8 +18,8 @@ import java.net.URI
 
 enum class MatomoEventCategory(val value: String) {
     ACTIVATION("activation"),
-    DYNAMIC(CodeType.DYNAMIC.name),
-    STATIC(CodeType.STATIC.name),
+    DYNAMIC("DYNAMIC"),
+    STATIC("STATIC"),
 }
 
 enum class MatomoEventName(val value: String) {

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
@@ -4,6 +4,7 @@ import app.ehrenamtskarte.backend.config.BackendConfiguration
 import app.ehrenamtskarte.backend.config.ProjectConfig
 import app.ehrenamtskarte.backend.db.entities.CardEntity
 import app.ehrenamtskarte.backend.db.entities.CodeType
+import app.ehrenamtskarte.backend.graphql.cards.types.ActivationState
 import app.ehrenamtskarte.backend.graphql.stores.types.SearchParams
 import jakarta.servlet.http.HttpServletRequest
 import org.matomo.java.tracking.MatomoException
@@ -106,7 +107,7 @@ class Matomo(
         request: HttpServletRequest,
         query: String,
         cardEntity: CardEntity?,
-        successful: Boolean,
+        cardActivationState: ActivationState,
     ) {
         sendTrackingRequests(
             projectConfig = projectConfig,
@@ -116,13 +117,13 @@ class Matomo(
                     .eventAction(query)
                     .eventCategory(MatomoEventCategory.ACTIVATION.value)
                     .eventName(
-                        if (successful) {
+                        if (cardActivationState == ActivationState.success) {
                             MatomoEventName.ACTIVATION_SUCCESSFUL.value
                         } else {
                             MatomoEventName.ACTIVATION_FAILED.value
                         },
                     )
-                    .eventValue(if (successful) 1.0 else 0.0)
+                    .eventValue(if (cardActivationState == ActivationState.success) 1.0 else 0.0)
                     .dimensions(if (cardEntity != null) mapOf(1L to cardEntity.regionId) else emptyMap()),
             ),
         )

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
@@ -1,7 +1,6 @@
 package app.ehrenamtskarte.backend.shared
 
 import app.ehrenamtskarte.backend.config.BackendConfiguration
-import app.ehrenamtskarte.backend.config.MatomoConfig
 import app.ehrenamtskarte.backend.config.ProjectConfig
 import app.ehrenamtskarte.backend.db.entities.CodeType
 import app.ehrenamtskarte.backend.db.repositories.CardRepository
@@ -38,66 +37,60 @@ class Matomo(
     config: BackendConfiguration,
 ) {
     private val logger = LoggerFactory.getLogger(Matomo::class.java)
-    private var tracker: MatomoTracker? = null
+    private var tracker: MatomoTracker = MatomoTracker(
+        TrackerConfiguration.builder().apiEndpoint(URI.create(config.matomoUrl)).build(),
+    )
 
-    private fun getTracker(config: BackendConfiguration): MatomoTracker {
-        val tracker = tracker
-        if (tracker == null) {
-            val newTracker = MatomoTracker(
-                TrackerConfiguration.builder().apiEndpoint(URI.create(config.matomoUrl)).build(),
-            )
-            this.tracker = newTracker
-            return newTracker
-        }
-
-        return tracker
-    }
-
-    private fun sendTrackingRequest(
-        config: BackendConfiguration,
-        matomoConfig: MatomoConfig,
-        requestBuilder: MatomoRequest.MatomoRequestBuilder,
-    ) {
+    private fun sendTrackingRequest(projectConfig: ProjectConfig, requestBuilder: MatomoRequest.MatomoRequestBuilder) {
         CoroutineScope(Dispatchers.IO).launch {
-            val siteId = matomoConfig.siteId
-            val tracker = getTracker(config)
+            projectConfig.matomo?.let { matomoConfig ->
+                val matomoRequest = requestBuilder
+                    .siteId(matomoConfig.siteId)
+                    .authToken(matomoConfig.accessToken)
+                    .build()
 
-            val matomoRequest = requestBuilder
-                .siteId(siteId)
-                .authToken(matomoConfig.accessToken)
-                .build()
+                try {
+                    tracker.sendRequestAsync(matomoRequest)
+                } catch (e: Exception) {
+                    when (e) {
+                        is IOException -> {
+                            logger.error("Could not send request to Matomo")
+                        }
 
-            try {
-                // Will log errors using its own logger
-                tracker.sendRequestAsync(matomoRequest)
-            } catch (_: IOException) {
-                logger.error("Could not send request to Matomo")
-            } catch (e: Exception) {
-                logger.error("Unexpected error while sending Matomo request", e)
+                        is ExecutionException, is InterruptedException -> {
+                            logger.error("Error while getting response", e)
+                        }
+                    }
+                }
             }
         }
     }
 
     private fun sendBulkTrackingRequest(
-        config: BackendConfiguration,
-        matomoConfig: MatomoConfig,
+        projectConfig: ProjectConfig,
         requestBuilder: Iterable<MatomoRequest.MatomoRequestBuilder>,
     ) {
         CoroutineScope(Dispatchers.IO).launch {
-            val siteId = matomoConfig.siteId
-            val tracker = getTracker(config)
-            val matomoRequests = requestBuilder.map {
-                it.siteId(siteId)
-                it.authToken(matomoConfig.accessToken)
-                it.build()
-            }
-            try {
-                // will log errors using it's own logger
-                tracker.sendBulkRequestAsync(matomoRequests)
-            } catch (_: IOException) {
-                logger.error("Could not send request to Matomo")
-            } catch (e: Exception) {
-                logger.error("Unexpected error while sending Matomo request", e)
+            projectConfig.matomo?.let { matomoConfig ->
+                val siteId = matomoConfig.siteId
+                val matomoRequests = requestBuilder.map {
+                    it.siteId(siteId)
+                    it.authToken(matomoConfig.accessToken)
+                    it.build()
+                }
+                try {
+                    tracker.sendBulkRequestAsync(matomoRequests)
+                } catch (e: Exception) {
+                    when (e) {
+                        is IOException -> {
+                            logger.debug("Could not send request to Matomo")
+                        }
+
+                        is ExecutionException, is InterruptedException -> {
+                            logger.debug("Error while getting response")
+                        }
+                    }
+                }
             }
         }
     }
@@ -130,7 +123,6 @@ class Matomo(
             .also { attachRequestInformation(it, request) }
 
     fun trackCreateCards(
-        config: BackendConfiguration,
         projectConfig: ProjectConfig,
         request: HttpServletRequest,
         query: String,
@@ -138,12 +130,9 @@ class Matomo(
         numberOfDynamicCards: Int,
         numberOfStaticCards: Int,
     ) {
-        if (projectConfig.matomo == null) return
-
         if (numberOfDynamicCards > 0 && numberOfStaticCards > 0) {
             sendBulkTrackingRequest(
-                config,
-                projectConfig.matomo,
+                projectConfig = projectConfig,
                 listOf(
                     buildCardsTrackingRequest(
                         request,
@@ -163,8 +152,7 @@ class Matomo(
             )
         } else if (numberOfDynamicCards > 0) {
             sendTrackingRequest(
-                config,
-                projectConfig.matomo,
+                projectConfig = projectConfig,
                 buildCardsTrackingRequest(
                     request,
                     regionId,
@@ -177,7 +165,6 @@ class Matomo(
     }
 
     fun trackVerification(
-        config: BackendConfiguration,
         projectConfig: ProjectConfig,
         request: HttpServletRequest,
         query: String,
@@ -185,11 +172,10 @@ class Matomo(
         codeType: CodeType,
         successful: Boolean,
     ) {
-        if (projectConfig.matomo === null) return
         val card = transaction { CardRepository.findByHash(projectConfig.id, cardHash) }
+
         sendTrackingRequest(
-            config,
-            projectConfig.matomo,
+            projectConfig = projectConfig,
             MatomoRequest.request()
                 .eventAction(query)
                 .eventCategory(MatomoEventCategory.valueOf(codeType.name).value)
@@ -206,18 +192,16 @@ class Matomo(
     }
 
     fun trackActivation(
-        config: BackendConfiguration,
         projectConfig: ProjectConfig,
         request: HttpServletRequest,
         query: String,
         cardHash: ByteArray,
         successful: Boolean,
     ) {
-        if (projectConfig.matomo === null) return
         val card = transaction { CardRepository.findByHash(projectConfig.id, cardHash) }
+
         sendTrackingRequest(
-            config,
-            projectConfig.matomo,
+            projectConfig = projectConfig,
             MatomoRequest.request()
                 .eventAction(query)
                 .eventCategory(MatomoEventCategory.ACTIVATION.value)
@@ -235,18 +219,16 @@ class Matomo(
     }
 
     fun trackSearch(
-        config: BackendConfiguration,
         projectConfig: ProjectConfig,
         request: HttpServletRequest,
         query: String,
         params: SearchParams,
         numResults: Int,
     ) {
-        if (projectConfig.matomo === null) return
         if (params.searchText === null && params.categoryIds === null) return
+
         sendTrackingRequest(
-            config,
-            projectConfig.matomo,
+            projectConfig = projectConfig,
             MatomoRequest.request()
                 .actionName(query)
                 .searchCategory(params.categoryIds?.joinToString(","))

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
@@ -2,11 +2,11 @@ package app.ehrenamtskarte.backend.shared
 
 import app.ehrenamtskarte.backend.config.BackendConfiguration
 import app.ehrenamtskarte.backend.config.ProjectConfig
+import app.ehrenamtskarte.backend.db.entities.CardEntity
 import app.ehrenamtskarte.backend.db.entities.CodeType
-import app.ehrenamtskarte.backend.db.repositories.CardRepository
 import app.ehrenamtskarte.backend.graphql.stores.types.SearchParams
 import jakarta.servlet.http.HttpServletRequest
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.matomo.java.tracking.MatomoException
 import org.matomo.java.tracking.MatomoRequest
 import org.matomo.java.tracking.MatomoTracker
 import org.matomo.java.tracking.TrackerConfiguration
@@ -78,12 +78,10 @@ class Matomo(
         projectConfig: ProjectConfig,
         request: HttpServletRequest,
         query: String,
-        cardHash: ByteArray,
+        card: CardEntity?,
         codeType: CodeType,
         successful: Boolean,
     ) {
-        val card = transaction { CardRepository.findByHash(projectConfig.id, cardHash) }
-
         sendTrackingRequests(
             projectConfig = projectConfig,
             httpRequest = request,
@@ -107,11 +105,9 @@ class Matomo(
         projectConfig: ProjectConfig,
         request: HttpServletRequest,
         query: String,
-        cardHash: ByteArray,
+        cardEntity: CardEntity?,
         successful: Boolean,
     ) {
-        val card = transaction { CardRepository.findByHash(projectConfig.id, cardHash) }
-
         sendTrackingRequests(
             projectConfig = projectConfig,
             httpRequest = request,
@@ -127,7 +123,7 @@ class Matomo(
                         },
                     )
                     .eventValue(if (successful) 1.0 else 0.0)
-                    .dimensions(if (card != null) mapOf(1L to card.regionId) else emptyMap()),
+                    .dimensions(if (cardEntity != null) mapOf(1L to cardEntity.regionId) else emptyMap()),
             ),
         )
     }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
@@ -41,87 +41,6 @@ class Matomo(
         TrackerConfiguration.builder().apiEndpoint(URI.create(config.matomoUrl)).build(),
     )
 
-    private fun sendTrackingRequest(projectConfig: ProjectConfig, requestBuilder: MatomoRequest.MatomoRequestBuilder) {
-        CoroutineScope(Dispatchers.IO).launch {
-            projectConfig.matomo?.let { matomoConfig ->
-                val matomoRequest = requestBuilder
-                    .siteId(matomoConfig.siteId)
-                    .authToken(matomoConfig.accessToken)
-                    .build()
-
-                try {
-                    tracker.sendRequestAsync(matomoRequest)
-                } catch (e: Exception) {
-                    when (e) {
-                        is IOException -> {
-                            logger.error("Could not send request to Matomo")
-                        }
-
-                        is ExecutionException, is InterruptedException -> {
-                            logger.error("Error while getting response", e)
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private fun sendBulkTrackingRequest(
-        projectConfig: ProjectConfig,
-        requestBuilder: Iterable<MatomoRequest.MatomoRequestBuilder>,
-    ) {
-        CoroutineScope(Dispatchers.IO).launch {
-            projectConfig.matomo?.let { matomoConfig ->
-                val siteId = matomoConfig.siteId
-                val matomoRequests = requestBuilder.map {
-                    it.siteId(siteId)
-                    it.authToken(matomoConfig.accessToken)
-                    it.build()
-                }
-                try {
-                    tracker.sendBulkRequestAsync(matomoRequests)
-                } catch (e: Exception) {
-                    when (e) {
-                        is IOException -> {
-                            logger.debug("Could not send request to Matomo")
-                        }
-
-                        is ExecutionException, is InterruptedException -> {
-                            logger.debug("Error while getting response")
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private fun attachRequestInformation(
-        builder: MatomoRequest.MatomoRequestBuilder,
-        request: HttpServletRequest,
-    ): MatomoRequest.MatomoRequestBuilder {
-        val userAgent = request.getHeader("User-Agent")
-        val acceptLanguage = request.getHeader("Accept-Language")
-        return builder
-            .headerAcceptLanguage(AcceptLanguage.fromHeader(acceptLanguage))
-            .headerUserAgent(userAgent)
-            .visitorIp(request.remoteAddr)
-    }
-
-    private fun buildCardsTrackingRequest(
-        request: HttpServletRequest,
-        regionId: Int,
-        query: String,
-        codeType: CodeType,
-        numberOfCards: Int,
-    ): MatomoRequest.MatomoRequestBuilder =
-        MatomoRequest.request()
-            .eventAction(query)
-            .eventCategory(MatomoEventCategory.valueOf(codeType.name).value)
-            .eventName(MatomoEventName.CARD_CREATION_SUCCESSFUL.value)
-            .eventValue(numberOfCards.toDouble())
-            .dimensions(mapOf(1L to regionId))
-            .also { attachRequestInformation(it, request) }
-
     fun trackCreateCards(
         projectConfig: ProjectConfig,
         request: HttpServletRequest,
@@ -130,38 +49,32 @@ class Matomo(
         numberOfDynamicCards: Int,
         numberOfStaticCards: Int,
     ) {
-        if (numberOfDynamicCards > 0 && numberOfStaticCards > 0) {
-            sendBulkTrackingRequest(
-                projectConfig = projectConfig,
-                listOf(
-                    buildCardsTrackingRequest(
-                        request,
-                        regionId,
-                        query,
-                        CodeType.STATIC,
-                        numberOfStaticCards,
-                    ),
-                    buildCardsTrackingRequest(
-                        request,
-                        regionId,
-                        query,
-                        CodeType.DYNAMIC,
-                        numberOfDynamicCards,
-                    ),
-                ),
-            )
-        } else if (numberOfDynamicCards > 0) {
-            sendTrackingRequest(
-                projectConfig = projectConfig,
-                buildCardsTrackingRequest(
-                    request,
-                    regionId,
-                    query,
-                    CodeType.DYNAMIC,
-                    numberOfDynamicCards,
-                ),
-            )
-        }
+        sendTrackingRequests(
+            projectConfig = projectConfig,
+            httpRequest = request,
+            requestBuilders = listOfNotNull(
+                if (numberOfStaticCards > 0) {
+                    MatomoRequest.request()
+                        .eventAction(query)
+                        .eventCategory(MatomoEventCategory.valueOf(CodeType.STATIC.name).value)
+                        .eventName(MatomoEventName.CARD_CREATION_SUCCESSFUL.value)
+                        .eventValue(numberOfStaticCards.toDouble())
+                        .dimensions(mapOf(1L to regionId))
+                } else {
+                    null
+                },
+                if (numberOfDynamicCards > 0) {
+                    MatomoRequest.request()
+                        .eventAction(query)
+                        .eventCategory(MatomoEventCategory.valueOf(CodeType.DYNAMIC.name).value)
+                        .eventName(MatomoEventName.CARD_CREATION_SUCCESSFUL.value)
+                        .eventValue(numberOfDynamicCards.toDouble())
+                        .dimensions(mapOf(1L to regionId))
+                } else {
+                    null
+                },
+            ),
+        )
     }
 
     fun trackVerification(
@@ -174,20 +87,22 @@ class Matomo(
     ) {
         val card = transaction { CardRepository.findByHash(projectConfig.id, cardHash) }
 
-        sendTrackingRequest(
+        sendTrackingRequests(
             projectConfig = projectConfig,
-            MatomoRequest.request()
-                .eventAction(query)
-                .eventCategory(MatomoEventCategory.valueOf(codeType.name).value)
-                .eventName(
-                    if (successful) {
-                        MatomoEventName.VERIFICATION_SUCCESSFUL.value
-                    } else {
-                        MatomoEventName.VERIFICATION_FAILED.value
-                    },
-                )
-                .dimensions(if (card != null) mapOf(1L to card.regionId) else emptyMap())
-                .also { attachRequestInformation(it, request) },
+            httpRequest = request,
+            requestBuilders = listOf(
+                MatomoRequest.request()
+                    .eventAction(query)
+                    .eventCategory(MatomoEventCategory.valueOf(codeType.name).value)
+                    .eventName(
+                        if (successful) {
+                            MatomoEventName.VERIFICATION_SUCCESSFUL.value
+                        } else {
+                            MatomoEventName.VERIFICATION_FAILED.value
+                        },
+                    )
+                    .dimensions(if (card != null) mapOf(1L to card.regionId) else emptyMap()),
+            ),
         )
     }
 
@@ -200,21 +115,23 @@ class Matomo(
     ) {
         val card = transaction { CardRepository.findByHash(projectConfig.id, cardHash) }
 
-        sendTrackingRequest(
+        sendTrackingRequests(
             projectConfig = projectConfig,
-            MatomoRequest.request()
-                .eventAction(query)
-                .eventCategory(MatomoEventCategory.ACTIVATION.value)
-                .eventName(
-                    if (successful) {
-                        MatomoEventName.ACTIVATION_SUCCESSFUL.value
-                    } else {
-                        MatomoEventName.ACTIVATION_FAILED.value
-                    },
-                )
-                .eventValue(if (successful) 1.0 else 0.0)
-                .dimensions(if (card != null) mapOf(1L to card.regionId) else emptyMap())
-                .also { attachRequestInformation(it, request) },
+            httpRequest = request,
+            requestBuilders = listOf(
+                MatomoRequest.request()
+                    .eventAction(query)
+                    .eventCategory(MatomoEventCategory.ACTIVATION.value)
+                    .eventName(
+                        if (successful) {
+                            MatomoEventName.ACTIVATION_SUCCESSFUL.value
+                        } else {
+                            MatomoEventName.ACTIVATION_FAILED.value
+                        },
+                    )
+                    .eventValue(if (successful) 1.0 else 0.0)
+                    .dimensions(if (card != null) mapOf(1L to card.regionId) else emptyMap()),
+            ),
         )
     }
 
@@ -225,16 +142,55 @@ class Matomo(
         params: SearchParams,
         numResults: Int,
     ) {
-        if (params.searchText === null && params.categoryIds === null) return
+        if (params.searchText != null || params.categoryIds != null) {
+            sendTrackingRequests(
+                projectConfig = projectConfig,
+                httpRequest = request,
+                requestBuilders = listOf(
+                    MatomoRequest.request()
+                        .actionName(query)
+                        .searchCategory(params.categoryIds?.joinToString(","))
+                        .searchQuery(params.searchText ?: "")
+                        .searchResultsCount(numResults.toLong()),
+                ),
+            )
+        }
+    }
 
-        sendTrackingRequest(
-            projectConfig = projectConfig,
-            MatomoRequest.request()
-                .actionName(query)
-                .searchCategory(params.categoryIds?.joinToString(","))
-                .searchQuery(params.searchText ?: "")
-                .searchResultsCount(numResults.toLong())
-                .also { attachRequestInformation(it, request) },
-        )
+    private fun sendTrackingRequests(
+        projectConfig: ProjectConfig,
+        httpRequest: HttpServletRequest,
+        requestBuilders: List<MatomoRequest.MatomoRequestBuilder>,
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            projectConfig.matomo?.let { matomoConfig ->
+                try {
+                    if (requestBuilders.isNotEmpty()) {
+                        tracker.sendBulkRequestAsync(
+                            requestBuilders.map {
+                                it.siteId(matomoConfig.siteId)
+                                it.authToken(matomoConfig.accessToken)
+                                it.headerAcceptLanguage(AcceptLanguage.fromHeader(httpRequest.getHeader("Accept-Language")))
+                                it.headerUserAgent(httpRequest.getHeader("User-Agent"))
+                                it.visitorIp(httpRequest.remoteAddr)
+                                it.build()
+                            },
+                        )
+                    }
+                } catch (e: Exception) {
+                    when (e) {
+                        is IOException -> {
+                            logger.error("Could not send request to Matomo")
+                        }
+
+                            else -> {
+                                logger.error("Unexpected error while sending request to Matomo $exception")
+                            }
+                        }
+                        null
+                    }
+                }
+            }
+        }
     }
 }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
@@ -6,9 +6,6 @@ import app.ehrenamtskarte.backend.db.entities.CodeType
 import app.ehrenamtskarte.backend.db.repositories.CardRepository
 import app.ehrenamtskarte.backend.graphql.stores.types.SearchParams
 import jakarta.servlet.http.HttpServletRequest
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.matomo.java.tracking.MatomoRequest
 import org.matomo.java.tracking.MatomoTracker
@@ -162,26 +159,24 @@ class Matomo(
         httpRequest: HttpServletRequest,
         requestBuilders: List<MatomoRequest.MatomoRequestBuilder>,
     ) {
-        CoroutineScope(Dispatchers.IO).launch {
-            projectConfig.matomo?.let { matomoConfig ->
+        projectConfig.matomo?.let { matomoConfig ->
+            if (requestBuilders.isNotEmpty()) {
+                // Also catch synchronous exceptions
                 try {
-                    if (requestBuilders.isNotEmpty()) {
-                        tracker.sendBulkRequestAsync(
-                            requestBuilders.map {
-                                it.siteId(matomoConfig.siteId)
-                                it.authToken(matomoConfig.accessToken)
-                                it.headerAcceptLanguage(AcceptLanguage.fromHeader(httpRequest.getHeader("Accept-Language")))
-                                it.headerUserAgent(httpRequest.getHeader("User-Agent"))
-                                it.visitorIp(httpRequest.remoteAddr)
-                                it.build()
-                            },
-                        )
-                    }
-                } catch (e: Exception) {
-                    when (e) {
-                        is IOException -> {
-                            logger.error("Could not send request to Matomo")
-                        }
+                    tracker.sendBulkRequestAsync(
+                        requestBuilders.map {
+                            it.siteId(matomoConfig.siteId)
+                            it.authToken(matomoConfig.accessToken)
+                            it.headerAcceptLanguage(AcceptLanguage.fromHeader(httpRequest.getHeader("Accept-Language")))
+                            it.headerUserAgent(httpRequest.getHeader("User-Agent"))
+                            it.visitorIp(httpRequest.remoteAddr)
+                            it.build()
+                        },
+                    ).exceptionally { exception ->
+                        when (exception) {
+                            is MatomoException -> {
+                                logger.error("Could not send request to Matomo $exception")
+                            }
 
                             else -> {
                                 logger.error("Unexpected error while sending request to Matomo $exception")
@@ -189,6 +184,8 @@ class Matomo(
                         }
                         null
                     }
+                } catch (e: Throwable) {
+                    logger.error("Error while sending tracking request: $e")
                 }
             }
         }

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
@@ -1,6 +1,7 @@
 package app.ehrenamtskarte.backend.shared
 
 import app.ehrenamtskarte.backend.config.BackendConfiguration
+import app.ehrenamtskarte.backend.config.MatomoConfig
 import app.ehrenamtskarte.backend.config.ProjectConfig
 import app.ehrenamtskarte.backend.db.entities.CardEntity
 import app.ehrenamtskarte.backend.db.entities.CodeType
@@ -47,32 +48,38 @@ class Matomo(
         numberOfDynamicCards: Int,
         numberOfStaticCards: Int,
     ) {
-        sendTrackingRequests(
-            projectConfig = projectConfig,
-            httpRequest = request,
-            requestBuilders = listOfNotNull(
-                if (numberOfStaticCards > 0) {
-                    MatomoRequest.request()
-                        .eventAction(query)
-                        .eventCategory(MatomoEventCategory.valueOf(CodeType.STATIC.name).value)
-                        .eventName(MatomoEventName.CARD_CREATION_SUCCESSFUL.value)
-                        .eventValue(numberOfStaticCards.toDouble())
-                        .dimensions(mapOf(1L to regionId))
-                } else {
-                    null
-                },
-                if (numberOfDynamicCards > 0) {
-                    MatomoRequest.request()
-                        .eventAction(query)
-                        .eventCategory(MatomoEventCategory.valueOf(CodeType.DYNAMIC.name).value)
-                        .eventName(MatomoEventName.CARD_CREATION_SUCCESSFUL.value)
-                        .eventValue(numberOfDynamicCards.toDouble())
-                        .dimensions(mapOf(1L to regionId))
-                } else {
-                    null
-                },
-            ),
-        )
+        projectConfig.matomo?.let { matomoConfig ->
+            sendTrackingRequests(
+                listOfNotNull(
+                    if (numberOfStaticCards > 0) {
+                        createEventRequest(
+                            matomoConfig = matomoConfig,
+                            httpRequest = request,
+                            eventAction = query,
+                            eventCategory = MatomoEventCategory.STATIC,
+                            eventName = MatomoEventName.CARD_CREATION_SUCCESSFUL,
+                            eventValue = numberOfStaticCards.toDouble(),
+                            dimensions = mapOf(1L to regionId),
+                        )
+                    } else {
+                        null
+                    },
+                    if (numberOfDynamicCards > 0) {
+                        createEventRequest(
+                            matomoConfig = matomoConfig,
+                            httpRequest = request,
+                            eventAction = query,
+                            eventCategory = MatomoEventCategory.DYNAMIC,
+                            eventName = MatomoEventName.CARD_CREATION_SUCCESSFUL,
+                            eventValue = numberOfDynamicCards.toDouble(),
+                            dimensions = mapOf(1L to regionId),
+                        )
+                    } else {
+                        null
+                    },
+                ),
+            )
+        }
     }
 
     fun trackVerification(
@@ -83,23 +90,26 @@ class Matomo(
         codeType: CodeType,
         successful: Boolean,
     ) {
-        sendTrackingRequests(
-            projectConfig = projectConfig,
-            httpRequest = request,
-            requestBuilders = listOf(
-                MatomoRequest.request()
-                    .eventAction(query)
-                    .eventCategory(MatomoEventCategory.valueOf(codeType.name).value)
-                    .eventName(
-                        if (successful) {
-                            MatomoEventName.VERIFICATION_SUCCESSFUL.value
-                        } else {
-                            MatomoEventName.VERIFICATION_FAILED.value
-                        },
-                    )
-                    .dimensions(if (card != null) mapOf(1L to card.regionId) else emptyMap()),
-            ),
-        )
+        projectConfig.matomo?.let { matomoConfig ->
+            sendTrackingRequest(
+                createEventRequest(
+                    matomoConfig = matomoConfig,
+                    httpRequest = request,
+                    eventAction = query,
+                    eventCategory = when (codeType) {
+                        CodeType.DYNAMIC -> MatomoEventCategory.DYNAMIC
+                        CodeType.STATIC -> MatomoEventCategory.STATIC
+                    },
+                    eventName = if (successful) {
+                        MatomoEventName.VERIFICATION_SUCCESSFUL
+                    } else {
+                        MatomoEventName.VERIFICATION_FAILED
+                    },
+                    eventValue = null,
+                    dimensions = if (card != null) mapOf(1L to card.regionId) else emptyMap(),
+                ),
+            )
+        }
     }
 
     fun trackActivation(
@@ -109,24 +119,23 @@ class Matomo(
         cardEntity: CardEntity?,
         cardActivationState: ActivationState,
     ) {
-        sendTrackingRequests(
-            projectConfig = projectConfig,
-            httpRequest = request,
-            requestBuilders = listOf(
-                MatomoRequest.request()
-                    .eventAction(query)
-                    .eventCategory(MatomoEventCategory.ACTIVATION.value)
-                    .eventName(
-                        if (cardActivationState == ActivationState.success) {
-                            MatomoEventName.ACTIVATION_SUCCESSFUL.value
-                        } else {
-                            MatomoEventName.ACTIVATION_FAILED.value
-                        },
-                    )
-                    .eventValue(if (cardActivationState == ActivationState.success) 1.0 else 0.0)
-                    .dimensions(if (cardEntity != null) mapOf(1L to cardEntity.regionId) else emptyMap()),
-            ),
-        )
+        projectConfig.matomo?.let { matomoConfig ->
+            sendTrackingRequest(
+                createEventRequest(
+                    matomoConfig = matomoConfig,
+                    httpRequest = request,
+                    eventAction = query,
+                    eventCategory = MatomoEventCategory.ACTIVATION,
+                    eventName = if (cardActivationState == ActivationState.success) {
+                        MatomoEventName.ACTIVATION_SUCCESSFUL
+                    } else {
+                        MatomoEventName.ACTIVATION_FAILED
+                    },
+                    eventValue = if (cardActivationState == ActivationState.success) 1.0 else 0.0,
+                    dimensions = if (cardEntity != null) mapOf(1L to cardEntity.regionId) else emptyMap(),
+                ),
+            )
+        }
     }
 
     fun trackSearch(
@@ -137,54 +146,91 @@ class Matomo(
         numResults: Int,
     ) {
         if (params.searchText != null || params.categoryIds != null) {
-            sendTrackingRequests(
-                projectConfig = projectConfig,
-                httpRequest = request,
-                requestBuilders = listOf(
-                    MatomoRequest.request()
-                        .actionName(query)
-                        .searchCategory(params.categoryIds?.joinToString(","))
-                        .searchQuery(params.searchText ?: "")
-                        .searchResultsCount(numResults.toLong()),
-                ),
-            )
-        }
-    }
-
-    private fun sendTrackingRequests(
-        projectConfig: ProjectConfig,
-        httpRequest: HttpServletRequest,
-        requestBuilders: List<MatomoRequest.MatomoRequestBuilder>,
-    ) {
-        projectConfig.matomo?.let { matomoConfig ->
-            if (requestBuilders.isNotEmpty()) {
-                // Also catch synchronous exceptions
-                try {
-                    tracker.sendBulkRequestAsync(
-                        requestBuilders.map {
-                            it.siteId(matomoConfig.siteId)
-                            it.authToken(matomoConfig.accessToken)
-                            it.headerAcceptLanguage(AcceptLanguage.fromHeader(httpRequest.getHeader("Accept-Language")))
-                            it.headerUserAgent(httpRequest.getHeader("User-Agent"))
-                            it.visitorIp(httpRequest.remoteAddr)
-                            it.build()
-                        },
-                    ).exceptionally { exception ->
-                        when (exception) {
-                            is MatomoException -> {
-                                logger.error("Could not send request to Matomo $exception")
-                            }
-
-                            else -> {
-                                logger.error("Unexpected error while sending request to Matomo $exception")
-                            }
-                        }
-                        null
-                    }
-                } catch (e: Throwable) {
-                    logger.error("Error while sending tracking request: $e")
-                }
+            projectConfig.matomo?.let { matomoConfig ->
+                sendTrackingRequest(
+                    createSearchRequest(
+                        matomoConfig = matomoConfig,
+                        httpRequest = request,
+                        eventAction = query,
+                        searchCategories = params.categoryIds,
+                        searchText = params.searchText,
+                        searchResultCount = numResults,
+                    ),
+                )
             }
         }
     }
+
+    private fun sendTrackingRequest(matomoRequest: MatomoRequest) {
+        try {
+            tracker.sendRequestAsync(matomoRequest).exceptionally(::logMatomoErrors)
+        } catch (e: Throwable) {
+            logger.error("Error while sending tracking request: $e")
+        }
+    }
+
+    private fun sendTrackingRequests(matomoRequests: List<MatomoRequest>) {
+        if (matomoRequests.isNotEmpty()) {
+            try {
+                tracker.sendBulkRequestAsync(matomoRequests).exceptionally(::logMatomoErrors)
+            } catch (e: Exception) {
+                logger.error("Error while sending tracking request: $e")
+            }
+        }
+    }
+
+    private fun logMatomoErrors(exception: Throwable): Nothing? {
+        when (exception.cause) {
+            is MatomoException -> {
+                logger.error("Could not send request to Matomo $exception")
+            }
+
+            else -> {
+                logger.error("Unexpected error while sending request to Matomo $exception")
+            }
+        }
+        return null
+    }
 }
+
+private fun createEventRequest(
+    matomoConfig: MatomoConfig,
+    httpRequest: HttpServletRequest,
+    eventAction: String,
+    eventCategory: MatomoEventCategory,
+    eventName: MatomoEventName,
+    eventValue: Double?,
+    dimensions: Map<Long, Any>,
+): MatomoRequest =
+    MatomoRequest.request()
+        .siteId(matomoConfig.siteId)
+        .authToken(matomoConfig.accessToken)
+        .headerAcceptLanguage(AcceptLanguage.fromHeader(httpRequest.getHeader("Accept-Language")))
+        .headerUserAgent(httpRequest.getHeader("User-Agent"))
+        .visitorIp(httpRequest.remoteAddr)
+        .eventAction(eventAction)
+        .eventCategory(eventCategory.value)
+        .eventName(eventName.value)
+        .apply { eventValue?.let { eventValue(eventValue) } }
+        .dimensions(dimensions)
+        .build()
+
+private fun createSearchRequest(
+    matomoConfig: MatomoConfig,
+    httpRequest: HttpServletRequest,
+    eventAction: String,
+    searchCategories: List<Int>?,
+    searchText: String?,
+    searchResultCount: Int,
+): MatomoRequest =
+    MatomoRequest.request()
+        .siteId(matomoConfig.siteId)
+        .authToken(matomoConfig.accessToken)
+        .headerAcceptLanguage(AcceptLanguage.fromHeader(httpRequest.getHeader("Accept-Language")))
+        .headerUserAgent(httpRequest.getHeader("User-Agent"))
+        .visitorIp(httpRequest.remoteAddr)
+        .eventAction(eventAction)
+        .searchCategory(searchCategories?.joinToString(","))
+        .searchQuery(searchText ?: "")
+        .searchResultsCount(searchResultCount.toLong())
+        .build()

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/shared/Matomo.kt
@@ -16,7 +16,7 @@ import org.matomo.java.tracking.MatomoTracker
 import org.matomo.java.tracking.TrackerConfiguration
 import org.matomo.java.tracking.parameters.AcceptLanguage
 import org.slf4j.LoggerFactory
-import java.io.IOException
+import org.springframework.stereotype.Service
 import java.net.URI
 
 enum class MatomoEventCategory(val value: String) {
@@ -33,7 +33,10 @@ enum class MatomoEventName(val value: String) {
     VERIFICATION_SUCCESSFUL("verification successful"),
 }
 
-object Matomo {
+@Service
+class Matomo(
+    config: BackendConfiguration,
+) {
     private val logger = LoggerFactory.getLogger(Matomo::class.java)
     private var tracker: MatomoTracker? = null
 
@@ -43,7 +46,7 @@ object Matomo {
             val newTracker = MatomoTracker(
                 TrackerConfiguration.builder().apiEndpoint(URI.create(config.matomoUrl)).build(),
             )
-            Matomo.tracker = newTracker
+            this.tracker = newTracker
             return newTracker
         }
 

--- a/frontend/frontend.iml
+++ b/frontend/frontend.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
+<module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager">
     <exclude-output />
     <content url="file://$MODULE_DIR$">


### PR DESCRIPTION
### Short Description

Refactors the `Matomo` class and a few adjacent code places.

### Proposed Changes

- Refactor the `Matomo` class to only have one level of method nesting.
- Only use `sendBulkRequestAsync()`, since it can handle single events as well.
- Only use the client built-in concurrency method, remove Kotlin Coroutine usage.
- Commit some IntelliJ files that keep getting changed automatically.
- Remove the `libs.jetbrains.kotlin.stdlib` library from the build file, since this gets added automatically by the Kotlin plugin.
- Remove transactions from the `Matomo` and `CardVerifier` class. These classes had buried transactions that queried for the same entity. They now take the entities as arguments, removing redundant DB queries. I suspect we have a lot more of deeply buried transactions that we should get rid of. Transactions should only occur at the very top level of our code, i.e. the controller code. Sprinkling those willy nilly into utility code only creates hard to follow DB interaction patterns and badly performing code.
- Remove the `@Synchronized` annotation from `generateTotpSecret()`. The function uses one generator object per call and should therefore be fully thread-safe already. Please object, if I'm wrong here.

### Side Effects

None

### Testing

Backend tests should trigger some tracking calls.

### Resolved Issues

Fixes: #3069
