### PR TITLE
3098: Notify release mise

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -687,6 +687,7 @@ jobs:
         resource_class: small
         steps:
             - prepare_workspace
+            - install_mise
             - install_app_toolbelt
             - run:
                 command: |
@@ -845,6 +846,7 @@ jobs:
         resource_class: small
         steps:
             - prepare_workspace
+            - install_mise
             - install_app_toolbelt
             - run:
                 command: |

--- a/.circleci/src/jobs/notify_release.yml
+++ b/.circleci/src/jobs/notify_release.yml
@@ -12,6 +12,7 @@ parameters:
     type: string
 steps:
   - prepare_workspace
+  - install_mise
   - install_app_toolbelt
   - run:
       name: Create github release

--- a/.circleci/src/jobs/promote_github_release.yml
+++ b/.circleci/src/jobs/promote_github_release.yml
@@ -8,6 +8,7 @@ docker:
 resource_class: small
 steps:
   - prepare_workspace
+  - install_mise
   - install_app_toolbelt
   - run:
       name: Remove prerelease flag from github release


### PR DESCRIPTION
### Short Description

Due to some refactoring of the jobs, `install_mise` was missing before `install_app_toolbelt` in some jobs 

### Proposed Changes

<!-- Describe this PR in more detail. -->

- use `install_mise` in `notify_release` and `promote_github_release`

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- N/A

### Testing

N/A

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3098
