### PR TITLE
3107: Upgrade mobile scanner

### DIFF
--- a/frontend/ios/Podfile.lock
+++ b/frontend/ios/Podfile.lock
@@ -1,93 +1,15 @@
 PODS:
   - Flutter (1.0.0)
-  - GoogleDataTransport (10.1.1):
-    - nanopb (~> 3.30910.0)
-    - PromisesObjC (~> 2.4)
-  - GoogleMLKit/BarcodeScanning (7.0.0):
-    - GoogleMLKit/MLKitCore
-    - MLKitBarcodeScanning (~> 6.0.0)
-  - GoogleMLKit/MLKitCore (7.0.0):
-    - MLKitCommon (~> 12.0.0)
-  - GoogleToolboxForMac/Defines (4.2.1)
-  - GoogleToolboxForMac/Logger (4.2.1):
-    - GoogleToolboxForMac/Defines (= 4.2.1)
-  - "GoogleToolboxForMac/NSData+zlib (4.2.1)":
-    - GoogleToolboxForMac/Defines (= 4.2.1)
-  - GoogleUtilities/Environment (8.1.2):
-    - GoogleUtilities/Privacy
-  - GoogleUtilities/Logger (8.1.2):
-    - GoogleUtilities/Environment
-    - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (8.1.2)
-  - GoogleUtilities/UserDefaults (8.1.2):
-    - GoogleUtilities/Logger
-    - GoogleUtilities/Privacy
-  - GTMSessionFetcher/Core (3.5.0)
-  - MLImage (1.0.0-beta6)
-  - MLKitBarcodeScanning (6.0.0):
-    - MLKitCommon (~> 12.0)
-    - MLKitVision (~> 8.0)
-  - MLKitCommon (12.0.0):
-    - GoogleDataTransport (~> 10.0)
-    - GoogleToolboxForMac/Logger (< 5.0, >= 4.2.1)
-    - "GoogleToolboxForMac/NSData+zlib (< 5.0, >= 4.2.1)"
-    - GoogleUtilities/Logger (~> 8.0)
-    - GoogleUtilities/UserDefaults (~> 8.0)
-    - GTMSessionFetcher/Core (< 4.0, >= 3.3.2)
-  - MLKitVision (8.0.0):
-    - GoogleToolboxForMac/Logger (< 5.0, >= 4.2.1)
-    - "GoogleToolboxForMac/NSData+zlib (< 5.0, >= 4.2.1)"
-    - GTMSessionFetcher/Core (< 4.0, >= 3.3.2)
-    - MLImage (= 1.0.0-beta6)
-    - MLKitCommon (~> 12.0)
-  - mobile_scanner (6.0.2):
-    - Flutter
-    - GoogleMLKit/BarcodeScanning (~> 7.0.0)
-  - nanopb (3.30910.0):
-    - nanopb/decode (= 3.30910.0)
-    - nanopb/encode (= 3.30910.0)
-  - nanopb/decode (3.30910.0)
-  - nanopb/encode (3.30910.0)
-  - PromisesObjC (2.4.1)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
-  - mobile_scanner (from `.symlinks/plugins/mobile_scanner/ios`)
-
-SPEC REPOS:
-  trunk:
-    - GoogleDataTransport
-    - GoogleMLKit
-    - GoogleToolboxForMac
-    - GoogleUtilities
-    - GTMSessionFetcher
-    - MLImage
-    - MLKitBarcodeScanning
-    - MLKitCommon
-    - MLKitVision
-    - nanopb
-    - PromisesObjC
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
-  mobile_scanner:
-    :path: ".symlinks/plugins/mobile_scanner/ios"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  GoogleDataTransport: a24e58982ab3ba2f64d79613e027fe7f57e88539
-  GoogleMLKit: eff9e23ec1d90ea4157a1ee2e32a4f610c5b3318
-  GoogleToolboxForMac: d1a2cbf009c453f4d6ded37c105e2f67a32206d8
-  GoogleUtilities: 766ace00c6b10d8148408f329d10c4f051931850
-  GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  MLImage: 0ad1c5f50edd027672d8b26b0fee78a8b4a0fc56
-  MLKitBarcodeScanning: 0a3064da0a7f49ac24ceb3cb46a5bc67496facd2
-  MLKitCommon: 07c2c33ae5640e5380beaaa6e4b9c249a205542d
-  MLKitVision: 45e79d68845a2de77e2dd4d7f07947f0ed157b0e
-  mobile_scanner: af8f71879eaba2bbcb4d86c6a462c3c0e7f23036
-  nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  PromisesObjC: 752c3227f599e3467650e47ea36f433eeb10c273
 
 PODFILE CHECKSUM: 61acc5da35f24f5204eec690219508875774a2f2
 

--- a/frontend/lib/identification/qr_code_scanner/qr_code_scanner.dart
+++ b/frontend/lib/identification/qr_code_scanner/qr_code_scanner.dart
@@ -80,7 +80,7 @@ class _QRViewState extends State<QrCodeScanner> {
                     children: [
                       MobileScanner(
                         key: qrKey,
-                        placeholderBuilder: (context, _) => Align(
+                        placeholderBuilder: (context) => Align(
                           alignment: Alignment.center,
                           child: Icon(Icons.camera_alt_outlined, size: 128, color: Colors.grey),
                         ),
@@ -147,7 +147,11 @@ class _QRViewState extends State<QrCodeScanner> {
   Future<void> _onCodeScanned(BarcodeCapture capture) async {
     if (capture.barcodes.length != 1) return;
     final barcode = capture.barcodes[0];
-    final code = barcode.rawBytes;
+    final code = switch (barcode.rawDecodedBytes) {
+      DecodedBarcodeBytes(:final bytes) => bytes,
+      DecodedVisionBarcodeBytes(:final bytes) => bytes,
+      null => null,
+    };
     if (code == null) return;
 
     if (processingCode) return;

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -832,10 +832,10 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: "0b466a0a8a211b366c2e87f3345715faef9b6011c7147556ad22f37de6ba3173"
+      sha256: ce3f059ebd6dbfab7292bba0e893e354b46730636820d3c9ef69005ce2d55bce
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.11"
+    version: "7.4.0"
   mocktail:
     dependency: "direct dev"
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -24,8 +24,7 @@ dependencies:
   flutter_svg: ^2.2.4
   permission_handler: ^11.3.0
   package_info_plus: ^10.2.1 # for about dialog
-  # Cannot be updated to v7 due to https://github.com/juliansteenbakker/mobile_scanner/issues/1444
-  mobile_scanner: 6.0.11
+  mobile_scanner: ^7.4.0
   fixnum: ^1.1.0
   # Manually update this dependency, issues can result in data loss
   # Pinned to 10.3.1 (not 11.0.0): 11.0.0 raised its Android module's compileSdk to 37, which


### PR DESCRIPTION
### Short Description

The APIs for mobile scanning internally changed on ios (vision api)
Therefore we had to wait until our qr code type is supported.

### Proposed Changes

<!-- Describe this PR in more detail. -->

- update mobile scanner and use new rawDecodedBytes

### Side Effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- N/A

### Testing

- Scan a qr code on real devices (!!!) and activate a card

### Resolved Issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3107
