### PR TITLE
3076: Improve region assignment

### DIFF
--- a/administration/src/hooks/useDebouncedValue.ts
+++ b/administration/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+
+const useDebouncedValue = <T>(value: T, delayMs: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setDebouncedValue(value), delayMs)
+    return () => clearTimeout(timeout)
+  }, [value, delayMs])
+
+  return debouncedValue
+}
+
+export default useDebouncedValue

--- a/administration/src/routes/beantragen/components/forms/RegionForm.tsx
+++ b/administration/src/routes/beantragen/components/forms/RegionForm.tsx
@@ -11,6 +11,7 @@ import {
   GetRegionsByPostalCodeQuery,
   Region,
 } from '../../../../graphql'
+import useDebouncedValue from '../../../../hooks/useDebouncedValue'
 import { ProjectConfigContext } from '../../../../provider/ProjectConfigContext'
 import { useUpdateStateCallback } from '../../hooks/useUpdateStateCallback'
 import {
@@ -49,6 +50,7 @@ const renderAlert = (
   state: State,
   postalCode: string,
   queryState: UseQueryState<GetRegionsByPostalCodeQuery>,
+  isCurrentResult: boolean,
   t: TFunction,
 ) => {
   if (state.region.manuallySelected) {
@@ -57,10 +59,17 @@ const renderAlert = (
   if (postalCode.length !== 5) {
     return <StyledAlert severity='error'>{t('regionAlertPostalCode')}</StyledAlert>
   }
-  if (queryState.fetching) {
+  if (queryState.fetching || !isCurrentResult) {
     return <StyledAlert severity='info' icon={<CircularProgress size='1em' />} />
   }
   if (queryState.error) {
+    return (
+      <StyledAlert severity='warning'>
+        <Trans i18nKey='applicationForms:regionNotDetermined' />
+      </StyledAlert>
+    )
+  }
+  if (queryState.data && queryState.data.regions.length === 0) {
     return (
       <StyledAlert severity='warning'>
         <Trans i18nKey='applicationForms:regionNotDetermined' />
@@ -110,15 +119,19 @@ const RegionForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
     const { t } = useTranslation('applicationForms')
     const setRegionState = useUpdateStateCallback(setState, 'region')
     const project = useContext(ProjectConfigContext).projectId
+    const debouncedPostalCode = useDebouncedValue(postalCode, 300)
     const [regionQueryState] = useQuery({
       query: GetRegionsByPostalCodeDocument,
-      variables: { postalCode, project },
-      pause: postalCode.length !== 5 || state.region.manuallySelected,
+      variables: { postalCode: debouncedPostalCode, project },
+      pause: debouncedPostalCode.length !== 5 || state.region.manuallySelected,
     })
+    // Guards against a race condition where an in-flight query for an older postal code could settle after a newer one and be mistaken for it,
+    // so the result is only trusted if it still matches the postal code currently shown.
+    const isCurrentResult = regionQueryState.operation?.variables.postalCode === postalCode
 
     // Auto-select region when query returns exactly one result
     useEffect(() => {
-      if (regionQueryState.data?.regions.length === 1) {
+      if (isCurrentResult && regionQueryState.data?.regions.length === 1) {
         const region = regionQueryState.data.regions[0]
         setState(prevState => {
           if (prevState.region.manuallySelected) {
@@ -130,7 +143,7 @@ const RegionForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
           }
         })
       }
-    }, [regionQueryState.data, postalCode, setState])
+    }, [isCurrentResult, regionQueryState.data, postalCode, setState])
 
     // Clear auto-selected region when postal code changes
     useEffect(() => {
@@ -173,7 +186,7 @@ const RegionForm: Form<State, ValidatedInput, AdditionalProps, Options> = {
           </Link>{' '}
           {t('regionSelectionListTextEnd')}
         </Typography>
-        {renderAlert(state, postalCode, regionQueryState, t)}
+        {renderAlert(state, postalCode, regionQueryState, isCurrentResult, t)}
         <SubForms.region.Component
           state={state.region}
           setState={setRegionState}

--- a/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/regions/RegionQueryController.kt
+++ b/backend/src/main/kotlin/app/ehrenamtskarte/backend/graphql/regions/RegionQueryController.kt
@@ -4,7 +4,6 @@ import app.ehrenamtskarte.backend.db.entities.ProjectEntity
 import app.ehrenamtskarte.backend.db.entities.Projects
 import app.ehrenamtskarte.backend.db.repositories.RegionsRepository
 import app.ehrenamtskarte.backend.graphql.exceptions.NotEakProjectException
-import app.ehrenamtskarte.backend.graphql.exceptions.RegionNotFoundException
 import app.ehrenamtskarte.backend.graphql.regions.types.Region
 import app.ehrenamtskarte.backend.graphql.shared.EAK_BAYERN_PROJECT
 import app.ehrenamtskarte.backend.shared.exceptions.ProjectNotFoundException
@@ -64,16 +63,11 @@ class RegionQueryController(
             if (projectEntity.project != EAK_BAYERN_PROJECT) {
                 throw NotEakProjectException()
             }
-            val regionEntities = regionIdentifierService.regionIdentifierByPostalCode
+            regionIdentifierService.regionIdentifierByPostalCode
                 .filter { pair -> pair.first == postalCode }
                 .mapNotNull { region ->
                     RegionsRepository.findRegionByRegionIdentifier(region.second, projectEntity.id)
                 }
-                .takeIf { it.isNotEmpty() }
-                ?: throw RegionNotFoundException()
-
-            regionEntities.map {
-                Region.fromEntity(it)
-            }
+                .map { Region.fromEntity(it) }
         }
 }


### PR DESCRIPTION
### Short Description

We were facing some race conditions for the region fetch via postal code.
I added some debouncing to reduce requests if the the user makes a rapid input change
Furthermore i checked if the postal code value that was typed, fits with the current result

### Proposed Changes

<!-- Describe this PR in more detail. -->

- add debouce hook
- remove RegionNotFound exception, since it's a valid result to find no region
- use debouncing and add race condition guard, show region not found for empty result list

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- N/A

### Testing

- Go to `/beantragen` and type in some postal codes that exist and don't exists and check that the resulting region that was selected is correct

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3076
