### PR TITLE
3071: Unconditionally create form fields in PDFs for Nürnberg

### DIFF
--- a/administration/src/project-configs/nuernberg/config.ts
+++ b/administration/src/project-configs/nuernberg/config.ts
@@ -122,16 +122,16 @@ function createAddressFormFields(pageIndex: number, info: CardInfo, card: Card):
     {
       name: `${pageIndex}.address.name`,
       // avoid only printing the name
-      text: addressLine1 || addressLine2 || plz || location ? info.fullName : undefined,
+      text: (addressLine1 || addressLine2 || plz || location ? info.fullName : undefined) ?? '',
     },
     // Address field 1
-    { name: `${pageIndex}.address.line.1`, text: addressLine1 },
+    { name: `${pageIndex}.address.line.1`, text: addressLine1 ?? '' },
     // Address field 2
-    { name: `${pageIndex}.address.line.2`, text: addressLine2 },
+    { name: `${pageIndex}.address.line.2`, text: addressLine2 ?? '' },
     // ZIP code and location
     {
       name: `${pageIndex}.address.location`,
-      text: plz && location ? `${plz} ${location}` : undefined,
+      text: plz && location ? `${plz} ${location}` : '',
     },
-  ].filter(field => field.text !== undefined && field.text.trim() !== '') as FormConfig[]
+  ]
 }


### PR DESCRIPTION
### Short Description

Unconditionally create form fields for Nürnberg PDFs. Emit empty form fields where no data is available.

### Side Effects

None

### Testing

- Start administration, switch to Nürnberg
- Go to http://localhost:3000/cards/import
- Import card sample data from `/administration/resources/cards/sample-bulk-import-nuernberg.csv`
- Examine generated PDF

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3071
