### PR TITLE
Fix circle ci cli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,11 @@ commands:
         description: This command builds the circle config from the files in src and validates that it is up-to-date and valid.
         steps:
             - run:
-                command: curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | sudo bash
+                command: mise install "github:CircleCI-Public/circleci-cli"
                 name: Install CircleCI CLI
+                working_directory: ~/project
             - run:
-                command: scripts/circleci-update-config
+                command: mise x -- scripts/circleci-update-config
                 name: Build circle config
                 working_directory: ~/project
             - run:
@@ -42,12 +43,12 @@ commands:
                       echo "The CircleCI config is up to date."
                       exit 0;
                     else
-                      echo "The CircleCI config is not up to date. You can update it by running the `./scripts/circleci-update-config` script."
+                      echo "The CircleCI config is not up to date. You can update it by running the \`./scripts/circleci-update-config\` script."
                       exit 1;
                     fi
                 name: CircleCI config up to date
             - run:
-                command: circleci config validate
+                command: mise x -- circleci config validate
                 name: Validate circle config
                 working_directory: ~/project
     install_app_toolbelt:
@@ -397,8 +398,8 @@ jobs:
         resource_class: small
         steps:
             - prepare_workspace
-            - check_circleci_config
             - install_mise
+            - check_circleci_config
             - install_node_modules
             - run:
                 command: mise x -- npm run ts:check
@@ -426,8 +427,8 @@ jobs:
         resource_class: small
         steps:
             - prepare_workspace
-            - check_circleci_config
             - install_mise
+            - check_circleci_config
             - setup_remote_docker:
                 docker_layer_caching: true
             - run:
@@ -470,8 +471,8 @@ jobs:
         resource_class: small
         steps:
             - prepare_workspace
-            - check_circleci_config
             - install_mise
+            - check_circleci_config
             - install_app_toolbelt
             - install_flutter_packages
             - run:
@@ -1383,4 +1384,3 @@ workflows:
                     - promote_android
                     - promote_ios
         when: << pipeline.parameters.run_promotion_frontend >>
-

--- a/.circleci/src/commands/check_circleci_config.yml
+++ b/.circleci/src/commands/check_circleci_config.yml
@@ -1,11 +1,16 @@
 description: This command builds the circle config from the files in src and validates that it is up-to-date and valid.
 steps:
   - run:
+      # Installs the exact version pinned in mise.toml/mise.lock instead of always grabbing
+      # the newest release, so `circleci config pack` produces the same output locally and in
+      # CI. An unpinned CLI silently reformats .circleci/config.yml on every new release, which
+      # made this check fail with no actual config change (#3091 investigation).
       name: Install CircleCI CLI
-      command: curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | sudo bash
+      command: mise install "github:CircleCI-Public/circleci-cli"
+      working_directory: ~/project
   - run:
       name: Build circle config
-      command: scripts/circleci-update-config
+      command: mise x -- scripts/circleci-update-config
       working_directory: ~/project
   - run: # Taken from https://github.com/roopakv/orbs/blob/master/src/commands/fail_if_dirty.yml
       name: CircleCI config up to date
@@ -21,10 +26,10 @@ steps:
           echo "The CircleCI config is up to date."
           exit 0;
         else
-          echo "The CircleCI config is not up to date. You can update it by running the `./scripts/circleci-update-config` script."
+          echo "The CircleCI config is not up to date. You can update it by running the \`./scripts/circleci-update-config\` script."
           exit 1;
         fi
   - run:
       name: Validate circle config
-      command: circleci config validate
+      command: mise x -- circleci config validate
       working_directory: ~/project

--- a/.circleci/src/jobs/check_administration.yml
+++ b/.circleci/src/jobs/check_administration.yml
@@ -4,8 +4,8 @@ resource_class: small
 working_directory: ~/project/administration
 steps:
   - prepare_workspace
-  - check_circleci_config
   - install_mise
+  - check_circleci_config
   - install_node_modules
   - run:
       name: Typescript

--- a/.circleci/src/jobs/check_backend.yml
+++ b/.circleci/src/jobs/check_backend.yml
@@ -7,8 +7,8 @@ environment:
 working_directory: ~/project/backend
 steps:
   - prepare_workspace
-  - check_circleci_config
   - install_mise
+  - check_circleci_config
   - setup_remote_docker:
       docker_layer_caching: true
   - run:

--- a/.circleci/src/jobs/check_frontend.yml
+++ b/.circleci/src/jobs/check_frontend.yml
@@ -4,8 +4,8 @@ resource_class: small
 working_directory: ~/project/frontend
 steps:
   - prepare_workspace
-  - check_circleci_config
   - install_mise
+  - check_circleci_config
   - install_app_toolbelt
   - install_flutter_packages
   - run:

--- a/mise.lock
+++ b/mise.lock
@@ -17,6 +17,7 @@ url = "https://download.docker.com/linux/static/stable/x86_64/docker-29.6.2.tgz"
 url = "https://download.docker.com/linux/static/stable/x86_64/docker-29.6.2.tgz"
 
 [tools.docker-cli."platforms.macos-arm64"]
+checksum = "blake3:064dc02f39e423316a443a65c30e74b503145118926d21fc372dbd620173a278"
 url = "https://download.docker.com/mac/static/stable/aarch64/docker-29.6.2.tgz"
 
 [tools.docker-cli."platforms.macos-x64"]
@@ -70,6 +71,45 @@ checksum = "sha256:6d36cc701393c066d67ebc77773b718d8c738bc4ccb350fbf1dc0e6a09f44
 url = "https://github.com/docker/compose/releases/download/v5.3.1/docker-compose-windows-x86_64.exe"
 url_api = "https://api.github.com/repos/docker/compose/releases/assets/469146923"
 provenance = "cosign"
+
+[[tools."github:CircleCI-Public/circleci-cli"]]
+version = "1.0.47471"
+backend = "github:CircleCI-Public/circleci-cli"
+
+[tools."github:CircleCI-Public/circleci-cli"."platforms.linux-arm64"]
+checksum = "sha256:9baf45cc2e7b04fefc8261a72cde92ed12f76b59cba14496e7c89c4b752fcf84"
+url = "https://github.com/CircleCI-Public/circleci-cli/releases/download/v1.0.47471/circleci-cli_1.0.47471_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/CircleCI-Public/circleci-cli/releases/assets/505347257"
+
+[tools."github:CircleCI-Public/circleci-cli"."platforms.linux-arm64-musl"]
+checksum = "sha256:9baf45cc2e7b04fefc8261a72cde92ed12f76b59cba14496e7c89c4b752fcf84"
+url = "https://github.com/CircleCI-Public/circleci-cli/releases/download/v1.0.47471/circleci-cli_1.0.47471_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/CircleCI-Public/circleci-cli/releases/assets/505347257"
+
+[tools."github:CircleCI-Public/circleci-cli"."platforms.linux-x64"]
+checksum = "sha256:0831fa38d0d51624f5a5720424351b85eaeec6ef0d0c589b3f0e9a84945e0fda"
+url = "https://github.com/CircleCI-Public/circleci-cli/releases/download/v1.0.47471/circleci-cli_1.0.47471_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/CircleCI-Public/circleci-cli/releases/assets/505347262"
+
+[tools."github:CircleCI-Public/circleci-cli"."platforms.linux-x64-musl"]
+checksum = "sha256:0831fa38d0d51624f5a5720424351b85eaeec6ef0d0c589b3f0e9a84945e0fda"
+url = "https://github.com/CircleCI-Public/circleci-cli/releases/download/v1.0.47471/circleci-cli_1.0.47471_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/CircleCI-Public/circleci-cli/releases/assets/505347262"
+
+[tools."github:CircleCI-Public/circleci-cli"."platforms.macos-arm64"]
+checksum = "sha256:6b6240d48fc9623955fe433bf8d805c5618847909a48238380e53f3539c5168f"
+url = "https://github.com/CircleCI-Public/circleci-cli/releases/download/v1.0.47471/circleci-cli_1.0.47471_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/CircleCI-Public/circleci-cli/releases/assets/505347259"
+
+[tools."github:CircleCI-Public/circleci-cli"."platforms.macos-x64"]
+checksum = "sha256:7bf2b31197dcb6df108b6dbaf738901969fb1c78710d56925b4bfa40ff0d34e0"
+url = "https://github.com/CircleCI-Public/circleci-cli/releases/download/v1.0.47471/circleci-cli_1.0.47471_darwin_amd64.tar.gz"
+url_api = "https://api.github.com/repos/CircleCI-Public/circleci-cli/releases/assets/505347258"
+
+[tools."github:CircleCI-Public/circleci-cli"."platforms.windows-x64"]
+checksum = "sha256:3fb392145741542db46862ae5f069278100af161b2ff21cef9589b052bffc69c"
+url = "https://github.com/CircleCI-Public/circleci-cli/releases/download/v1.0.47471/circleci-cli_1.0.47471_windows_amd64.zip"
+url_api = "https://api.github.com/repos/CircleCI-Public/circleci-cli/releases/assets/505347263"
 
 [[tools.node]]
 version = "26.5.0"

--- a/mise.toml
+++ b/mise.toml
@@ -25,3 +25,4 @@ docker-cli = 'latest'
 docker-compose = 'latest'
 node = '26'
 npm = '11'
+"github:CircleCI-Public/circleci-cli" = "1.0.47471"


### PR DESCRIPTION
### Short Description

With a new circle cli cli version the indentation changed.
We commited a config.yml with old indentation in the repo and the CI runs in with a new cli version and detects changes and then the check of the config file fails

### Proposed Changes

<!-- Describe this PR in more detail. -->

- use a fixed circle ci cli version from mise

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- N/A

### Testing

N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
